### PR TITLE
refactor(query)!: share column metadata across executor and rows

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -13,9 +13,10 @@ use serde::de::Error as _;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::time::sleep;
 
-use crate::SnowflakeSession;
-use crate::row::SnowflakeColumnType;
-use crate::{Error, Result, SnowflakeRow, chunk::download_chunk};
+use crate::{
+    Error, Result, SnowflakeColumn, SnowflakeRow, SnowflakeSession, chunk::download_chunk,
+    row::SnowflakeColumnType,
+};
 
 pub(super) const SESSION_EXPIRED: &str = "390112";
 pub(super) const QUERY_IN_PROGRESS_CODE: &str = "333333";
@@ -27,7 +28,7 @@ pub struct QueryExecutor {
     qrmk: String,
     chunks: Mutex<VecDeque<RawQueryResponseChunk>>,
     chunk_headers: HeaderMap,
-    column_types: Arc<Vec<SnowflakeColumnType>>,
+    columns: Arc<[SnowflakeColumn]>,
     column_indices: Arc<HashMap<String, usize>>,
     row_set: Mutex<Option<Vec<Vec<Option<String>>>>>,
 }
@@ -133,24 +134,30 @@ impl QueryExecutor {
         })?;
         let row_set = Mutex::new(Some(row_set));
 
-        let column_indices = row_types
-            .iter()
-            .enumerate()
-            .map(|(i, row_type)| (row_type.name.to_ascii_uppercase(), i))
-            .collect::<HashMap<_, _>>();
-        let column_indices = Arc::new(column_indices);
-
-        let column_types = row_types
+        let columns = row_types
             .into_iter()
-            .map(|row_type| SnowflakeColumnType {
-                snowflake_type: row_type.data_type,
-                nullable: row_type.nullable,
-                length: row_type.length,
-                precision: row_type.precision,
-                scale: row_type.scale,
+            .enumerate()
+            .map(|(index, row_type)| {
+                SnowflakeColumn::new(
+                    row_type.name.to_ascii_uppercase(),
+                    index,
+                    SnowflakeColumnType {
+                        snowflake_type: row_type.data_type,
+                        nullable: row_type.nullable,
+                        length: row_type.length,
+                        precision: row_type.precision,
+                        scale: row_type.scale,
+                    },
+                )
             })
             .collect::<Vec<_>>();
-        let column_types = Arc::new(column_types);
+
+        let column_indices = columns
+            .iter()
+            .map(|column| (column.name().to_string(), column.index()))
+            .collect::<HashMap<_, _>>();
+        let column_indices = Arc::new(column_indices);
+        let columns = Arc::from(columns);
 
         let chunk_headers = response_data.chunk_headers.unwrap_or_default();
         let chunk_headers: HeaderMap = HeaderMap::try_from(&chunk_headers)?;
@@ -160,7 +167,7 @@ impl QueryExecutor {
             qrmk,
             chunks,
             chunk_headers,
-            column_types,
+            columns,
             column_indices,
             row_set,
         })
@@ -252,25 +259,14 @@ impl QueryExecutor {
     fn convert_row(&self, row: Vec<Option<String>>) -> SnowflakeRow {
         SnowflakeRow {
             row,
+            columns: Arc::clone(&self.columns),
             column_indices: Arc::clone(&self.column_indices),
-            column_types: Arc::clone(&self.column_types),
         }
     }
 
     /// Column metadata for this result set, including when [`fetch_all`](Self::fetch_all) returns no rows.
-    pub fn snowflake_columns(&self) -> Vec<crate::SnowflakeColumn> {
-        let mut names: Vec<(String, usize)> = self
-            .column_indices
-            .iter()
-            .map(|(k, v)| (k.clone(), *v))
-            .collect();
-        names.sort_by_key(|(_, idx)| *idx);
-        names
-            .into_iter()
-            .map(|(name, index)| {
-                crate::SnowflakeColumn::new(name, index, self.column_types[index].clone())
-            })
-            .collect()
+    pub fn columns(&self) -> &[SnowflakeColumn] {
+        self.columns.as_ref()
     }
 }
 

--- a/src/row.rs
+++ b/src/row.rs
@@ -33,7 +33,7 @@ use crate::{Error, Result};
 /// assert_eq!(column.index(), 0);
 /// assert_eq!(column.column_type().snowflake_type(), "fixed");
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SnowflakeColumn {
     pub(super) name: String,
     pub(super) index: usize,
@@ -192,7 +192,7 @@ impl SnowflakeColumnType {
 #[derive(Debug)]
 pub struct SnowflakeRow {
     pub(crate) row: Vec<Option<String>>,
-    pub(crate) column_types: Arc<Vec<SnowflakeColumnType>>,
+    pub(crate) columns: Arc<[SnowflakeColumn]>,
     pub(crate) column_indices: Arc<HashMap<String, usize>>,
 }
 
@@ -202,33 +202,21 @@ impl SnowflakeRow {
             .column_indices
             .get(&column_name.to_ascii_uppercase())
             .ok_or_else(|| Error::Decode(format!("column not found: {column_name}")))?;
-        let ty = &self.column_types[*idx];
-        (&self.row[*idx], ty).try_get()
+        self.at(*idx)
     }
     pub fn at<T: SnowflakeDecode>(&self, column_index: usize) -> Result<T> {
-        let ty = &self.column_types[column_index];
+        let ty = self.columns[column_index].column_type();
         (&self.row[column_index], ty).try_get()
     }
     pub fn column_names(&self) -> Vec<&str> {
-        let mut names: Vec<(_, usize)> = self.column_indices.iter().map(|(k, v)| (k, *v)).collect();
-        names.sort_by_key(|(_, v)| *v);
-        names.into_iter().map(|(name, _)| name.as_str()).collect()
+        self.columns.iter().map(|column| column.name()).collect()
     }
+    pub fn columns(&self) -> &[SnowflakeColumn] {
+        self.columns.as_ref()
+    }
+    #[deprecated(note = "use columns() instead")]
     pub fn column_types(&self) -> Vec<SnowflakeColumn> {
-        let mut names: Vec<(String, usize)> = self
-            .column_indices
-            .iter()
-            .map(|(k, v)| (k.clone(), *v))
-            .collect();
-        names.sort_by_key(|(_, v)| *v);
-        names
-            .into_iter()
-            .map(|(name, index)| SnowflakeColumn {
-                name,
-                index,
-                column_type: self.column_types[index].clone(),
-            })
-            .collect()
+        self.columns.iter().cloned().collect()
     }
 }
 

--- a/tests/cases/test_basic_operations.rs
+++ b/tests/cases/test_basic_operations.rs
@@ -60,26 +60,26 @@ async fn test_basic_operations() -> Result<()> {
     assert_eq!(rows[1].get::<i64>("ID")?, 2);
     assert_eq!(rows[1].get::<String>("VALUE")?, "world");
 
-    // Test column_types method with various data types
-    let column_types = rows[0].column_types();
-    assert_eq!(column_types.len(), 6);
+    // Test columns method with various data types
+    let columns = rows[0].columns();
+    assert_eq!(columns.len(), 6);
 
     // Check ID column (NUMBER/FIXED)
-    let id_column = &column_types[0];
+    let id_column = &columns[0];
     assert_eq!(id_column.name(), "ID");
     assert_eq!(id_column.index(), 0);
     assert_eq!(id_column.column_type().snowflake_type(), "fixed");
     assert!(id_column.column_type().nullable());
 
     // Check VALUE column (STRING/TEXT)
-    let value_column = &column_types[1];
+    let value_column = &columns[1];
     assert_eq!(value_column.name(), "VALUE");
     assert_eq!(value_column.index(), 1);
     assert_eq!(value_column.column_type().snowflake_type(), "text");
     assert!(value_column.column_type().nullable());
 
     // Check PRICE column (DECIMAL)
-    let price_column = &column_types[2];
+    let price_column = &columns[2];
     assert_eq!(price_column.name(), "PRICE");
     assert_eq!(price_column.index(), 2);
     assert_eq!(price_column.column_type().snowflake_type(), "fixed");
@@ -88,21 +88,21 @@ async fn test_basic_operations() -> Result<()> {
     assert_eq!(price_column.column_type().scale(), Some(2));
 
     // Check IS_ACTIVE column (BOOLEAN)
-    let is_active_column = &column_types[3];
+    let is_active_column = &columns[3];
     assert_eq!(is_active_column.name(), "IS_ACTIVE");
     assert_eq!(is_active_column.index(), 3);
     assert_eq!(is_active_column.column_type().snowflake_type(), "boolean");
     assert!(is_active_column.column_type().nullable());
 
     // Check CREATED_DATE column (DATE)
-    let date_column = &column_types[4];
+    let date_column = &columns[4];
     assert_eq!(date_column.name(), "CREATED_DATE");
     assert_eq!(date_column.index(), 4);
     assert_eq!(date_column.column_type().snowflake_type(), "date");
     assert!(date_column.column_type().nullable());
 
     // Check UPDATED_AT column (TIMESTAMP_NTZ)
-    let timestamp_column = &column_types[5];
+    let timestamp_column = &columns[5];
     assert_eq!(timestamp_column.name(), "UPDATED_AT");
     assert_eq!(timestamp_column.index(), 5);
     assert_eq!(
@@ -110,6 +110,30 @@ async fn test_basic_operations() -> Result<()> {
         "timestamp_ntz"
     );
     assert!(timestamp_column.column_type().nullable());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_executor_columns_available_without_rows() -> Result<()> {
+    let client = common::connect()?;
+    let session = client.create_session().await?;
+
+    let executor = session
+        .execute("SELECT 1 AS ID, 'hello' AS NAME LIMIT 0")
+        .await?;
+
+    let columns = executor.columns();
+    assert_eq!(columns.len(), 2);
+    assert_eq!(columns[0].name(), "ID");
+    assert_eq!(columns[0].index(), 0);
+    assert_eq!(columns[0].column_type().snowflake_type(), "fixed");
+    assert_eq!(columns[1].name(), "NAME");
+    assert_eq!(columns[1].index(), 1);
+    assert_eq!(columns[1].column_type().snowflake_type(), "text");
+
+    let rows = executor.fetch_all().await?;
+    assert!(rows.is_empty());
 
     Ok(())
 }

--- a/tests/cases/test_chunk.rs
+++ b/tests/cases/test_chunk.rs
@@ -80,7 +80,7 @@ async fn test_download_chunked_results() -> Result<()> {
     assert!(rows[0].column_names().contains(&"SEQ"));
     assert!(rows[0].column_names().contains(&"RAND"));
 
-    let columns = rows[0].column_types();
+    let columns = rows[0].columns();
     assert_eq!(
         columns[0]
             .column_type()


### PR DESCRIPTION
Reorganize result-set column metadata storage so that QueryExecutor and SnowflakeRow share the same metadata representation.

Previously, the `SnowflakeColumn` array was rebuilt on each call to `QueryExecutor::snowflake_columns()` and `SnowflakeRow::column_types()`.
However, the lifecycle of that `SnowflakeColumn` array is the same as the lifecycle of `QueryExecutor`, so it should be constructed only once when the executor is created.

Accordingly, this change stores the metadata on `QueryExecutor` as `columns: Arc<[SnowflakeColumn]>` and makes `SnowflakeRow` share the same metadata slice.

This PR also unifies the API naming to `columns()`.

- `SnowflakeRow::column_types()` is deprecated.
- `QueryExecutor::snowflake_columns()` is simply renamed because it has not been released yet.