### PR TITLE
feat: migrate to Rust 2024 edition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,14 @@ env:
   SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
   SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
   SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
-  
+
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: [1.74, stable]
+        version: [1.85, stable]
     name: Test with Rust ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snowflake-connector-rs"
 version = "0.6.5"
-edition = "2021"
+edition = "2024"
 authors = ["kenkoooo <kenkou.n@gmail.com>"]
 description = "A Rust client for Snowflake"
 readme = "README.md"

--- a/src/auth/key_pair.rs
+++ b/src/auth/key_pair.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
 use rsa::RsaPrivateKey;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -2,7 +2,7 @@ mod key_pair;
 
 use chrono::Utc;
 use reqwest::Client;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{Error, Result, SnowflakeAuthMethod, SnowflakeClientConfig};
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,16 +2,16 @@ use std::time::{Duration, Instant};
 use std::{collections::HashMap, sync::Arc};
 
 use http::{
-    header::{ACCEPT, AUTHORIZATION},
     HeaderMap,
+    header::{ACCEPT, AUTHORIZATION},
 };
 use reqwest::Client;
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 
-use crate::row::SnowflakeColumnType;
 use crate::SnowflakeSession;
-use crate::{chunk::download_chunk, Error, Result, SnowflakeRow};
+use crate::row::SnowflakeColumnType;
+use crate::{Error, Result, SnowflakeRow, chunk::download_chunk};
 
 pub(super) const SESSION_EXPIRED: &str = "390112";
 pub(super) const QUERY_IN_PROGRESS_CODE: &str = "333333";

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use crate::{
-    query::{QueryExecutor, QueryRequest},
     Result, SnowflakeRow,
+    query::{QueryExecutor, QueryRequest},
 };
 
 pub struct SnowflakeSession {

--- a/tests/test-chunk.rs
+++ b/tests/test-chunk.rs
@@ -9,8 +9,7 @@ async fn test_download_chunked_results() -> Result<()> {
 
     // Act
     let session = client.create_session().await?;
-    let query =
-        "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
+    let query = "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
     let rows = session.query(query).await?;
 
     // Assert
@@ -50,8 +49,7 @@ async fn test_query_executor() -> Result<()> {
 
     // Act
     let session = client.create_session().await?;
-    let query =
-        "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
+    let query = "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
 
     let executor = session.execute(query).await?;
     let mut rows = Vec::with_capacity(10000);


### PR DESCRIPTION
- Run `cargo fix --edition` and encountered warning in `SnowflakeSession::query` regarding drop order changes, but left as-is since it doesn't affect the result
- Update `Cargo.toml` edition to 2024
- Run `cargo fmt` to apply formatting changes
- Update CI configuration to reflect MSRV changes for Rust 2024 edition migration