### PR TITLE
export SnowflakeColumnType and SnowflakeColumn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod session;
 use std::time::Duration;
 
 pub use error::{Error, Result};
-pub use row::{SnowflakeDecode, SnowflakeRow};
+pub use row::{SnowflakeColumn, SnowflakeColumnType, SnowflakeDecode, SnowflakeRow};
 pub use session::SnowflakeSession;
 
 use auth::login;


### PR DESCRIPTION
We need to export SnowflakeColumnType to extract type information from SnowflakeRow