### PR TITLE
feat: add constructors and equality traits to SnowflakeColumn types

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -460,7 +460,7 @@ mod tests {
         let column_type = SnowflakeColumnType::new("text".to_string(), true, Some(255), None, None);
 
         assert_eq!(column_type.snowflake_type(), "text");
-        assert_eq!(column_type.nullable(), true);
+        assert!(column_type.nullable());
         assert_eq!(column_type.length(), Some(255));
         assert_eq!(column_type.precision(), None);
         assert_eq!(column_type.scale(), None);
@@ -472,7 +472,7 @@ mod tests {
             SnowflakeColumnType::new("fixed".to_string(), false, None, Some(10), Some(2));
 
         assert_eq!(column_type.snowflake_type(), "fixed");
-        assert_eq!(column_type.nullable(), false);
+        assert!(!column_type.nullable());
         assert_eq!(column_type.length(), None);
         assert_eq!(column_type.precision(), Some(10));
         assert_eq!(column_type.scale(), Some(2));
@@ -537,7 +537,7 @@ mod tests {
         assert_eq!(column.name(), "price");
         assert_eq!(column.index(), 2);
         assert_eq!(column.column_type().snowflake_type(), "fixed");
-        assert_eq!(column.column_type().nullable(), false);
+        assert!(!column.column_type().nullable());
         assert_eq!(column.column_type().precision(), Some(18));
         assert_eq!(column.column_type().scale(), Some(6));
         assert_eq!(column.column_type().length(), None);

--- a/src/row.rs
+++ b/src/row.rs
@@ -4,7 +4,36 @@ use chrono::{DateTime, Days, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta};
 
 use crate::{Error, Result};
 
-#[derive(Debug)]
+/// Represents a Snowflake database column with its metadata.
+///
+/// This struct provides information about a column including its name, index position,
+/// and type information. It's typically used when working with query results to
+/// understand the structure of returned data.
+///
+/// # Examples
+///
+/// ```
+/// use snowflake_connector_rs::{SnowflakeColumn, SnowflakeColumnType};
+///
+/// let column_type = SnowflakeColumnType::new(
+///     "fixed".to_string(),
+///     false,
+///     None,
+///     None,
+///     None
+/// );
+///
+/// let column = SnowflakeColumn::new(
+///     "user_id".to_string(),
+///     0,
+///     column_type
+/// );
+///
+/// assert_eq!(column.name(), "user_id");
+/// assert_eq!(column.index(), 0);
+/// assert_eq!(column.column_type().snowflake_type(), "fixed");
+/// ```
+#[derive(Debug, PartialEq, Eq)]
 pub struct SnowflakeColumn {
     pub(super) name: String,
     pub(super) index: usize,
@@ -12,6 +41,44 @@ pub struct SnowflakeColumn {
 }
 
 impl SnowflakeColumn {
+    /// Creates a new `SnowflakeColumn`.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the column
+    /// * `index` - The zero-based index position of the column in the result set
+    /// * `column_type` - The type information for this column
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use snowflake_connector_rs::{SnowflakeColumn, SnowflakeColumnType};
+    ///
+    /// let column_type = SnowflakeColumnType::new(
+    ///     "text".to_string(),
+    ///     true,
+    ///     Some(255),
+    ///     None,
+    ///     None
+    /// );
+    ///
+    /// let column = SnowflakeColumn::new(
+    ///     "username".to_string(),
+    ///     1,
+    ///     column_type
+    /// );
+    ///
+    /// assert_eq!(column.name(), "username");
+    /// assert_eq!(column.index(), 1);
+    /// ```
+    pub fn new(name: String, index: usize, column_type: SnowflakeColumnType) -> Self {
+        Self {
+            name,
+            index,
+            column_type,
+        }
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -24,7 +91,35 @@ impl SnowflakeColumn {
     }
 }
 
-#[derive(Debug, Clone)]
+/// Represents the type information of a Snowflake column.
+///
+/// This struct contains metadata about a column including its Snowflake data type,
+/// whether it allows NULL values, and optional size/precision/scale parameters.
+///
+/// # Examples
+///
+/// ```
+/// use snowflake_connector_rs::SnowflakeColumnType;
+///
+/// // Create a text column type (VARCHAR/STRING in Snowflake)
+/// let text_type = SnowflakeColumnType::new(
+///     "text".to_string(),
+///     true,
+///     Some(255),
+///     None,
+///     None
+/// );
+///
+/// // Create a fixed column type (DECIMAL/NUMBER in Snowflake)
+/// let fixed_type = SnowflakeColumnType::new(
+///     "fixed".to_string(),
+///     false,
+///     None,
+///     Some(10),
+///     Some(2)
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SnowflakeColumnType {
     pub(super) snowflake_type: String,
     pub(super) nullable: bool,
@@ -34,6 +129,49 @@ pub struct SnowflakeColumnType {
 }
 
 impl SnowflakeColumnType {
+    /// Creates a new `SnowflakeColumnType`.
+    ///
+    /// # Arguments
+    ///
+    /// * `snowflake_type` - The Snowflake data type name (e.g., "text", "fixed", "boolean")
+    /// * `nullable` - Whether the column allows NULL values
+    /// * `length` - Optional length for character types (e.g., text with length 255)
+    /// * `precision` - Optional precision for numeric types (e.g., fixed(10,2))
+    /// * `scale` - Optional scale for numeric types (e.g., fixed(10,2))
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use snowflake_connector_rs::SnowflakeColumnType;
+    ///
+    /// let text_type = SnowflakeColumnType::new(
+    ///     "text".to_string(),
+    ///     true,
+    ///     Some(100),
+    ///     None,
+    ///     None
+    /// );
+    ///
+    /// assert_eq!(text_type.snowflake_type(), "text");
+    /// assert_eq!(text_type.nullable(), true);
+    /// assert_eq!(text_type.length(), Some(100));
+    /// ```
+    pub fn new(
+        snowflake_type: String,
+        nullable: bool,
+        length: Option<i64>,
+        precision: Option<i64>,
+        scale: Option<i64>,
+    ) -> Self {
+        Self {
+            snowflake_type,
+            nullable,
+            length,
+            precision,
+            scale,
+        }
+    }
+
     pub fn snowflake_type(&self) -> &str {
         &self.snowflake_type
     }
@@ -311,4 +449,105 @@ fn unwrap(value: &Option<String>) -> Result<&String> {
     value
         .as_ref()
         .ok_or_else(|| Error::Decode("value is null".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snowflake_column_type_new() {
+        let column_type = SnowflakeColumnType::new("text".to_string(), true, Some(255), None, None);
+
+        assert_eq!(column_type.snowflake_type(), "text");
+        assert_eq!(column_type.nullable(), true);
+        assert_eq!(column_type.length(), Some(255));
+        assert_eq!(column_type.precision(), None);
+        assert_eq!(column_type.scale(), None);
+    }
+
+    #[test]
+    fn test_snowflake_column_type_new_decimal() {
+        let column_type =
+            SnowflakeColumnType::new("fixed".to_string(), false, None, Some(10), Some(2));
+
+        assert_eq!(column_type.snowflake_type(), "fixed");
+        assert_eq!(column_type.nullable(), false);
+        assert_eq!(column_type.length(), None);
+        assert_eq!(column_type.precision(), Some(10));
+        assert_eq!(column_type.scale(), Some(2));
+    }
+
+    #[test]
+    fn test_snowflake_column_type_equality() {
+        let type1 = SnowflakeColumnType::new("fixed".to_string(), true, None, None, None);
+
+        let type2 = SnowflakeColumnType::new("fixed".to_string(), true, None, None, None);
+
+        let type3 = SnowflakeColumnType::new("text".to_string(), true, Some(100), None, None);
+
+        assert_eq!(type1, type2);
+        assert_ne!(type1, type3);
+    }
+
+    #[test]
+    fn test_snowflake_column_new() {
+        let column_type = SnowflakeColumnType::new("text".to_string(), true, Some(255), None, None);
+
+        let column = SnowflakeColumn::new("username".to_string(), 0, column_type.clone());
+
+        assert_eq!(column.name(), "username");
+        assert_eq!(column.index(), 0);
+        assert_eq!(column.column_type(), &column_type);
+    }
+
+    #[test]
+    fn test_snowflake_column_equality() {
+        let column_type1 = SnowflakeColumnType::new("fixed".to_string(), false, None, None, None);
+
+        let column_type2 = SnowflakeColumnType::new("fixed".to_string(), false, None, None, None);
+
+        let column_type3 = SnowflakeColumnType::new("text".to_string(), true, Some(50), None, None);
+
+        let column1 = SnowflakeColumn::new("id".to_string(), 0, column_type1);
+
+        let column2 = SnowflakeColumn::new("id".to_string(), 0, column_type2);
+
+        let column3 = SnowflakeColumn::new("name".to_string(), 1, column_type3);
+
+        let column4 = SnowflakeColumn::new(
+            "id".to_string(),
+            1, // Different index
+            column1.column_type().clone(),
+        );
+
+        assert_eq!(column1, column2);
+        assert_ne!(column1, column3);
+        assert_ne!(column1, column4); // Different index should make them unequal
+    }
+
+    #[test]
+    fn test_complex_column_types() {
+        // Test with all optional fields filled
+        let complex_type =
+            SnowflakeColumnType::new("fixed".to_string(), false, None, Some(18), Some(6));
+
+        let column = SnowflakeColumn::new("price".to_string(), 2, complex_type);
+
+        assert_eq!(column.name(), "price");
+        assert_eq!(column.index(), 2);
+        assert_eq!(column.column_type().snowflake_type(), "fixed");
+        assert_eq!(column.column_type().nullable(), false);
+        assert_eq!(column.column_type().precision(), Some(18));
+        assert_eq!(column.column_type().scale(), Some(6));
+        assert_eq!(column.column_type().length(), None);
+    }
+
+    #[test]
+    fn test_column_type_clone() {
+        let original =
+            SnowflakeColumnType::new("timestamp_ntz".to_string(), true, None, None, Some(6));
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
 }

--- a/tests/test-basic-operations.rs
+++ b/tests/test-basic-operations.rs
@@ -28,8 +28,15 @@ async fn test_basic_operations() -> Result<()> {
     let client = common::connect()?;
     let session = client.create_session().await?;
 
-    // Create a temporary table
-    let query = "CREATE TEMPORARY TABLE example (id NUMBER, value STRING)";
+    // Create a temporary table with various data types
+    let query = "CREATE TEMPORARY TABLE example (
+        id NUMBER, 
+        value STRING,
+        price DECIMAL(10,2),
+        is_active BOOLEAN,
+        created_date DATE,
+        updated_at TIMESTAMP_NTZ
+    )";
     let rows = session.query(query).await?;
     assert_eq!(rows.len(), 1);
     assert_eq!(
@@ -38,19 +45,69 @@ async fn test_basic_operations() -> Result<()> {
     );
 
     // Insert some data
-    let query = "INSERT INTO example (id, value) VALUES (1, 'hello'), (2, 'world')";
+    let query = "INSERT INTO example (id, value, price, is_active, created_date, updated_at) 
+                 VALUES (1, 'hello', 99.99, true, '2023-01-01', '2023-01-01 12:00:00')";
     let rows = session.query(query).await?;
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].get::<i64>("NUMBER OF ROWS INSERTED")?, 2);
+    assert_eq!(rows[0].get::<i64>("NUMBER OF ROWS INSERTED")?, 1);
 
     // Select the data back
     let query = "SELECT * FROM example ORDER BY id";
     let rows = session.query(query).await?;
-    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].get::<i64>("ID")?, 1);
     assert_eq!(rows[0].get::<String>("VALUE")?, "hello");
-    assert_eq!(rows[1].get::<i64>("ID")?, 2);
-    assert_eq!(rows[1].get::<String>("VALUE")?, "world");
+
+    // Test column_types method with various data types
+    let column_types = rows[0].column_types();
+    assert_eq!(column_types.len(), 6);
+
+    // Check ID column (NUMBER/FIXED)
+    let id_column = &column_types[0];
+    assert_eq!(id_column.name(), "ID");
+    assert_eq!(id_column.index(), 0);
+    assert_eq!(id_column.column_type().snowflake_type(), "fixed");
+    assert_eq!(id_column.column_type().nullable(), true);
+
+    // Check VALUE column (STRING/TEXT)
+    let value_column = &column_types[1];
+    assert_eq!(value_column.name(), "VALUE");
+    assert_eq!(value_column.index(), 1);
+    assert_eq!(value_column.column_type().snowflake_type(), "text");
+    assert_eq!(value_column.column_type().nullable(), true);
+
+    // Check PRICE column (DECIMAL)
+    let price_column = &column_types[2];
+    assert_eq!(price_column.name(), "PRICE");
+    assert_eq!(price_column.index(), 2);
+    assert_eq!(price_column.column_type().snowflake_type(), "fixed");
+    assert_eq!(price_column.column_type().nullable(), true);
+    assert_eq!(price_column.column_type().precision(), Some(10));
+    assert_eq!(price_column.column_type().scale(), Some(2));
+
+    // Check IS_ACTIVE column (BOOLEAN)
+    let is_active_column = &column_types[3];
+    assert_eq!(is_active_column.name(), "IS_ACTIVE");
+    assert_eq!(is_active_column.index(), 3);
+    assert_eq!(is_active_column.column_type().snowflake_type(), "boolean");
+    assert_eq!(is_active_column.column_type().nullable(), true);
+
+    // Check CREATED_DATE column (DATE)
+    let date_column = &column_types[4];
+    assert_eq!(date_column.name(), "CREATED_DATE");
+    assert_eq!(date_column.index(), 4);
+    assert_eq!(date_column.column_type().snowflake_type(), "date");
+    assert_eq!(date_column.column_type().nullable(), true);
+
+    // Check UPDATED_AT column (TIMESTAMP_NTZ)
+    let timestamp_column = &column_types[5];
+    assert_eq!(timestamp_column.name(), "UPDATED_AT");
+    assert_eq!(timestamp_column.index(), 5);
+    assert_eq!(
+        timestamp_column.column_type().snowflake_type(),
+        "timestamp_ntz"
+    );
+    assert_eq!(timestamp_column.column_type().nullable(), true);
 
     Ok(())
 }

--- a/tests/test-basic-operations.rs
+++ b/tests/test-basic-operations.rs
@@ -67,21 +67,21 @@ async fn test_basic_operations() -> Result<()> {
     assert_eq!(id_column.name(), "ID");
     assert_eq!(id_column.index(), 0);
     assert_eq!(id_column.column_type().snowflake_type(), "fixed");
-    assert_eq!(id_column.column_type().nullable(), true);
+    assert!(id_column.column_type().nullable());
 
     // Check VALUE column (STRING/TEXT)
     let value_column = &column_types[1];
     assert_eq!(value_column.name(), "VALUE");
     assert_eq!(value_column.index(), 1);
     assert_eq!(value_column.column_type().snowflake_type(), "text");
-    assert_eq!(value_column.column_type().nullable(), true);
+    assert!(value_column.column_type().nullable());
 
     // Check PRICE column (DECIMAL)
     let price_column = &column_types[2];
     assert_eq!(price_column.name(), "PRICE");
     assert_eq!(price_column.index(), 2);
     assert_eq!(price_column.column_type().snowflake_type(), "fixed");
-    assert_eq!(price_column.column_type().nullable(), true);
+    assert!(price_column.column_type().nullable());
     assert_eq!(price_column.column_type().precision(), Some(10));
     assert_eq!(price_column.column_type().scale(), Some(2));
 
@@ -90,14 +90,14 @@ async fn test_basic_operations() -> Result<()> {
     assert_eq!(is_active_column.name(), "IS_ACTIVE");
     assert_eq!(is_active_column.index(), 3);
     assert_eq!(is_active_column.column_type().snowflake_type(), "boolean");
-    assert_eq!(is_active_column.column_type().nullable(), true);
+    assert!(is_active_column.column_type().nullable());
 
     // Check CREATED_DATE column (DATE)
     let date_column = &column_types[4];
     assert_eq!(date_column.name(), "CREATED_DATE");
     assert_eq!(date_column.index(), 4);
     assert_eq!(date_column.column_type().snowflake_type(), "date");
-    assert_eq!(date_column.column_type().nullable(), true);
+    assert!(date_column.column_type().nullable());
 
     // Check UPDATED_AT column (TIMESTAMP_NTZ)
     let timestamp_column = &column_types[5];
@@ -107,7 +107,7 @@ async fn test_basic_operations() -> Result<()> {
         timestamp_column.column_type().snowflake_type(),
         "timestamp_ntz"
     );
-    assert_eq!(timestamp_column.column_type().nullable(), true);
+    assert!(timestamp_column.column_type().nullable());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR enhances SnowflakeColumn and SnowflakeColumnType structs to make them easier to mock and test in user code. The primary goal is to improve the developer experience when writing tests that involve these column metadata structures.

## Changes

- Add `new()` constructors for both SnowflakeColumn and SnowflakeColumnType
- Implement PartialEq and Eq traits to enable equality comparisons
- Add comprehensive documentation with usage examples
- Expand integration tests to cover various Snowflake data types

## Benefits

Users can now easily create mock instances of these structs in their tests without relying on internal implementation details. The equality traits also enable straightforward assertions in test scenarios.