### PR TITLE
Add support for using configuration options required for Snowpark Container Services

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@ pub struct SnowflakeClientConfig {
     pub schema: Option<String>,
     pub role: Option<String>,
     pub timeout: Option<Duration>,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub protocol: Option<String>,
 }
 
 #[derive(Clone)]
@@ -78,6 +81,9 @@ pub enum SnowflakeAuthMethod {
     KeyPair {
         encrypted_pem: String,
         password: Vec<u8>,
+    },
+    Oauth {
+        token: String,
     },
 }
 
@@ -120,6 +126,9 @@ impl SnowflakeClient {
             account: self.config.account.clone(),
             session_token,
             timeout: self.config.timeout,
+            host: self.config.host.clone(),
+            port: self.config.port,
+            protocol: self.config.protocol.clone(),
         })
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -7,6 +7,9 @@ use crate::{
 
 pub struct SnowflakeSession {
     pub(super) http: reqwest::Client,
+    pub(super) host: Option<String>,
+    pub(super) port: Option<u16>,
+    pub(super) protocol: Option<String>,
     pub(super) account: String,
     pub(super) session_token: String,
     pub(super) timeout: Option<Duration>,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -9,6 +9,10 @@ pub fn connect() -> Result<SnowflakeClient> {
     let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok();
     let database = std::env::var("SNOWFLAKE_DATABASE").ok();
     let schema = std::env::var("SNOWFLAKE_SCHEMA").ok();
+    let host = std::env::var("SNOWFLAKE_HOST").ok();
+    let port = std::env::var("SNOWFLAKE_PORT").ok().and_then(|var| var.parse().ok());
+    let protocol = std::env::var("SNOWFLAKE_PROTOCOL").ok();
+
 
     let client = SnowflakeClient::new(
         &username,
@@ -19,6 +23,9 @@ pub fn connect() -> Result<SnowflakeClient> {
             database,
             schema,
             role,
+            host,
+            port,
+            protocol,
             timeout: None,
         },
     )?;


### PR DESCRIPTION
Hello! I've made some changes to add basic support for using Oauth tokens for authentication in the library. The motivation for this change is to support connecting using the token (and other configuration variables) [provided by Snowpark Container Services](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/additional-considerations-services-jobs#connecting-to-snowflake) to connect to Snowflake on the internal network. This change does not provide any facility for performing the oauth flow since in SPCS the token is just provided in an environment variable.

I've tested this manually in SPCS as well as running the existing tests against a local dev instance using the host/port parameters, but I haven't added any automated tests because I don't know which features your test instance has access to. I'm happy to add some, though, depending on what's available and your tolerance for spend.

I've also fixed a bug that prevents the `SESSION_EXPIRED` error from ever being bubbled up - instead, previously, if a session expired, the error was always a json decoding error.

Thanks for this connector, it's made experimentation and prototyping a lot easier.


_Disclaimer: I work for Snowflake, but this contribution is made in my personal capacity and not on behalf of Snowflake in any way._