### PR TITLE
add: date decoder

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use chrono::NaiveDateTime;
+use chrono::{Days, NaiveDate, NaiveDateTime};
 
 use crate::{Error, Result};
 
@@ -106,6 +106,19 @@ impl SnowflakeDecode for NaiveDateTime {
         Err(Error::Decode(format!("'{value}' is not datetime")))
     }
 }
+impl SnowflakeDecode for chrono::NaiveDate {
+    fn try_decode(value: &Option<String>) -> Result<Self> {
+        let value = unwrap(value)?;
+        let days_since_epoch = value
+            .parse::<u64>()
+            .map_err(|_| Error::Decode(format!("'{value}' is not Date type")))?;
+        NaiveDate::from_ymd_opt(1970, 1, 1)
+            .unwrap_or_default()
+            .checked_add_days(Days::new(days_since_epoch))
+            .ok_or(Error::Decode(format!("'{value}' is not a valid date")))
+    }
+}
+
 impl SnowflakeDecode for serde_json::Value {
     fn try_decode(value: &Option<String>) -> Result<Self> {
         let value = unwrap(value)?;

--- a/tests/test-basic-operations.rs
+++ b/tests/test-basic-operations.rs
@@ -1,6 +1,26 @@
 use snowflake_connector_rs::{Result, SnowflakeAuthMethod, SnowflakeClient, SnowflakeClientConfig};
 
 #[tokio::test]
+async fn test_decode_naive_date() -> Result<()> {
+    // Arrange
+    let client = connect()?;
+    let session = client.create_session().await?;
+
+    // Act
+    let query = "SELECT '2020-01-01'::DATE AS date";
+    let rows = session.query(query).await?;
+
+    // Assert
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].get::<chrono::NaiveDate>("DATE")?,
+        chrono::NaiveDate::from_ymd_opt(2020, 1, 1).unwrap()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_basic_operations() -> Result<()> {
     // Connect to Snowflake
     let client = connect()?;


### PR DESCRIPTION
This PR includes the changes required to decode DATE type in Snowflake. 
ref: https://docs.snowflake.com/en/developer-guide/sql-api/handling-responses#getting-metadata-about-the-results

DATE
Integer value (in a string) of the number of days since the epoch (e.g. 18262).