### PR TITLE
Adding query in progress response code check to async polling logic

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -240,7 +240,9 @@ async fn poll_for_async_results(
 
         let response: SnowflakeResponse =
             serde_json::from_str(&body).map_err(|e| Error::Json(e, body))?;
-        if response.code.as_deref() != Some(QUERY_IN_PROGRESS_ASYNC_CODE) {
+        if response.code.as_deref() != Some(QUERY_IN_PROGRESS_ASYNC_CODE)
+            && response.code.as_deref() != Some(QUERY_IN_PROGRESS_CODE)
+        {
             return Ok(response);
         }
     }


### PR DESCRIPTION
Looks like I missed another place where the response code for in progress queries are being checked.