### PR TITLE
feat: expose result column metadata on QueryExecutor

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -256,6 +256,22 @@ impl QueryExecutor {
             column_types: Arc::clone(&self.column_types),
         }
     }
+
+    /// Column metadata for this result set, including when [`fetch_all`](Self::fetch_all) returns no rows.
+    pub fn snowflake_columns(&self) -> Vec<crate::SnowflakeColumn> {
+        let mut names: Vec<(String, usize)> = self
+            .column_indices
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect();
+        names.sort_by_key(|(_, idx)| *idx);
+        names
+            .into_iter()
+            .map(|(name, index)| {
+                crate::SnowflakeColumn::new(name, index, self.column_types[index].clone())
+            })
+            .collect()
+    }
 }
 
 async fn poll_for_async_results(


### PR DESCRIPTION
This adds QueryExecutor::snowflake_columns(), returning Vec<SnowflakeColumn> in result-set order using the same metadata already stored on the executor (column_indices / column_types).

Why: Callers that convert query results to Arrow (or other tabular formats) need column names and types even when Snowflake returns no rows (e.g. LIMIT 0). Today that information is only easy to access via SnowflakeRow::column_types(), which requires at least one row. Reading metadata from the executor before fetch_all() fixes empty result sets.

Compatibility: New public API only; existing behavior unchanged.