### PR TITLE
fix: include HTTP status code in communication error messages

### DIFF
--- a/src/auth/external_browser.rs
+++ b/src/auth/external_browser.rs
@@ -141,7 +141,7 @@ async fn request_authenticator(
     let status = resp.status();
     let text = resp.text().await?;
     if !status.is_success() {
-        return Err(Error::Communication(text));
+        return Err(Error::Communication(format!("HTTP {status}: {text}")));
     }
 
     let parsed: AuthenticatorResponse =

--- a/src/auth/login.rs
+++ b/src/auth/login.rs
@@ -105,7 +105,7 @@ pub(crate) async fn login(
     let status = resp.status();
     let body = resp.text().await?;
     if !status.is_success() {
-        return Err(Error::Communication(body));
+        return Err(Error::Communication(format!("HTTP {status}: {body}")));
     }
 
     let parsed: Response = serde_json::from_str(&body).map_err(|e| Error::Json(e, body))?;

--- a/src/query.rs
+++ b/src/query.rs
@@ -68,7 +68,7 @@ impl QueryExecutor {
         let status = response.status();
         let body = response.text().await?;
         if !status.is_success() {
-            return Err(Error::Communication(body));
+            return Err(Error::Communication(format!("HTTP {status}: {body}")));
         }
 
         let mut response: SnowflakeResponse =
@@ -287,7 +287,7 @@ async fn poll_for_async_results(
         let status = resp.status();
         let body = resp.text().await?;
         if !status.is_success() {
-            return Err(Error::Communication(body));
+            return Err(Error::Communication(format!("HTTP {status}: {body}")));
         }
 
         let response: SnowflakeResponse =


### PR DESCRIPTION
## Summary

- When Snowflake returns an HTTP error (4xx/5xx), the `Error::Communication` message previously contained only the response body, which is often empty or unhelpful for diagnosing transient failures.
- This change prefixes the error message with the HTTP status code (e.g. `HTTP 503 Service Unavailable: <body>`), making it immediately clear whether the error is a client error (4xx) or server error (5xx).
- Applied to all three HTTP error paths: query execution, async result polling, and login.

## Test plan

- [x] `cargo check` passes
- [x] All 66 unit tests pass (`cargo test` — the `test_async_query` integration test is excluded as it requires Snowflake credentials)
- [ ] Verify error messages in a real Snowflake environment when HTTP errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/estie-inc/snowflake-connector-rs/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
