### PR TITLE
Add: allow usage of proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snowflake-connector-rs"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["kenkoooo <kenkou.n@gmail.com>"]
 description = "A Rust client for Snowflake"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use session::SnowflakeSession;
 
 use auth::login;
 
-use reqwest::{Client, ClientBuilder};
+use reqwest::{Client, ClientBuilder, Proxy};
 
 #[derive(Clone)]
 pub struct SnowflakeClient {
@@ -93,6 +93,23 @@ impl SnowflakeClient {
             username: username.to_string(),
             auth,
             config,
+        })
+    }
+
+    pub fn with_proxy(self, host: &str, port: u16, username: &str, password: &str) -> Result<Self> {
+        let proxy = Proxy::all(format!("http://{}:{}", host, port).as_str())?
+            .basic_auth(username, password);
+
+        let client = ClientBuilder::new()
+            .gzip(true)
+            .use_rustls_tls()
+            .proxy(proxy)
+            .build()?;
+        Ok(Self {
+            http: client,
+            username: self.username,
+            auth: self.auth,
+            config: self.config,
         })
     }
 


### PR DESCRIPTION
This PR add the ability to set an http proxy for the connector using basic auth.

The scope is limited to cover our needs.