### PR TITLE
Implement query_with_limit & fetch_all_with_limit

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -18,6 +18,19 @@ impl SnowflakeSession {
         executor.fetch_all().await
     }
 
+    /// Run a query while capping concurrent chunk downloads.
+    ///
+    /// The `max_concurrency` argument limits how many result chunks are fetched at once.
+    /// Values below `1` are treated as `1`.
+    pub async fn query_with_limit<Q: Into<QueryRequest>>(
+        &self,
+        request: Q,
+        max_concurrency: usize,
+    ) -> Result<Vec<SnowflakeRow>> {
+        let executor = QueryExecutor::create(self, request).await?;
+        executor.fetch_all_with_limit(max_concurrency).await
+    }
+
     pub async fn execute<Q: Into<QueryRequest>>(&self, request: Q) -> Result<QueryExecutor> {
         QueryExecutor::create(self, request).await
     }


### PR DESCRIPTION
Run a query while capping concurrent chunk downloads.

Avoids queries with many results overwhelming the network.