### PR TITLE
Add optional features for DES/3DES

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,12 @@ sha2 = "0.10"
 base64 = "0.22"
 jsonwebtoken = "9.1"
 
+[features]
+decrypt-des = ["pkcs8/des-insecure"]
+decrypt-3des = ["pkcs8/3des"]
+
+[package.metadata.docs.rs]
+all-features = true
+
 [dev-dependencies]
 tokio = { version = "1.41", features = ["macros", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A Rust client for Snowflake, which enables you to connect to Snowflake and run queries.
 
+## Usage
+
 ```rust
 let client = SnowflakeClient::new(
     "USERNAME",
@@ -32,3 +34,10 @@ assert_eq!(rows.len(), 2);
 assert_eq!(rows[0].get::<i64>("ID")?, 1);
 assert_eq!(rows[0].get::<String>("VALUE")?, "hello");
 ```
+
+## Features
+
+This crate supports optional features to decrypt legacy keys that use DES or 3DES encryption.
+
+- **`decrypt-des`**: Enables DES decryption support
+- **`decrypt-3des`**: Enables 3DES decryption support


### PR DESCRIPTION
Fixes #68

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional features for DES/3DES key decryption, enables docs.rs to build with all features, and documents usage/features in the README.
> 
> - **Config (Cargo.toml)**:
>   - Add crate features `decrypt-des` (`pkcs8/des-insecure`) and `decrypt-3des` (`pkcs8/3des`) for legacy key decryption.
>   - Enable docs.rs builds with all features via `package.metadata.docs.rs.all-features = true`.
> - **Docs (README.md)**:
>   - Add Usage section with example.
>   - Document optional features: `decrypt-des` and `decrypt-3des`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5fc8da25281fc6ba25597075f3ccc572707c08f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->