### PR TITLE
fix: disable idle connection pooling to prevent S3 stale connection errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -267,15 +267,15 @@ impl SnowflakeTransportConfig {
     pub(crate) fn build_http_client(&self) -> Result<reqwest::Client> {
         // Disable idle connection pooling to prevent stale-connection errors.
         //
-        // Snowflake uploads query result chunks to S3, and this client
-        // fetches them via presigned URLs. S3 closes idle keep-alive
-        // connections aggressively (the exact timeout is undocumented, but
-        // reported to be only a few seconds). When the pool hands out a
-        // connection that S3 has already closed, hyper returns
-        // `Error(IncompleteMessage)`.
+        // This client talks to both the Snowflake REST API and S3 (for
+        // downloading query-result chunks via presigned URLs). S3 closes
+        // idle keep-alive connections aggressively (the exact timeout is
+        // undocumented, but reported to be only a few seconds). When the
+        // pool hands out a connection that S3 has already closed, hyper
+        // returns `Error(IncompleteMessage)`.
         //
         // Disabling pooling is acceptable here because the bottleneck is
-        // downloading chunk data from Snowflake / S3, not establishing TCP
+        // data transfer with Snowflake / S3, not establishing TCP
         // connections.
         let builder = reqwest::ClientBuilder::new()
             .gzip(true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,7 +265,15 @@ impl SnowflakeTransportConfig {
     }
 
     pub(crate) fn build_http_client(&self) -> Result<reqwest::Client> {
-        let builder = reqwest::ClientBuilder::new().gzip(true).use_rustls_tls();
+        // Snowflake uploads query result chunks to S3, and this client fetches
+        // them via presigned URLs. S3 closes idle keep-alive connections after
+        // ~20 seconds, so we set the pool idle timeout below that threshold to
+        // avoid reusing a connection that the server has already closed
+        // (which would cause hyper::Error(IncompleteMessage)).
+        let builder = reqwest::ClientBuilder::new()
+            .gzip(true)
+            .use_rustls_tls()
+            .pool_idle_timeout(Duration::from_secs(15));
 
         let builder = if let Some(proxy) = &self.proxy {
             builder.proxy(proxy.to_reqwest_proxy()?)

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,15 +265,22 @@ impl SnowflakeTransportConfig {
     }
 
     pub(crate) fn build_http_client(&self) -> Result<reqwest::Client> {
-        // Snowflake uploads query result chunks to S3, and this client fetches
-        // them via presigned URLs. S3 closes idle keep-alive connections after
-        // ~20 seconds, so we set the pool idle timeout below that threshold to
-        // avoid reusing a connection that the server has already closed
-        // (which would cause hyper::Error(IncompleteMessage)).
+        // Disable idle connection pooling to prevent stale-connection errors.
+        //
+        // Snowflake uploads query result chunks to S3, and this client
+        // fetches them via presigned URLs. S3 closes idle keep-alive
+        // connections aggressively (the exact timeout is undocumented, but
+        // reported to be only a few seconds). When the pool hands out a
+        // connection that S3 has already closed, hyper returns
+        // `Error(IncompleteMessage)`.
+        //
+        // Disabling pooling is acceptable here because the bottleneck is
+        // downloading chunk data from Snowflake / S3, not establishing TCP
+        // connections.
         let builder = reqwest::ClientBuilder::new()
             .gzip(true)
             .use_rustls_tls()
-            .pool_idle_timeout(Duration::from_secs(15));
+            .pool_max_idle_per_host(0);
 
         let builder = if let Some(proxy) = &self.proxy {
             builder.proxy(proxy.to_reqwest_proxy()?)

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,6 +265,8 @@ impl SnowflakeTransportConfig {
     }
 
     pub(crate) fn build_http_client(&self) -> Result<reqwest::Client> {
+        let builder = reqwest::ClientBuilder::new().gzip(true).use_rustls_tls();
+
         // Disable idle connection pooling to prevent stale-connection errors.
         //
         // This client talks to both the Snowflake REST API and S3 (for
@@ -277,10 +279,7 @@ impl SnowflakeTransportConfig {
         // Disabling pooling is acceptable here because the bottleneck is
         // data transfer with Snowflake / S3, not establishing TCP
         // connections.
-        let builder = reqwest::ClientBuilder::new()
-            .gzip(true)
-            .use_rustls_tls()
-            .pool_max_idle_per_host(0);
+        let builder = builder.pool_max_idle_per_host(0);
 
         let builder = if let Some(proxy) = &self.proxy {
             builder.proxy(proxy.to_reqwest_proxy()?)


### PR DESCRIPTION
## Summary
- Snowflake uploads query result chunks to S3, and this client fetches them via presigned URLs
- S3 closes idle keep-alive connections aggressively (the exact timeout is undocumented, but [reported to be only a few seconds](https://repost.aws/questions/QU9abzqZn6R7K3KNqJ7EiKww/s3-idle-connection-timeout)). When the connection pool hands out a connection that S3 has already closed, hyper returns `Error(IncompleteMessage)`
- Disable pooling entirely via `pool_max_idle_per_host(0)` — the bottleneck is downloading chunk data from Snowflake / S3, not establishing TCP connections, so pooling provides negligible benefit here

## References
- [S3 idle connection timeout (AWS re:Post)](https://repost.aws/questions/QU9abzqZn6R7K3KNqJ7EiKww/s3-idle-connection-timeout)
- [delta-rs pool_idle_timeout comment](https://github.com/delta-io/delta-rs/blob/785667e5d65e3b45cf27e0a74cf297479f42d307/crates/aws/src/storage.rs#L401-L406)

## Test plan
- [x] `cargo check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)