### PR TITLE
fix(external-browser): add Connection: close to prevent keep-alive from stealing callbacks

### DIFF
--- a/src/external_browser_listener.rs
+++ b/src/external_browser_listener.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
 use hyper::header::{
-    ACCESS_CONTROL_REQUEST_HEADERS, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, ORIGIN, VARY,
+    ACCESS_CONTROL_REQUEST_HEADERS, CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, ORIGIN,
+    VARY,
 };
 use hyper::http::StatusCode;
 use hyper::server::conn::http1;
@@ -283,7 +284,8 @@ Your identity was confirmed and propagated to Snowflake.
     let mut builder = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, content_type)
-        .header(CONTENT_LENGTH, body.len().to_string());
+        .header(CONTENT_LENGTH, body.len().to_string())
+        .header(CONNECTION, "close");
 
     if let Some(origin) = stored_origin {
         builder = builder
@@ -707,5 +709,83 @@ mod tests {
 
         let _ = running.shutdown.send(());
         let _ = running.handle.await;
+    }
+
+    /// Reproduce: spawn listener on a fixed port, send a callback (which
+    /// creates a hyper keep-alive HTTP connection), shut down the listener,
+    /// then spawn again on the same port.  The second bind must succeed.
+    #[tokio::test]
+    async fn rebind_fixed_port_after_http_callback() {
+        let fixed_port = 19991;
+        let cfg = || ListenerConfig {
+            port: fixed_port,
+            application: Some("rebind-test".to_string()),
+            ..Default::default()
+        };
+
+        // ── 1st listener ──
+        let r1 = spawn_listener(cfg())
+            .await
+            .expect("first spawn_listener failed");
+        let base1 = format!("http://{}", r1.addr);
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{base1}/callback"))
+            .json(&serde_json::json!({"token": "tok1"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), ReqwestStatusCode::OK);
+
+        let _ = r1.shutdown.send(());
+        let _ = r1.handle.await;
+
+        // ── 2nd listener on the same port ──
+        let r2 = spawn_listener(cfg())
+            .await
+            .expect("second spawn_listener failed (EADDRINUSE?)");
+        let base2 = format!("http://{}", r2.addr);
+
+        let resp = client
+            .post(format!("{base2}/callback"))
+            .json(&serde_json::json!({"token": "tok2"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), ReqwestStatusCode::OK);
+
+        let _ = r2.shutdown.send(());
+        let _ = r2.handle.await;
+    }
+
+    /// Stress test: rapidly cycle spawn → callback → shutdown on the same
+    /// fixed port, leaving hyper keep-alive connections in flight.
+    #[tokio::test]
+    async fn rebind_fixed_port_rapid_cycles() {
+        let fixed_port = 19992;
+        let client = reqwest::Client::new();
+
+        for i in 0..5 {
+            let r = spawn_listener(ListenerConfig {
+                port: fixed_port,
+                application: Some("rapid-cycle".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap_or_else(|e| panic!("cycle {i}: spawn_listener failed: {e}"));
+
+            let base = format!("http://{}", r.addr);
+            let resp = client
+                .post(format!("{base}/callback"))
+                .json(&serde_json::json!({"token": format!("tok{i}")}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), ReqwestStatusCode::OK);
+
+            let _ = r.shutdown.send(());
+            let _ = r.handle.await;
+        }
     }
 }


### PR DESCRIPTION
## Problem

When using external browser SSO with a **fixed callback port**, the second authentication flow (e.g. `create_session()` called twice in a pipeline) would time out waiting for the browser callback — even though the listener successfully bound to the port.

## Root Cause

The callback HTTP server uses hyper's HTTP/1.1 which enables **keep-alive by default**. After the first auth flow completes:

1. `shutdown_listener()` drops the `TcpListener`, but the **fire-and-forget handler task** (`tokio::spawn` in `run_loop`) continues running, holding the accepted `TcpStream` open via keep-alive.
2. When the second auth flow spawns a new listener on the same port, the browser completes SSO and redirects back to `localhost:<port>`.
3. The browser **reuses the keep-alive TCP connection** from the first auth instead of opening a new one.
4. The request is handled by the **stale handler task**, which sends the token to the **old `watch` channel** — the new listener's channel never receives it.
5. The second auth times out after 60 seconds.

## Fix

Add `Connection: close` header to the callback response (`ok_callback_response`). This tells the browser to close the TCP connection after receiving the response, forcing subsequent redirects to establish a fresh connection that reaches the new listener.

## Reproduction

Confirmed with a real Snowflake environment using a fixed port:

**Before fix:**
```
=== 1st create_session ===
1st session OK: SELECT 1 = 1
=== 2nd create_session ===
Callback was not received in time. Falling back to manual URL input.
```

**After fix:**
```
=== 1st create_session ===
1st session OK: SELECT 1 = 1
=== 2nd create_session ===
2nd session OK: SELECT 2 = 2
Both sessions succeeded!
```

## Test plan

- [x] Existing listener unit tests pass (17/17)
- [x] Added `rebind_fixed_port_after_http_callback` — spawns listener on a fixed port, sends a callback, shuts down, respawns on the same port, verifies second callback succeeds
- [x] Added `rebind_fixed_port_rapid_cycles` — 5 rapid spawn/callback/shutdown cycles on the same fixed port
- [x] Verified with real Snowflake external browser auth (fixed port 8765, two consecutive `create_session` calls)
- [ ] CI: fmt, clippy, tests on ubuntu/macos/windows × Rust 1.88/stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)