### PR TITLE
add: a method to expose column names

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -18,6 +18,9 @@ impl SnowflakeRow {
             .ok_or_else(|| Error::Decode(format!("column not found: {}", column_name)))?;
         self.row[*index].try_get()
     }
+    pub fn column_names(&self) -> Vec<&str> {
+        self.column_names.iter().map(|(k, _)| k.as_str()).collect()
+    }
 }
 
 pub trait SnowflakeDecode: Sized {

--- a/tests/test-chunk.rs
+++ b/tests/test-chunk.rs
@@ -34,6 +34,8 @@ async fn test_download_chunked_results() -> Result<()> {
     assert_eq!(rows.len(), 10000);
     assert!(rows[0].get::<u64>("SEQ").is_ok());
     assert!(rows[0].get::<String>("RAND").is_ok());
+    assert!(rows[0].column_names().contains(&"SEQ"));
+    assert!(rows[0].column_names().contains(&"RAND"));
 
     Ok(())
 }


### PR DESCRIPTION
Unlike other SQL clients, this package currently lacks the functionality to access column names in the result of a query. To address this limitation, I have implemented a method that returns a list of column names. Kindly consider accepting this change to enhance the package's usability.