### PR TITLE
feat: export QueryRequest from query module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod session;
 use std::time::Duration;
 
 pub use error::{Error, Result};
-pub use query::QueryExecutor;
+pub use query::{QueryExecutor, QueryRequest};
 pub use row::{SnowflakeColumn, SnowflakeColumnType, SnowflakeDecode, SnowflakeRow};
 pub use session::SnowflakeSession;
 


### PR DESCRIPTION
This PR exports the `QueryRequest` struct from the `query` module.

## Changes

- Added `QueryRequest` to the public exports in `src/lib.rs`

Please let me know if you have any concerns or suggestions.