### PR TITLE
Poll getResultUrl to handle async execution

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,9 @@ pub enum Error {
 
     #[error("unsupported format: {0}")]
     UnsupportedFormat(String),
+
+    #[error("polling error: {0}")]
+    Polling(String),
 }
 
 /// A `Result` alias where the `Err` case is `snowflake::Error`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@ pub struct SnowflakeClientConfig {
     pub database: Option<String>,
     pub schema: Option<String>,
     pub role: Option<String>,
+    pub polling_interval: Option<std::time::Duration>,
+    pub max_polling_attempts: Option<usize>,
 }
 
 pub enum SnowflakeAuthMethod {
@@ -95,6 +97,8 @@ impl SnowflakeClient {
             http: self.http.clone(),
             account: self.config.account.clone(),
             session_token,
+            polling_interval: self.config.polling_interval,
+            max_polling_attempts: self.config.max_polling_attempts,
         })
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -6,11 +6,13 @@ pub struct SnowflakeSession {
     pub(super) http: reqwest::Client,
     pub(super) account: String,
     pub(super) session_token: String,
+    pub(super) polling_interval: Option<std::time::Duration>,
+    pub(super) max_polling_attempts: Option<usize>
 }
 
 impl SnowflakeSession {
     pub async fn query<Q: Into<QueryRequest>>(&self, request: Q) -> Result<Vec<SnowflakeRow>> {
-        let rows = query(&self.http, &self.account, request, &self.session_token).await?;
+        let rows = query(&self.http, &self.account, request, &self.session_token, self.polling_interval, self.max_polling_attempts).await?;
         Ok(rows)
     }
 }

--- a/tests/test-basic-operations.rs
+++ b/tests/test-basic-operations.rs
@@ -72,6 +72,8 @@ fn connect() -> Result<SnowflakeClient> {
             database,
             schema,
             role,
+            polling_interval: None,
+            max_polling_attempts: None,
         },
     )?;
 

--- a/tests/test-chunk.rs
+++ b/tests/test-chunk.rs
@@ -21,6 +21,8 @@ async fn test_download_chunked_results() -> Result<()> {
             database,
             schema,
             role,
+            polling_interval: None,
+            max_polling_attempts: None,
         },
     )?;
 


### PR DESCRIPTION
Use the query in progress async code to determine whether we need to poll the result url. Similarly to the [Snowflake Go connector](https://github.com/snowflakedb/gosnowflake/blob/master/restful.go#L28). Addresses #10 
