### PR TITLE
feat: refresh expired presigned URLs for chunk downloads

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,12 +1,18 @@
+use std::collections::HashMap;
 use std::io::Read;
 use std::time::Duration;
 
+use chrono::{NaiveDateTime, Utc};
 use flate2::bufread::GzDecoder;
 use reqwest::StatusCode;
 use reqwest::header::HeaderMap;
 use tokio::time::sleep;
+use url::Url;
 
 use crate::{Error, Result};
+
+/// Buffer before actual expiry to avoid the URL expiring mid-download.
+const EXPIRY_BUFFER_SECS: i64 = 300;
 
 const HEADER_SSE_C_ALGORITHM: &str = "x-amz-server-side-encryption-customer-algorithm";
 const HEADER_SSE_C_KEY: &str = "x-amz-server-side-encryption-customer-key";
@@ -48,6 +54,10 @@ pub(crate) async fn download_chunk(
     mut headers: HeaderMap,
     qrmk: String,
 ) -> Result<Vec<Vec<Option<String>>>> {
+    if is_presigned_url_expired(&chunk_url) {
+        return Err(Error::ChunkUrlExpired);
+    }
+
     if headers.is_empty() {
         headers.append(HEADER_SSE_C_ALGORITHM, AES256.parse()?);
         headers.append(HEADER_SSE_C_KEY, qrmk.parse()?);
@@ -119,6 +129,24 @@ async fn download_chunk_once(
     Ok(rows)
 }
 
+/// Check whether an S3 V4 presigned URL has expired or will expire within
+/// [`EXPIRY_BUFFER_SECS`] by parsing `X-Amz-Date` and `X-Amz-Expires`.
+/// Returns `false` when the URL cannot be parsed so that the download is
+/// attempted normally.
+fn is_presigned_url_expired(url: &str) -> bool {
+    let Some(parsed) = Url::parse(url).ok() else {
+        return false;
+    };
+    let pairs: HashMap<_, _> = parsed.query_pairs().collect();
+    let expiry = (|| {
+        let signed_at =
+            NaiveDateTime::parse_from_str(pairs.get("X-Amz-Date")?, "%Y%m%dT%H%M%SZ").ok()?;
+        let secs: i64 = pairs.get("X-Amz-Expires")?.parse().ok()?;
+        Some(signed_at.and_utc() + chrono::Duration::seconds(secs))
+    })();
+    expiry.is_some_and(|exp| Utc::now() + chrono::Duration::seconds(EXPIRY_BUFFER_SECS) >= exp)
+}
+
 fn is_retryable_status(status: StatusCode) -> bool {
     status.is_server_error()
         || status == StatusCode::TOO_MANY_REQUESTS
@@ -158,5 +186,56 @@ mod tests {
         assert_eq!(retry_delay(4), Duration::from_secs(16));
         assert_eq!(retry_delay(5), Duration::from_secs(16));
         assert_eq!(retry_delay(6), Duration::from_secs(16));
+    }
+
+    #[test]
+    fn presigned_url_expired_in_the_past() {
+        let url =
+            "https://bucket.s3.amazonaws.com/key?X-Amz-Date=20200101T000000Z&X-Amz-Expires=3600";
+        assert!(is_presigned_url_expired(url));
+    }
+
+    #[test]
+    fn presigned_url_far_future_not_expired() {
+        let url =
+            "https://bucket.s3.amazonaws.com/key?X-Amz-Date=20990101T000000Z&X-Amz-Expires=86400";
+        assert!(!is_presigned_url_expired(url));
+    }
+
+    #[test]
+    fn presigned_url_realistic_snowflake_format() {
+        // Mirrors the actual URL shape from Snowflake error logs.
+        // X-Amz-Date=20260326T163806Z + X-Amz-Expires=21599 (≈6h)
+        // Expired in the past relative to 2026-03-27, so this should be true.
+        let url = "https://bucket.s3.us-west-2.amazonaws.com/data?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA&X-Amz-Date=20260326T163806Z&X-Amz-Expires=21599&X-Amz-SignedHeaders=host&X-Amz-Signature=abc";
+        assert!(is_presigned_url_expired(url));
+    }
+
+    #[test]
+    fn presigned_url_no_params_returns_false() {
+        assert!(!is_presigned_url_expired(
+            "https://bucket.s3.amazonaws.com/key"
+        ));
+    }
+
+    #[test]
+    fn presigned_url_invalid_date_returns_false() {
+        let url = "https://bucket.s3.amazonaws.com/key?X-Amz-Date=invalid&X-Amz-Expires=3600";
+        assert!(!is_presigned_url_expired(url));
+    }
+
+    #[tokio::test]
+    async fn download_chunk_returns_chunk_url_expired_for_expired_url() {
+        let client = reqwest::Client::new();
+        let expired_url =
+            "https://bucket.s3.amazonaws.com/key?X-Amz-Date=20200101T000000Z&X-Amz-Expires=3600"
+                .to_string();
+        let result = download_chunk(client, expired_url, HeaderMap::new(), String::new()).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, crate::Error::ChunkUrlExpired),
+            "expected ChunkUrlExpired, got: {err:?}"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     #[error("chunk download error: {0}")]
     ChunkDownload(String),
 
+    #[error("chunk presigned URL expired (HTTP 403)")]
+    ChunkUrlExpired,
+
     #[error("io error: {0}")]
     IO(#[from] std::io::Error),
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -9,7 +9,6 @@ use http::{
     header::{ACCEPT, AUTHORIZATION},
 };
 use reqwest::{Client, Url};
-use serde::de::Error as _;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::time::sleep;
 
@@ -24,12 +23,20 @@ const DEFAULT_TIMEOUT_SECONDS: u64 = 300;
 
 pub struct QueryExecutor {
     http: Client,
-    qrmk: String,
+    /// Updated on refresh because it may be rotated.
+    qrmk: Mutex<String>,
     chunks: Mutex<VecDeque<RawQueryResponseChunk>>,
-    chunk_headers: HeaderMap,
+    /// Updated on refresh because it may change.
+    chunk_headers: Mutex<HeaderMap>,
     column_types: Arc<Vec<SnowflakeColumnType>>,
     column_indices: Arc<HashMap<String, usize>>,
     row_set: Mutex<Option<Vec<Vec<Option<String>>>>>,
+    session_token: String,
+    base_url: Url,
+    /// Path to re-fetch query-result metadata with fresh presigned URLs.
+    /// This does **not** re-execute the query.
+    result_path: String,
+    total_chunks: usize,
 }
 
 impl QueryExecutor {
@@ -54,67 +61,16 @@ impl QueryExecutor {
             .append_pair("requestId", &request_id.to_string());
 
         let request: QueryRequest = request.into();
-        let response = http
-            .post(url)
-            .header(ACCEPT, "application/snowflake")
-            .header(
-                AUTHORIZATION,
-                format!(r#"Snowflake Token="{session_token}""#),
-            )
-            .json(&request)
-            .send()
-            .await?;
+        let mut response_data = send_snowflake_request(
+            snowflake_request(http, http::Method::POST, url, session_token).json(&request),
+        )
+        .await?;
 
-        let status = response.status();
-        let body = response.text().await?;
-        if !status.is_success() {
-            return Err(Error::Communication(format!("HTTP {status}: {body}")));
+        if let Some(result_url) = response_data.get_result_url.take() {
+            response_data =
+                poll_for_async_results(http, &result_url, session_token, query_timeout, base_url.clone())
+                    .await?;
         }
-
-        let mut response: SnowflakeResponse =
-            serde_json::from_str(&body).map_err(|e| Error::Json(e, body))?;
-
-        let response_code = response.code.as_deref();
-        if response_code == Some(QUERY_IN_PROGRESS_ASYNC_CODE)
-            || response_code == Some(QUERY_IN_PROGRESS_CODE)
-        {
-            let Some(data) = response.data else {
-                return Err(Error::Json(
-                    serde_json::Error::custom("missing data field in async query response"),
-                    "".to_string(),
-                ));
-            };
-            match data.get_result_url {
-                Some(result_url) => {
-                    response = poll_for_async_results(
-                        http,
-                        &result_url,
-                        session_token,
-                        query_timeout,
-                        base_url.clone(),
-                    )
-                    .await?
-                }
-                None => {
-                    return Err(Error::NoPollingUrlAsyncQuery);
-                }
-            }
-        }
-
-        if let Some(SESSION_EXPIRED) = response.code.as_deref() {
-            return Err(Error::SessionExpired);
-        }
-
-        if !response.success {
-            return Err(Error::Communication(response.message.unwrap_or_default()));
-        }
-
-        let Some(response_data) = response.data else {
-            return Err(Error::Json(
-                serde_json::Error::custom("missing data field in query response"),
-                "".to_string(),
-            ));
-        };
 
         if let Some(format) = response_data.query_result_format {
             if format != "json" {
@@ -123,8 +79,14 @@ impl QueryExecutor {
         }
 
         let http = http.clone();
+        let session_token = session_token.clone();
         let qrmk = response_data.qrmk.unwrap_or_default();
-        let chunks = Mutex::new(VecDeque::from(response_data.chunks.unwrap_or_default()));
+        let result_path = response_data
+            .get_result_url
+            .unwrap_or_else(|| format!("/queries/{}/result", response_data.query_id));
+        let chunks_vec = response_data.chunks.unwrap_or_default();
+        let total_chunks = chunks_vec.len();
+        let chunks = Mutex::new(VecDeque::from(chunks_vec));
         let row_types = response_data.row_types.ok_or_else(|| {
             Error::UnsupportedFormat("the response doesn't contain 'rowtype'".to_string())
         })?;
@@ -157,12 +119,16 @@ impl QueryExecutor {
 
         Ok(Self {
             http,
-            qrmk,
+            qrmk: Mutex::new(qrmk),
             chunks,
-            chunk_headers,
+            chunk_headers: Mutex::new(chunk_headers),
             column_types,
             column_indices,
             row_set,
+            session_token,
+            base_url,
+            result_path,
+            total_chunks,
         })
     }
 
@@ -173,25 +139,47 @@ impl QueryExecutor {
         row_set.is_none() && chunks.is_empty()
     }
 
-    /// Fetch a single chunk
+    /// Fetch a single chunk.
+    ///
+    /// When a presigned URL has expired, this method transparently refreshes
+    /// all remaining URLs (without re-executing the query) and retries.
     pub async fn fetch_next_chunk(&self) -> Result<Option<Vec<SnowflakeRow>>> {
-        let row_set = &mut *self.row_set.lock().await;
-        if let Some(row_set) = row_set.take() {
-            let rows = row_set.into_iter().map(|r| self.convert_row(r)).collect();
-            return Ok(Some(rows));
+        {
+            let mut row_set = self.row_set.lock().await;
+            if let Some(rs) = row_set.take() {
+                let rows = rs.into_iter().map(|r| self.convert_row(r)).collect();
+                return Ok(Some(rows));
+            }
         }
 
-        let http = self.http.clone();
-        let chunk_headers = self.chunk_headers.clone();
-        let qrmk = self.qrmk.clone();
-        let chunks = &mut *self.chunks.lock().await;
-        let Some(chunk) = chunks.pop_front() else {
-            return Ok(None);
+        // pop_front yields chunks in the original order (0, 1, 2, …).
+        // total_chunks - remaining_after_pop gives the original index.
+        let (chunk_url, original_index) = {
+            let mut chunks = self.chunks.lock().await;
+            let Some(chunk) = chunks.pop_front() else {
+                return Ok(None);
+            };
+            (chunk.url, self.total_chunks - chunks.len() - 1)
         };
 
-        let rows = download_chunk(http, chunk.url, chunk_headers, qrmk).await?;
-        let rows = rows.into_iter().map(|r| self.convert_row(r)).collect();
-        Ok(Some(rows))
+        let http = self.http.clone();
+        let chunk_headers = self.chunk_headers.lock().await.clone();
+        let qrmk = self.qrmk.lock().await.clone();
+
+        match download_chunk(http.clone(), chunk_url, chunk_headers, qrmk).await {
+            Ok(rows) => {
+                let rows = rows.into_iter().map(|r| self.convert_row(r)).collect();
+                Ok(Some(rows))
+            }
+            Err(Error::ChunkUrlExpired) => {
+                let (fresh_url, chunk_headers, qrmk) =
+                    self.refresh_presigned_urls(original_index).await?;
+                let rows = download_chunk(http, fresh_url, chunk_headers, qrmk).await?;
+                let rows = rows.into_iter().map(|r| self.convert_row(r)).collect();
+                Ok(Some(rows))
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Fetch all the remaining chunks at once
@@ -229,11 +217,14 @@ impl QueryExecutor {
         // The semaphore ensures that no more than `concurrency` downloads are in flight.
         let semaphore = Arc::new(Semaphore::new(concurrency));
 
+        let chunk_headers = self.chunk_headers.lock().await.clone();
+        let qrmk = self.qrmk.lock().await.clone();
+
         let mut handles = Vec::with_capacity(chunks.len());
         while let Some(chunk) = chunks.pop_front() {
             let http = self.http.clone();
-            let chunk_headers = self.chunk_headers.clone();
-            let qrmk = self.qrmk.clone();
+            let chunk_headers = chunk_headers.clone();
+            let qrmk = qrmk.clone();
             let semaphore = semaphore.clone();
             handles.push(tokio::spawn(async move {
                 let _permit = semaphore.acquire_owned().await?;
@@ -249,6 +240,53 @@ impl QueryExecutor {
         Ok(rows)
     }
 
+    /// Re-fetch result metadata from Snowflake to obtain fresh presigned URLs,
+    /// update internal state (`qrmk`, `chunk_headers`, remaining `chunks`),
+    /// and return the fresh URL + headers + qrmk for `retry_chunk_index`.
+    ///
+    /// This does **not** re-execute the query.  Snowflake persists query
+    /// results for 24 hours; this call simply returns the same result set
+    /// with newly signed download URLs.
+    async fn refresh_presigned_urls(
+        &self,
+        retry_chunk_index: usize,
+    ) -> Result<(String, HeaderMap, String)> {
+        let url = resolve_url(&self.base_url, &self.result_path)?;
+        let data = send_snowflake_request(snowflake_request(
+            &self.http,
+            http::Method::GET,
+            url,
+            &self.session_token,
+        ))
+        .await?;
+
+        let fresh_qrmk = data.qrmk.unwrap_or_default();
+        let fresh_headers: HeaderMap =
+            HeaderMap::try_from(&data.chunk_headers.unwrap_or_default())?;
+        let fresh_chunks = data.chunks.unwrap_or_default();
+
+        let fresh_url = fresh_chunks
+            .get(retry_chunk_index)
+            .ok_or_else(|| {
+                Error::Communication(format!(
+                    "refreshed result missing chunk index {} (total: {})",
+                    retry_chunk_index,
+                    fresh_chunks.len()
+                ))
+            })?
+            .url
+            .clone();
+
+        *self.qrmk.lock().await = fresh_qrmk.clone();
+        *self.chunk_headers.lock().await = fresh_headers.clone();
+        *self.chunks.lock().await = fresh_chunks
+            .into_iter()
+            .skip(retry_chunk_index + 1)
+            .collect();
+
+        Ok((fresh_url, fresh_headers, fresh_qrmk))
+    }
+
     fn convert_row(&self, row: Vec<Option<String>>) -> SnowflakeRow {
         SnowflakeRow {
             row,
@@ -258,44 +296,85 @@ impl QueryExecutor {
     }
 }
 
+/// Build a request with Snowflake's standard auth headers.
+fn snowflake_request(
+    http: &Client,
+    method: http::Method,
+    url: Url,
+    session_token: &str,
+) -> reqwest::RequestBuilder {
+    http.request(method, url)
+        .header(ACCEPT, "application/snowflake")
+        .header(
+            AUTHORIZATION,
+            format!(r#"Snowflake Token="{session_token}""#),
+        )
+}
+
+/// Send a Snowflake API request, validate the response (HTTP errors,
+/// session expiry, API-level failures), and return the `data` payload.
+async fn send_snowflake_request(request: reqwest::RequestBuilder) -> Result<RawQueryResponse> {
+    let resp = request.send().await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    if !status.is_success() {
+        return Err(Error::Communication(format!("HTTP {status}: {body}")));
+    }
+    let response: SnowflakeResponse =
+        serde_json::from_str(&body).map_err(|e| Error::Json(e, body))?;
+    if response.code.as_deref() == Some(SESSION_EXPIRED) {
+        return Err(Error::SessionExpired);
+    }
+    if !response.success {
+        return Err(Error::Communication(response.message.unwrap_or_default()));
+    }
+    response
+        .data
+        .ok_or_else(|| Error::Communication("missing data field in response".to_string()))
+}
+
+fn resolve_url(base_url: &Url, path: &str) -> Result<Url> {
+    if let Ok(absolute) = Url::parse(path) {
+        Ok(absolute)
+    } else {
+        Ok(base_url.join(path)?)
+    }
+}
+
+/// Poll until the async query completes, checking the response code.
 async fn poll_for_async_results(
     http: &Client,
     result_url: &str,
     session_token: &str,
     timeout: Duration,
     base_url: Url,
-) -> Result<SnowflakeResponse> {
+) -> Result<RawQueryResponse> {
     let start = Instant::now();
     while start.elapsed() < timeout {
         sleep(Duration::from_secs(10)).await;
-        let url = if let Ok(url) = Url::parse(result_url) {
-            url
-        } else {
-            base_url.join(result_url)?
-        };
-
-        let resp = http
-            .get(url)
-            .header(ACCEPT, "application/snowflake")
-            .header(
-                AUTHORIZATION,
-                format!(r#"Snowflake Token="{session_token}""#),
-            )
+        let url = resolve_url(&base_url, result_url)?;
+        let resp = snowflake_request(http, http::Method::GET, url, session_token)
             .send()
             .await?;
-
         let status = resp.status();
         let body = resp.text().await?;
         if !status.is_success() {
             return Err(Error::Communication(format!("HTTP {status}: {body}")));
         }
-
         let response: SnowflakeResponse =
             serde_json::from_str(&body).map_err(|e| Error::Json(e, body))?;
         if response.code.as_deref() != Some(QUERY_IN_PROGRESS_ASYNC_CODE)
             && response.code.as_deref() != Some(QUERY_IN_PROGRESS_CODE)
         {
-            return Ok(response);
+            if response.code.as_deref() == Some(SESSION_EXPIRED) {
+                return Err(Error::SessionExpired);
+            }
+            if !response.success {
+                return Err(Error::Communication(response.message.unwrap_or_default()));
+            }
+            return response
+                .data
+                .ok_or_else(|| Error::Communication("missing data field in response".to_string()));
         }
     }
 
@@ -524,9 +603,7 @@ impl From<String> for QueryRequest {
 struct RawQueryResponse {
     #[allow(unused)]
     parameters: Option<Vec<RawQueryResponseParameter>>,
-    #[allow(unused)]
     query_id: String,
-    #[allow(unused)]
     get_result_url: Option<String>,
     #[allow(unused)]
     returned: Option<i64>,
@@ -583,7 +660,7 @@ struct RawQueryResponseParameter {
     value: serde_json::Value,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RawQueryResponseChunk {
     url: String,

--- a/src/query.rs
+++ b/src/query.rs
@@ -67,9 +67,14 @@ impl QueryExecutor {
         .await?;
 
         if let Some(result_url) = response_data.get_result_url.take() {
-            response_data =
-                poll_for_async_results(http, &result_url, session_token, query_timeout, base_url.clone())
-                    .await?;
+            response_data = poll_for_async_results(
+                http,
+                &result_url,
+                session_token,
+                query_timeout,
+                base_url.clone(),
+            )
+            .await?;
         }
 
         if let Some(format) = response_data.query_result_format {

--- a/src/query.rs
+++ b/src/query.rs
@@ -304,6 +304,16 @@ impl QueryExecutor {
         }
     }
 
+    /// Returns `true` if any remaining chunk URL still contains the
+    /// expired marker set by [`expire_chunk_urls_for_testing`].
+    #[cfg(test)]
+    async fn has_expired_chunk_urls(&self) -> bool {
+        let chunks = self.chunks.lock().await;
+        chunks
+            .iter()
+            .any(|c| c.url.contains("expired.s3.amazonaws.com"))
+    }
+
     fn convert_row(&self, row: Vec<Option<String>>) -> SnowflakeRow {
         SnowflakeRow {
             row,
@@ -784,6 +794,19 @@ mod tests {
             !rows.unwrap().is_empty(),
             "refreshed chunk should contain rows"
         );
+
+        // refresh_presigned_urls must also update the remaining chunk
+        // URLs in the executor so that subsequent fetches use fresh URLs.
+        if !executor.eof().await {
+            assert!(
+                !executor.has_expired_chunk_urls().await,
+                "remaining chunk URLs should have been replaced with fresh ones"
+            );
+
+            // Verify the next chunk downloads normally with the fresh URL.
+            let next = executor.fetch_next_chunk().await.unwrap();
+            assert!(next.is_some(), "next chunk after refresh should succeed");
+        }
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -292,6 +292,18 @@ impl QueryExecutor {
         Ok((fresh_url, fresh_headers, fresh_qrmk))
     }
 
+    /// Replace all remaining chunk URLs with expired ones so that
+    /// `is_presigned_url_expired` returns `true` on the next download attempt.
+    #[cfg(test)]
+    async fn expire_chunk_urls_for_testing(&self) {
+        let mut chunks = self.chunks.lock().await;
+        for chunk in chunks.iter_mut() {
+            chunk.url = "https://expired.s3.amazonaws.com/chunk\
+                ?X-Amz-Date=20200101T000000Z&X-Amz-Expires=3600"
+                .to_string();
+        }
+    }
+
     fn convert_row(&self, row: Vec<Option<String>>) -> SnowflakeRow {
         SnowflakeRow {
             row,
@@ -692,6 +704,87 @@ struct SnowflakeResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Create a Snowflake session using environment variables.
+    /// Returns `None` when credentials are not available so that
+    /// integration tests can be silently skipped.
+    async fn create_test_session() -> Option<crate::SnowflakeSession> {
+        let username = std::env::var("SNOWFLAKE_USERNAME").ok()?;
+        let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+        let private_key = std::env::var("SNOWFLAKE_PRIVATE_KEY").ok()?;
+        let password = std::env::var("SNOWFLAKE_PRIVATE_KEY_PASSWORD").ok()?;
+
+        let mut session_config = crate::SnowflakeSessionConfig::default();
+        if let Ok(v) = std::env::var("SNOWFLAKE_ROLE") {
+            session_config = session_config.with_role(v);
+        }
+        if let Ok(v) = std::env::var("SNOWFLAKE_WAREHOUSE") {
+            session_config = session_config.with_warehouse(v);
+        }
+        if let Ok(v) = std::env::var("SNOWFLAKE_DATABASE") {
+            session_config = session_config.with_database(v);
+        }
+        if let Ok(v) = std::env::var("SNOWFLAKE_SCHEMA") {
+            session_config = session_config.with_schema(v);
+        }
+
+        let config = crate::SnowflakeClientConfig::new(
+            &username,
+            &account,
+            crate::SnowflakeAuthMethod::KeyPair {
+                encrypted_pem: private_key,
+                password: password.into_bytes(),
+            },
+        )
+        .with_session(session_config);
+
+        let client = crate::SnowflakeClient::new(config).ok()?;
+        client.create_session().await.ok()
+    }
+
+    /// Verify that `fetch_next_chunk` transparently refreshes expired
+    /// presigned URLs by calling `refresh_presigned_urls`.
+    ///
+    /// 1. Execute a Snowflake query large enough to produce multiple chunks.
+    /// 2. Consume the initial inline row-set.
+    /// 3. Replace remaining chunk URLs with expired ones.
+    /// 4. Call `fetch_next_chunk` and assert it succeeds — proving that
+    ///    the refresh endpoint returned fresh URLs and the download worked.
+    ///
+    /// Skipped when Snowflake credentials are not set.
+    #[tokio::test]
+    async fn test_fetch_next_chunk_refreshes_expired_urls() {
+        let Some(session) = create_test_session().await else {
+            return;
+        };
+
+        let query = "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS PAD \
+                     FROM TABLE(GENERATOR(ROWCOUNT=>200000))";
+        let executor = session.execute(query).await.unwrap();
+
+        // Consume the initial row_set.
+        let first = executor.fetch_next_chunk().await.unwrap();
+        assert!(first.is_some(), "expected initial row_set");
+
+        // We need remaining chunks for this test.
+        assert!(
+            !executor.eof().await,
+            "need remaining chunks to test refresh"
+        );
+
+        // Poison all remaining chunk URLs so they appear expired.
+        executor.expire_chunk_urls_for_testing().await;
+
+        // fetch_next_chunk should detect the expired URL, call
+        // refresh_presigned_urls (GET /queries/{id}/result), obtain
+        // fresh URLs, and download the chunk successfully.
+        let rows = executor.fetch_next_chunk().await.unwrap();
+        assert!(rows.is_some(), "expected rows after URL refresh");
+        assert!(
+            !rows.unwrap().is_empty(),
+            "refreshed chunk should contain rows"
+        );
+    }
 
     #[test]
     fn test_deserialize_session_expired() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -784,6 +784,10 @@ mod tests {
 
         // Poison all remaining chunk URLs so they appear expired.
         executor.expire_chunk_urls_for_testing().await;
+        assert!(
+            executor.has_expired_chunk_urls().await,
+            "chunk URLs should be expired after poisoning"
+        );
 
         // fetch_next_chunk should detect the expired URL, call
         // refresh_presigned_urls (GET /queries/{id}/result), obtain
@@ -802,10 +806,6 @@ mod tests {
                 !executor.has_expired_chunk_urls().await,
                 "remaining chunk URLs should have been replaced with fresh ones"
             );
-
-            // Verify the next chunk downloads normally with the fresh URL.
-            let next = executor.fetch_next_chunk().await.unwrap();
-            assert!(next.is_some(), "next chunk after refresh should succeed");
         }
     }
 


### PR DESCRIPTION
## Summary
- Snowflake's presigned URLs for query-result chunks expire after ~6 hours, causing `HTTP 403` errors during long-running downloads
- Added `is_presigned_url_expired()` to parse `X-Amz-Date` + `X-Amz-Expires` from the URL and detect expiry before downloading (with a 5-minute buffer)
- On expiry, calls `GET /queries/{queryId}/result` to obtain fresh presigned URLs for the same result set (does **not** re-execute the query)
- Also refreshes `qrmk`, `chunk_headers`, and remaining `chunks`
- Wrapped `qrmk` and `chunk_headers` in `Mutex` so they can be safely updated during a refresh
- Extracted `send_snowflake_request` / `snowflake_request` / `resolve_url` helper functions, consolidating inline HTTP logic from `create()` and `poll_for_async_results()`
- Changed `poll_for_async_results()` to return `RawQueryResponse` directly (session-expired / success checks are now handled internally)
- Removed unused `serde::de::Error` import
- Added an integration test for the refresh flow: poison chunk URLs with expired timestamps → assert URLs are expired → `fetch_next_chunk` triggers automatic refresh → verify download succeeds → verify remaining chunk URLs are also updated via `has_expired_chunk_urls`

## Review & Testing Checklist for Human
- [ ] **Changes to async query handling in `create()`**: The old code explicitly checked `response.code` to determine whether a query was async and returned `NoPollingUrlAsyncQuery` on missing poll URL. The new code lets `send_snowflake_request` extract `.data` first, then branches on `get_result_url` presence alone. (1) Verify that async responses with `success: false` are not mishandled by `send_snowflake_request`. (2) Verify that an async response with `get_result_url: None` silently passing through (instead of raising `NoPollingUrlAsyncQuery`) is acceptable.
- [ ] Confirm that `poll_for_async_results()` returning `RawQueryResponse` (instead of `SnowflakeResponse`) correctly handles `SESSION_EXPIRED` and failure cases internally.
- [ ] Verify `refresh_presigned_urls` calls the correct endpoint (`/queries/{queryId}/result`) via `send_snowflake_request`, and that the returned `chunks` indices align with the original chunk ordering.
- [ ] `fetch_all_with_concurrency_limit` does **not** handle `ChunkUrlExpired` — this is intentional since rusel only uses `fetch_next_chunk`. Confirm no other consumers are affected.
- [ ] The integration test `test_fetch_next_chunk_refreshes_expired_urls` only exercises the proactive detection path (`is_presigned_url_expired` before HTTP request). It does not test recovery from an actual HTTP 403 response. Confirm this is sufficient given that the current implementation always checks URL parameters before making the request.

**Recommended test plan**: CI runs the integration test automatically (with Snowflake credentials). Additionally, a manual verification with a real 6+ hour query is recommended — set `RUST_LOG=debug` and confirm that downloads resume after a refresh.

## Test plan
- [x] `cargo test --lib` — all 73 tests pass
- [x] `cargo fmt --check` / `cargo clippy` pass
- [x] Unit tests for URL expiry parsing (verified against real Snowflake URL format from production logs)
- [x] Unit test: `download_chunk` returns `ChunkUrlExpired` for an expired URL
- [x] Integration test: `fetch_next_chunk` refresh flow — poison URLs → assert `has_expired_chunk_urls == true` → refresh → download succeeds → assert `has_expired_chunk_urls == false` (runs in CI with Snowflake credentials)
- [ ] Confirm presigned URL refresh works correctly with a real 6+ hour query

### Notes
- #101 is already merged
- `fetch_all_with_concurrency_limit` (the default path for `session.query()`) does not support URL refresh. Since rusel only uses `execute()` + `fetch_next_chunk()`, this PR resolves the rusel issue
- Rebased onto main (conflicts resolved)
- The integration test is silently skipped when Snowflake credentials are not set (`create_test_session()` returns `None`)

Link to Devin session: https://app.devin.ai/sessions/670906ca375148e8a8381563f5c2296d
Requested by: @akira-john
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/estie-inc/snowflake-connector-rs/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
