### PR TITLE
Fix deadlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ thiserror = "1.0"
 uuid = { version = "1.11", features = ["v4"] }
 flate2 = "1.0"
 tokio = { version = "1.41", features = ["rt"] }
+tokio-stream = "0.1.17"
 chrono = "0.4"
+futures = "0.3"
 pkcs8 = { version = "0.10", features = ["pem", "pkcs5", "encryption"] }
 rsa = "0.9"
 sha2 = "0.10"

--- a/src/row.rs
+++ b/src/row.rs
@@ -53,9 +53,9 @@ impl SnowflakeColumnType {
 
 #[derive(Debug)]
 pub struct SnowflakeRow {
-    pub(crate) row: Vec<Option<String>>,
-    pub(crate) column_types: Arc<Vec<SnowflakeColumnType>>,
-    pub(crate) column_indices: Arc<HashMap<String, usize>>,
+    pub row: Vec<Option<String>>,
+    pub column_types: Arc<Vec<SnowflakeColumnType>>,
+    pub column_indices: Arc<HashMap<String, usize>>,
 }
 
 impl SnowflakeRow {

--- a/tests/test-decode.rs
+++ b/tests/test-decode.rs
@@ -8,6 +8,10 @@ async fn test_decode() -> Result<()> {
     let client = common::connect()?;
     let session = client.create_session().await?;
 
+    session
+        .execute("ALTER SESSION SET timezone = 'UTC'")
+        .await?;
+
     // Create a temporary table
     // DATETIME aliases TIMESTAMP_NTZ
     let query = "CREATE TEMPORARY TABLE example (


### PR DESCRIPTION
Fix deadlock that arises when initial row set has >= 10 rows; if this happens, the mpsc::channel is fully filled and tx.send() blocks, but the receiver channel is not yet returned and read from => deadlock.

This PR moves the initial row set handling to the new Tokio task, so the channel can be returned already.