### PR TITLE
export QueryExecutor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ mod session;
 use std::time::Duration;
 
 pub use error::{Error, Result};
+pub use query::QueryExecutor;
 pub use row::{SnowflakeColumn, SnowflakeColumnType, SnowflakeDecode, SnowflakeRow};
 pub use session::SnowflakeSession;
 


### PR DESCRIPTION
We need to export QueryExecutor to store its state in structs which the users define.