### PR TITLE
fix: use rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snowflake-connector-rs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["kenkoooo <kenkou.n@gmail.com>"]
 description = "A Rust client for Snowflake"
@@ -11,7 +11,7 @@ keywords = ["snowflake", "database", "sql", "client"]
 
 [dependencies]
 http = "0.2"
-reqwest = { version = "0.11", features = ["json", "gzip"] }
+reqwest = { version = "0.11", features = ["json", "gzip", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ impl SnowflakeClient {
         auth: SnowflakeAuthMethod,
         config: SnowflakeClientConfig,
     ) -> Result<Self> {
-        let client = ClientBuilder::new().gzip(true).build()?;
+        let client = ClientBuilder::new().gzip(true).use_rustls_tls().build()?;
         Ok(Self {
             http: client,
             username: username.to_string(),


### PR DESCRIPTION
In some environments, there is no native TLS installed, and the library doesn't work as reported in #19. To resolve this issue, we use rustls instead of the native TLS.

Thank you, @bobdemp, for contributing.

Resolve #19