### PR TITLE
Change methods to take &self rather than &mut self

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -14,7 +14,7 @@ pub struct SnowflakeSession {
 
 impl SnowflakeSession {
     pub async fn query<Q: Into<QueryRequest>>(&self, request: Q) -> Result<Vec<SnowflakeRow>> {
-        let mut executor = QueryExecutor::create(self, request).await?;
+        let executor = QueryExecutor::create(self, request).await?;
         executor.fetch_all().await
     }
 

--- a/tests/test-chunk.rs
+++ b/tests/test-chunk.rs
@@ -53,7 +53,7 @@ async fn test_query_executor() -> Result<()> {
     let query =
         "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
 
-    let mut executor = session.execute(query).await?;
+    let executor = session.execute(query).await?;
     let mut rows = Vec::with_capacity(10000);
     while let Some(mut r) = executor.fetch_next_chunk().await? {
         rows.append(&mut r);


### PR DESCRIPTION
fix https://github.com/estie-inc/snowflake-connector-rs/issues/37

Changed
- `fn eof(&self)` to `async fn eof(&self)`
- `async fn fetch_next_chunk(&mut self)` to `async fn fetch_next_chunk(&self)`
- `async fn fetch_all(&mut self)` to `async fn fetch_all(&self)`

For this change, calls to `fetch_next_chunk` can be parallelized.
