### PR TITLE
refactor(external-browser): separate concerns across auth flow, liste…

### DIFF
--- a/src/auth/external_browser.rs
+++ b/src/auth/external_browser.rs
@@ -1,18 +1,15 @@
-use std::io::{self, Write};
 use std::time::Duration;
 
-use reqwest::Client;
-use reqwest::Url;
+use reqwest::{Client, Url};
 use serde::Deserialize;
 use serde_json::json;
-use tokio::time;
 
 use crate::auth::client::AUTH_REQUEST_TIMEOUT;
 use crate::external_browser_launcher::{BrowserLauncher, LaunchOutcome, SystemCommandRunner};
 use crate::external_browser_listener::{
-    CallbackPayload, ListenerConfig, RunningListener, spawn_listener,
+    CallbackWaitError, ListenerConfig, RunningListener, spawn_listener,
 };
-use crate::external_browser_payload::parse_token_and_consent_from_pairs;
+use crate::external_browser_payload::BrowserCallbackPayload;
 use crate::{
     BrowserLaunchMode, Error, ExternalBrowserConfig, Result, WithCallbackListenerConfig,
     WithoutCallbackListenerConfig,
@@ -20,15 +17,22 @@ use crate::{
 
 #[cfg(unix)]
 mod manual_input_unix;
+mod manual_redirect_input;
 
 const EXTERNAL_BROWSER_CALLBACK_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
 
-pub struct ExternalBrowserResult {
-    pub token: String,
-    pub proof_key: Option<String>,
+pub(crate) struct ExternalBrowserResult {
+    pub(crate) token: String,
+    pub(crate) proof_key: Option<String>,
 }
 
-pub async fn run_external_browser_flow(
+impl ExternalBrowserResult {
+    pub(crate) fn new(token: String, proof_key: Option<String>) -> Self {
+        Self { token, proof_key }
+    }
+}
+
+pub(in crate::auth) async fn run_external_browser_flow(
     http: &Client,
     username: &str,
     account: &str,
@@ -66,37 +70,37 @@ async fn run_external_browser_flow_with_listener(
     base_url: &Url,
     config_with_listener: &WithCallbackListenerConfig,
 ) -> Result<ExternalBrowserResult> {
-    let listener_config = ListenerConfig {
-        application: Some(super::client::client_app_id().to_string()),
-        host: config_with_listener.callback_socket_addr(),
-        port: config_with_listener.callback_socket_port(),
-        protocol: "http".to_string(),
-    };
+    let listener_config = ListenerConfig::new(
+        Some(super::client::client_app_id().to_string()),
+        config_with_listener.callback_socket_addr(),
+        config_with_listener.callback_socket_port(),
+        "http".to_string(),
+    );
     let listener = spawn_listener(listener_config)
         .await
         .map_err(|e| Error::Communication(e.to_string()))?;
-    let redirect_port = listener.addr.port();
+    let redirect_port = listener.redirect_port();
 
-    let auth = match request_authenticator(http, username, account, base_url, redirect_port).await {
-        Ok(data) => data,
-        Err(err) => {
-            shutdown_listener(listener).await;
-            return Err(err);
-        }
-    };
+    let auth =
+        match request_external_browser_challenge(http, username, account, base_url, redirect_port)
+            .await
+        {
+            Ok(data) => data,
+            Err(err) => {
+                listener.shutdown().await;
+                return Err(err);
+            }
+        };
 
     let launch_mode = config_with_listener.browser_launch_mode();
     if let Err(err) = open_auth_page(&auth.sso_url, launch_mode) {
-        shutdown_listener(listener).await;
+        listener.shutdown().await;
         return Err(err);
     }
 
     let payload =
         resolve_payload_with_listener(listener, EXTERNAL_BROWSER_CALLBACK_WAIT_TIMEOUT).await?;
-    Ok(ExternalBrowserResult {
-        token: payload.token,
-        proof_key: auth.proof_key,
-    })
+    Ok(ExternalBrowserResult::new(payload.token, auth.proof_key))
 }
 
 async fn run_external_browser_flow_without_listener(
@@ -107,30 +111,31 @@ async fn run_external_browser_flow_without_listener(
     config_without_listener: &WithoutCallbackListenerConfig,
 ) -> Result<ExternalBrowserResult> {
     let redirect_port = config_without_listener.redirect_port().get();
-    let auth = request_authenticator(http, username, account, base_url, redirect_port).await?;
+    let auth = request_external_browser_challenge(http, username, account, base_url, redirect_port)
+        .await?;
     let launch_mode = config_without_listener.browser_launch_mode();
     open_auth_page(&auth.sso_url, launch_mode)?;
 
     eprintln!(
         "The browser may display a connection error page for localhost:{redirect_port}; this is expected in this mode."
     );
-    let payload = manual_token_flow().await?;
+    let payload = manual_redirect_input::manual_token_flow().await?;
     Ok(ExternalBrowserResult {
         token: payload.token,
         proof_key: auth.proof_key,
     })
 }
 
-async fn request_authenticator(
+async fn request_external_browser_challenge(
     http: &Client,
     username: &str,
     account: &str,
     base_url: &Url,
     redirect_port: u16,
-) -> Result<AuthenticatorData> {
+) -> Result<ExternalBrowserChallenge> {
     let url = base_url.join("session/authenticator-request")?;
 
-    let body = authenticator_request_body(username, account, redirect_port);
+    let body = challenge_request_body(username, account, redirect_port);
 
     let resp = http
         .post(url)
@@ -144,7 +149,7 @@ async fn request_authenticator(
         return Err(Error::Communication(format!("HTTP {status}: {text}")));
     }
 
-    let parsed: AuthenticatorResponse =
+    let parsed: ExternalBrowserChallengeResponse =
         serde_json::from_str(&text).map_err(|e| Error::Json(e, text.clone()))?;
     if !parsed.success {
         return Err(Error::Communication(parsed.message.unwrap_or_default()));
@@ -152,12 +157,12 @@ async fn request_authenticator(
 
     let data = parsed
         .data
-        .ok_or_else(|| Error::Communication("missing authenticator-response data".to_string()))?;
+        .ok_or_else(|| Error::Communication("missing challenge response data".to_string()))?;
     Ok(data)
 }
 
 #[derive(Debug, Deserialize)]
-struct AuthenticatorData {
+struct ExternalBrowserChallenge {
     #[serde(rename = "ssoUrl")]
     sso_url: String,
     #[serde(rename = "proofKey")]
@@ -165,17 +170,13 @@ struct AuthenticatorData {
 }
 
 #[derive(Debug, Deserialize)]
-struct AuthenticatorResponse {
-    data: Option<AuthenticatorData>,
+struct ExternalBrowserChallengeResponse {
+    data: Option<ExternalBrowserChallenge>,
     message: Option<String>,
     success: bool,
 }
 
-fn authenticator_request_body(
-    username: &str,
-    account: &str,
-    redirect_port: u16,
-) -> serde_json::Value {
+fn challenge_request_body(username: &str, account: &str, redirect_port: u16) -> serde_json::Value {
     json!({
         "data": {
             "ACCOUNT_NAME": account,
@@ -212,185 +213,24 @@ fn open_auth_page(sso_url: &str, mode: BrowserLaunchMode) -> Result<()> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CallbackWaitError {
-    TimedOut,
-    ListenerStopped,
-}
-
 async fn resolve_payload_with_listener(
-    listener: RunningListener,
+    mut listener: RunningListener,
     timeout: Duration,
-) -> Result<CallbackPayload> {
-    let callback_result = wait_for_token(listener.payloads.clone(), timeout).await;
-    shutdown_listener(listener).await;
+) -> Result<BrowserCallbackPayload> {
+    let callback_result = listener.wait_for_payload(timeout).await;
+    listener.shutdown().await;
 
     match callback_result {
         Ok(payload) => Ok(payload),
         Err(CallbackWaitError::TimedOut) => {
             eprintln!("Callback was not received in time. Falling back to manual URL input.");
-            manual_token_flow().await
+            manual_redirect_input::manual_token_flow().await
         }
         Err(CallbackWaitError::ListenerStopped) => {
             eprintln!(
                 "Local callback listener stopped before receiving token. Continue with manual URL input."
             );
-            manual_token_flow().await
+            manual_redirect_input::manual_token_flow().await
         }
-    }
-}
-
-async fn wait_for_token(
-    rx: tokio::sync::watch::Receiver<Option<CallbackPayload>>,
-    timeout: Duration,
-) -> std::result::Result<CallbackPayload, CallbackWaitError> {
-    match time::timeout(timeout, wait_for_token_inner(rx)).await {
-        Ok(res) => res,
-        Err(_) => Err(CallbackWaitError::TimedOut),
-    }
-}
-
-async fn wait_for_token_inner(
-    rx: tokio::sync::watch::Receiver<Option<CallbackPayload>>,
-) -> std::result::Result<CallbackPayload, CallbackWaitError> {
-    let mut rx = rx.clone();
-    if let Some(payload) = rx.borrow().clone() {
-        return Ok(payload);
-    }
-
-    loop {
-        if rx.changed().await.is_err() {
-            return Err(CallbackWaitError::ListenerStopped);
-        }
-        if let Some(payload) = rx.borrow().clone() {
-            return Ok(payload);
-        }
-    }
-}
-
-async fn shutdown_listener(listener: RunningListener) {
-    let _ = listener.shutdown.send(());
-    let _ = listener.handle.await;
-}
-
-async fn manual_token_flow() -> Result<CallbackPayload> {
-    tokio::task::spawn_blocking(manual_token_flow_blocking)
-        .await
-        .map_err(|e| Error::Communication(format!("manual input task failed: {e}")))?
-}
-
-fn manual_token_flow_blocking() -> Result<CallbackPayload> {
-    eprintln!(
-        "After completing authentication, paste the URL you were redirected to (not logged)."
-    );
-
-    eprint!("Redirected URL: ");
-    let _ = io::stderr().flush();
-    let input = read_redirected_url_line()?;
-
-    eprintln!("Received redirected URL input. Continuing authentication...");
-
-    payload_from_redirect_input(input.trim())
-}
-
-fn read_redirected_url_line() -> Result<String> {
-    #[cfg(unix)]
-    if let Some(result) = manual_input_unix::try_read_redirected_url_line_noncanonical() {
-        return result;
-    }
-
-    // TODO(windows): investigate whether long redirected URLs can be truncated in
-    // canonical console input mode and add a Windows-specific raw/non-canonical fallback.
-
-    let mut input = String::new();
-    io::stdin()
-        .read_line(&mut input)
-        .map_err(|e| Error::Communication(format!("failed to read input: {e}")))?;
-
-    validate_redirected_url_input(input)
-}
-
-fn validate_redirected_url_input(input: String) -> Result<String> {
-    if input.trim().is_empty() {
-        return Err(Error::Communication(
-            "No redirected URL was provided".to_string(),
-        ));
-    }
-    Ok(input)
-}
-
-fn extract_payload_from_url(url: &str) -> Option<CallbackPayload> {
-    let parsed = Url::parse(url).ok()?;
-    let query = parse_token_and_consent_from_pairs(parsed.query_pairs());
-    let fragment = parsed
-        .fragment()
-        .map(|frag| {
-            parse_token_and_consent_from_pairs(url::form_urlencoded::parse(frag.as_bytes()))
-        })
-        .unwrap_or_default();
-
-    let token = query.token.or(fragment.token)?;
-    let consent = query.consent.or(fragment.consent);
-
-    Some(CallbackPayload { token, consent })
-}
-
-fn payload_from_redirect_input(input: &str) -> Result<CallbackPayload> {
-    extract_payload_from_url(input).ok_or_else(|| {
-        Error::Communication(
-            "Unable to extract token from redirected URL (expected query or fragment token=...)"
-                .to_string(),
-        )
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::payload_from_redirect_input;
-
-    #[test]
-    fn payload_from_redirect_input_extracts_token() {
-        let url = "https://example.test/callback?token=abc123&other=1";
-        let payload = payload_from_redirect_input(url).unwrap();
-        assert_eq!(payload.token, "abc123");
-        assert_eq!(payload.consent, None);
-    }
-
-    #[test]
-    fn payload_from_redirect_input_extracts_consent() {
-        let url = "https://example.test/callback?token=abc123&consent=false";
-        let payload = payload_from_redirect_input(url).unwrap();
-        assert_eq!(payload.token, "abc123");
-        assert_eq!(payload.consent, Some(false));
-    }
-
-    #[test]
-    fn payload_from_redirect_input_extracts_token_from_fragment() {
-        let url = "https://example.test/callback#token=abc123&consent=true";
-        let payload = payload_from_redirect_input(url).unwrap();
-        assert_eq!(payload.token, "abc123");
-        assert_eq!(payload.consent, Some(true));
-    }
-
-    #[test]
-    fn payload_from_redirect_input_prefers_query_token_over_fragment_token() {
-        let url = "https://example.test/callback?token=query_token#token=fragment_token";
-        let payload = payload_from_redirect_input(url).unwrap();
-        assert_eq!(payload.token, "query_token");
-    }
-
-    #[test]
-    fn payload_from_redirect_input_keeps_query_token_and_query_consent() {
-        let url = "https://example.test/callback?token=query_token&consent=false#consent=true";
-        let payload = payload_from_redirect_input(url).unwrap();
-        assert_eq!(payload.token, "query_token");
-        assert_eq!(payload.consent, Some(false));
-    }
-
-    #[test]
-    fn payload_from_redirect_input_fails_without_token() {
-        let url = "https://example.test/callback?missing=true";
-        let err = payload_from_redirect_input(url).unwrap_err();
-        assert!(format!("{err}").contains("Unable to extract token"));
     }
 }

--- a/src/auth/external_browser/manual_input_unix.rs
+++ b/src/auth/external_browser/manual_input_unix.rs
@@ -3,7 +3,7 @@ use std::ops::ControlFlow;
 
 use nix::sys::termios::{self, LocalFlags, SetArg, SpecialCharacterIndices, Termios};
 
-use super::validate_redirected_url_input;
+use super::manual_redirect_input::validate_redirected_url_input;
 use crate::{Error, Result};
 
 pub(super) fn try_read_redirected_url_line_noncanonical() -> Option<Result<String>> {

--- a/src/auth/external_browser/manual_redirect_input.rs
+++ b/src/auth/external_browser/manual_redirect_input.rs
@@ -1,0 +1,131 @@
+use std::io::{self, Write};
+
+use reqwest::Url;
+
+use crate::external_browser_payload::{BrowserCallbackPayload, parse_token_and_consent_from_pairs};
+use crate::{Error, Result};
+
+#[cfg(unix)]
+use super::manual_input_unix;
+
+pub(super) async fn manual_token_flow() -> Result<BrowserCallbackPayload> {
+    tokio::task::spawn_blocking(manual_token_flow_blocking)
+        .await
+        .map_err(|e| Error::Communication(format!("manual input task failed: {e}")))?
+}
+
+fn manual_token_flow_blocking() -> Result<BrowserCallbackPayload> {
+    eprintln!(
+        "After completing authentication, paste the URL you were redirected to (not logged)."
+    );
+
+    eprint!("Redirected URL: ");
+    let _ = io::stderr().flush();
+    let input = read_redirected_url_line()?;
+
+    eprintln!("Received redirected URL input. Continuing authentication...");
+
+    payload_from_redirect_input(input.trim())
+}
+
+fn read_redirected_url_line() -> Result<String> {
+    #[cfg(unix)]
+    if let Some(result) = manual_input_unix::try_read_redirected_url_line_noncanonical() {
+        return result;
+    }
+
+    // TODO(windows): investigate whether long redirected URLs can be truncated in
+    // canonical console input mode and add a Windows-specific raw/non-canonical fallback.
+
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .map_err(|e| Error::Communication(format!("failed to read input: {e}")))?;
+
+    validate_redirected_url_input(input)
+}
+
+pub(super) fn validate_redirected_url_input(input: String) -> Result<String> {
+    if input.trim().is_empty() {
+        return Err(Error::Communication(
+            "No redirected URL was provided".to_string(),
+        ));
+    }
+    Ok(input)
+}
+
+fn extract_payload_from_url(url: &str) -> Option<BrowserCallbackPayload> {
+    let parsed = Url::parse(url).ok()?;
+    let query = parse_token_and_consent_from_pairs(parsed.query_pairs());
+    let fragment = parsed
+        .fragment()
+        .map(|frag| {
+            parse_token_and_consent_from_pairs(url::form_urlencoded::parse(frag.as_bytes()))
+        })
+        .unwrap_or_default();
+
+    let token = query.token.or(fragment.token)?;
+    let consent = query.consent.or(fragment.consent);
+
+    Some(BrowserCallbackPayload { token, consent })
+}
+
+fn payload_from_redirect_input(input: &str) -> Result<BrowserCallbackPayload> {
+    extract_payload_from_url(input).ok_or_else(|| {
+        Error::Communication(
+            "Unable to extract token from redirected URL (expected query or fragment token=...)"
+                .to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::payload_from_redirect_input;
+
+    #[test]
+    fn payload_from_redirect_input_extracts_token() {
+        let url = "https://example.test/callback?token=abc123&other=1";
+        let payload = payload_from_redirect_input(url).unwrap();
+        assert_eq!(payload.token, "abc123");
+        assert_eq!(payload.consent, None);
+    }
+
+    #[test]
+    fn payload_from_redirect_input_extracts_consent() {
+        let url = "https://example.test/callback?token=abc123&consent=false";
+        let payload = payload_from_redirect_input(url).unwrap();
+        assert_eq!(payload.token, "abc123");
+        assert_eq!(payload.consent, Some(false));
+    }
+
+    #[test]
+    fn payload_from_redirect_input_extracts_token_from_fragment() {
+        let url = "https://example.test/callback#token=abc123&consent=true";
+        let payload = payload_from_redirect_input(url).unwrap();
+        assert_eq!(payload.token, "abc123");
+        assert_eq!(payload.consent, Some(true));
+    }
+
+    #[test]
+    fn payload_from_redirect_input_prefers_query_token_over_fragment_token() {
+        let url = "https://example.test/callback?token=query_token#token=fragment_token";
+        let payload = payload_from_redirect_input(url).unwrap();
+        assert_eq!(payload.token, "query_token");
+    }
+
+    #[test]
+    fn payload_from_redirect_input_keeps_query_token_and_query_consent() {
+        let url = "https://example.test/callback?token=query_token&consent=false#consent=true";
+        let payload = payload_from_redirect_input(url).unwrap();
+        assert_eq!(payload.token, "query_token");
+        assert_eq!(payload.consent, Some(false));
+    }
+
+    #[test]
+    fn payload_from_redirect_input_fails_without_token() {
+        let url = "https://example.test/callback?missing=true";
+        let err = payload_from_redirect_input(url).unwrap_err();
+        assert!(format!("{err}").contains("Unable to extract token"));
+    }
+}

--- a/src/external_browser_listener.rs
+++ b/src/external_browser_listener.rs
@@ -1,52 +1,31 @@
-use std::convert::Infallible;
-use std::error::Error;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::Arc;
+mod handler;
+mod runtime;
 
-use http_body_util::{BodyExt, Full};
-use hyper::body::{Bytes, Incoming};
-use hyper::header::{
-    ACCESS_CONTROL_REQUEST_HEADERS, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, ORIGIN, VARY,
+use std::{
+    error::Error,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    time::Duration,
 };
-use hyper::http::StatusCode;
-use hyper::server::conn::http1;
-use hyper::service::service_fn;
-use hyper::{Method, Request, Response};
-use hyper_util::rt::TokioIo;
-use serde::Deserialize;
-use socket2::{Domain, Protocol, Socket, Type};
+
 use tokio::{
-    net::TcpListener,
-    sync::Mutex,
     sync::{oneshot, watch},
-    task::{JoinError, JoinHandle, JoinSet},
+    task::JoinHandle,
 };
 
-use crate::external_browser_payload::{ParsedTokenAndConsent, parse_token_and_consent_from_pairs};
+use crate::external_browser_payload::BrowserCallbackPayload;
+
+use runtime::{ListenerRuntime, bind_listener, build_origin};
 
 type ListenerError = Box<dyn Error + Send + Sync>;
-type ConnectionTaskResult = Result<(), ListenerError>;
 
-#[derive(Debug, Deserialize)]
-struct TokenPayload {
-    token: Option<String>,
-    consent: Option<bool>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CallbackPayload {
-    pub token: String,
-    pub consent: Option<bool>,
-}
-
-pub struct ListenerConfig {
+pub(crate) struct ListenerConfig {
     /// Application name used in the human-facing HTML response.
     ///
     /// This corresponds to Python connector's `AuthByWebBrowser._application`.
-    pub application: Option<String>,
-    pub host: IpAddr,
-    pub port: u16,
-    pub protocol: String,
+    application: Option<String>,
+    host: IpAddr,
+    port: u16,
+    protocol: String,
 }
 
 impl Default for ListenerConfig {
@@ -60,222 +39,102 @@ impl Default for ListenerConfig {
     }
 }
 
-pub struct RunningListener {
-    pub addr: SocketAddr,
-    pub shutdown: oneshot::Sender<()>,
-    pub handle: JoinHandle<Result<(), ListenerError>>,
-    pub payloads: watch::Receiver<Option<CallbackPayload>>,
-}
-
-struct ListenerShared {
-    expected_origin: String,
-    application: Option<String>,
-    payload_tx: watch::Sender<Option<CallbackPayload>>,
-    validated_origin: Mutex<Option<String>>,
-}
-
-impl ListenerShared {
-    fn new(
-        expected_origin: String,
+impl ListenerConfig {
+    pub(crate) fn new(
         application: Option<String>,
-        payload_tx: watch::Sender<Option<CallbackPayload>>,
+        host: IpAddr,
+        port: u16,
+        protocol: String,
     ) -> Self {
         Self {
-            expected_origin,
             application,
-            payload_tx,
-            validated_origin: Mutex::new(None),
-        }
-    }
-
-    async fn handle(&self, req: Request<Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
-        let request_origin = header_to_string(req.headers().get(ORIGIN));
-
-        match *req.method() {
-            Method::OPTIONS => self.handle_preflight(request_origin, &req).await,
-            Method::GET => {
-                let payload = extract_payload_from_query(req.uri().query());
-                self.handle_callback(payload).await
-            }
-            Method::POST => {
-                let whole_body = req
-                    .into_body()
-                    .collect()
-                    .await
-                    .map(|c| c.to_bytes())
-                    .unwrap_or_default();
-                let payload = extract_payload_from_body(&whole_body);
-                self.handle_callback(payload).await
-            }
-            _ => Ok(Response::builder()
-                .status(StatusCode::METHOD_NOT_ALLOWED)
-                .body(Full::new(Bytes::from_static(b"method not allowed")))
-                .expect("building method not allowed response failed")),
-        }
-    }
-
-    async fn handle_preflight(
-        &self,
-        request_origin: Option<String>,
-        req: &Request<Incoming>,
-    ) -> Result<Response<Full<Bytes>>, Infallible> {
-        let expected_origin = self.expected_origin.clone();
-        let allowed_origin =
-            request_origin.filter(|origin| origin_allowed_value(origin, &expected_origin));
-        if allowed_origin.is_none() {
-            return Ok(forbidden());
-        }
-
-        self.set_validated_origin(allowed_origin.clone()).await;
-
-        let allow_headers =
-            requested_headers(req).unwrap_or_else(|| "Content-Type, Origin".to_string());
-        Ok(preflight_cors_response(
-            Response::builder().status(StatusCode::OK),
-            allowed_origin
-                .as_deref()
-                .unwrap_or(expected_origin.as_str()),
-            &allow_headers,
-        )
-        .header(VARY, "Accept-Encoding, Origin")
-        .header(CONTENT_LENGTH, "0")
-        .body(Full::new(Bytes::new()))
-        .expect("building preflight response failed"))
-    }
-
-    async fn handle_callback(
-        &self,
-        payload: Option<CallbackPayload>,
-    ) -> Result<Response<Full<Bytes>>, Infallible> {
-        self.publish_payload(&payload);
-        let stored_origin = self.validated_origin().await;
-        Ok(ok_callback_response(
-            payload.as_ref(),
-            stored_origin.as_deref(),
-            self.application.as_deref(),
-        ))
-    }
-
-    fn publish_payload(&self, payload: &Option<CallbackPayload>) {
-        if let Some(payload) = payload {
-            let _ = self.payload_tx.send(Some(payload.clone()));
-        }
-    }
-
-    async fn set_validated_origin(&self, origin: Option<String>) {
-        let mut guard = self.validated_origin.lock().await;
-        *guard = origin;
-    }
-
-    async fn validated_origin(&self) -> Option<String> {
-        self.validated_origin.lock().await.clone()
-    }
-}
-
-struct ConnectionTasks {
-    shutdown_tx: watch::Sender<bool>,
-    shutdown_rx: watch::Receiver<bool>,
-    tasks: JoinSet<ConnectionTaskResult>,
-}
-
-impl ConnectionTasks {
-    fn new() -> Self {
-        let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        Self {
-            shutdown_tx,
-            shutdown_rx,
-            tasks: JoinSet::new(),
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.tasks.is_empty()
-    }
-
-    fn spawn(&mut self, stream: tokio::net::TcpStream, shared: Arc<ListenerShared>) {
-        let shutdown = self.shutdown_rx.clone();
-        self.tasks
-            .spawn(async move { run_connection(stream, shared, shutdown).await });
-    }
-
-    async fn join_next(&mut self) -> Option<Result<ConnectionTaskResult, JoinError>> {
-        self.tasks.join_next().await
-    }
-
-    async fn shutdown_and_drain(&mut self) {
-        let _ = self.shutdown_tx.send(true);
-        while !self.is_empty() {
-            log_connection_task_result(self.join_next().await);
+            host,
+            port,
+            protocol,
         }
     }
 }
 
-struct ListenerRuntime {
-    listener: TcpListener,
-    shared: Arc<ListenerShared>,
-    shutdown: oneshot::Receiver<()>,
-    connections: ConnectionTasks,
+pub(crate) struct RunningListener {
+    addr: SocketAddr,
+    shutdown: oneshot::Sender<()>,
+    handle: JoinHandle<Result<(), ListenerError>>,
+    payloads: watch::Receiver<Option<BrowserCallbackPayload>>,
 }
 
-impl ListenerRuntime {
-    fn new(
-        listener: TcpListener,
-        expected_origin: String,
-        application: Option<String>,
-        shutdown: oneshot::Receiver<()>,
-        payload_tx: watch::Sender<Option<CallbackPayload>>,
-    ) -> Self {
-        Self {
-            listener,
-            shared: Arc::new(ListenerShared::new(
-                expected_origin,
-                application,
-                payload_tx,
-            )),
-            shutdown,
-            connections: ConnectionTasks::new(),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CallbackWaitError {
+    TimedOut,
+    ListenerStopped,
+}
+
+impl RunningListener {
+    pub(crate) fn redirect_port(&self) -> u16 {
+        self.addr.port()
+    }
+
+    pub(crate) async fn wait_for_payload(
+        &mut self,
+        timeout: Duration,
+    ) -> std::result::Result<BrowserCallbackPayload, CallbackWaitError> {
+        match tokio::time::timeout(timeout, Self::wait_for_payload_inner(&mut self.payloads)).await
+        {
+            Ok(res) => res,
+            Err(_) => Err(CallbackWaitError::TimedOut),
         }
     }
 
-    async fn run(mut self) -> Result<(), ListenerError> {
+    async fn wait_for_payload_inner(
+        rx: &mut watch::Receiver<Option<BrowserCallbackPayload>>,
+    ) -> std::result::Result<BrowserCallbackPayload, CallbackWaitError> {
+        if let Some(payload) = rx.borrow().clone() {
+            return Ok(payload);
+        }
+
         loop {
-            tokio::select! {
-                join_result = self.connections.join_next(), if !self.connections.is_empty() => {
-                    log_connection_task_result(join_result);
-                }
-                res = self.listener.accept() => {
-                    let (stream, _peer) = match res {
-                        Ok(v) => v,
-                        Err(e) => {
-                            eprintln!("accept error: {e}");
-                            continue;
-                        }
-                    };
-                    self.connections.spawn(stream, self.shared.clone());
-                }
-                _ = &mut self.shutdown => {
-                    break;
-                }
+            if rx.changed().await.is_err() {
+                return Err(CallbackWaitError::ListenerStopped);
+            }
+            if let Some(payload) = rx.borrow().clone() {
+                return Ok(payload);
             }
         }
+    }
 
-        drop(self.listener);
-        self.connections.shutdown_and_drain().await;
-        Ok(())
+    pub(crate) async fn shutdown(self) {
+        let _ = self.shutdown.send(());
+        let _ = self.handle.await;
+    }
+
+    #[cfg(test)]
+    fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::type_complexity)]
+    fn into_parts(
+        self,
+    ) -> (
+        SocketAddr,
+        oneshot::Sender<()>,
+        JoinHandle<Result<(), ListenerError>>,
+        watch::Receiver<Option<BrowserCallbackPayload>>,
+    ) {
+        (self.addr, self.shutdown, self.handle, self.payloads)
     }
 }
 
-pub async fn spawn_listener(cfg: ListenerConfig) -> Result<RunningListener, ListenerError> {
+pub(crate) async fn spawn_listener(cfg: ListenerConfig) -> Result<RunningListener, ListenerError> {
     let (listener, local_addr) = bind_listener(&cfg)?;
     let expected_origin = build_origin(&cfg.protocol, cfg.host, local_addr.port());
-    let application = cfg.application.clone();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (payload_tx, payload_rx) = watch::channel(None);
     let handle = tokio::spawn(
         ListenerRuntime::new(
             listener,
             expected_origin,
-            application,
+            cfg.application,
             shutdown_rx,
             payload_tx,
         )
@@ -290,200 +149,18 @@ pub async fn spawn_listener(cfg: ListenerConfig) -> Result<RunningListener, List
     })
 }
 
-async fn run_connection(
-    stream: tokio::net::TcpStream,
-    shared: Arc<ListenerShared>,
-    mut shutdown: watch::Receiver<bool>,
-) -> ConnectionTaskResult {
-    let io = TokioIo::new(stream);
-    let svc = service_fn(move |req| {
-        let shared = shared.clone();
-        async move { shared.handle(req).await }
-    });
-    let conn = http1::Builder::new().serve_connection(io, svc);
-    tokio::pin!(conn);
-
-    tokio::select! {
-        res = conn.as_mut() => {
-            res.map_err(|err| Box::new(err) as ListenerError)
-        }
-        _ = shutdown.changed() => {
-            conn.as_mut().graceful_shutdown();
-            conn.await.map_err(|err| Box::new(err) as ListenerError)
-        }
-    }
-}
-
-fn log_connection_task_result(join_result: Option<Result<ConnectionTaskResult, JoinError>>) {
-    match join_result {
-        Some(Ok(Ok(()))) => {}
-        Some(Ok(Err(err))) => eprintln!("serve error: {err}"),
-        Some(Err(err)) => eprintln!("connection task join error: {err}"),
-        None => {}
-    }
-}
-
-fn extract_payload_from_body(body: &Bytes) -> Option<CallbackPayload> {
-    // 1) JSON: {"token": "...", "consent": true}
-    serde_json::from_slice::<TokenPayload>(body)
-        .ok()
-        .and_then(|parsed| {
-            parsed.token.map(|token| CallbackPayload {
-                token,
-                consent: parsed.consent,
-            })
-        })
-        // 2) x-www-form-urlencoded / key=value fallback
-        .or_else(|| {
-            std::str::from_utf8(body)
-                .ok()
-                .map(|body_str| {
-                    parse_token_and_consent_from_pairs(url::form_urlencoded::parse(
-                        body_str.as_bytes(),
-                    ))
-                })
-                .and_then(parsed_to_payload)
-        })
-}
-
-fn preflight_cors_response(
-    mut builder: hyper::http::response::Builder,
-    allowed_origin: &str,
-    allow_headers: &str,
-) -> hyper::http::response::Builder {
-    builder = builder
-        .header("Access-Control-Allow-Origin", allowed_origin)
-        .header("Access-Control-Allow-Methods", "POST, GET")
-        .header("Access-Control-Allow-Headers", allow_headers)
-        .header("Access-Control-Max-Age", "86400");
-    builder
-}
-
-fn ok_callback_response(
-    payload: Option<&CallbackPayload>,
-    stored_origin: Option<&str>,
-    application: Option<&str>,
-) -> Response<Full<Bytes>> {
-    if payload.is_none() {
-        return Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, "text/plain")
-            .header(CONTENT_LENGTH, "17")
-            .body(Full::new(Bytes::from_static(b"no token provided")))
-            .expect("building no token provided response failed");
-    }
-
-    // - If a validated Origin exists (OPTIONS preflight succeeded), return JSON with consent only.
-    // - Otherwise, return a simple HTML page telling the user they can close the window.
-    let cors_mode = stored_origin.is_some();
-    let (content_type, body) = if cors_mode {
-        let consent = payload.and_then(|p| p.consent).unwrap_or(true);
-        let msg = serde_json::json!({"consent": consent}).to_string();
-        ("text/html", msg)
-    } else {
-        let app_line = application
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(|app| format!("Client application: {app}.\n"))
-            .unwrap_or_default();
-        let msg = format!(
-            r#"<!DOCTYPE html><html><head><meta charset=\"UTF-8\"/>
-<link rel=\"icon\" href=\"data:,\">
-<title>SAML Response for Snowflake</title></head>
-<body>
-Your identity was confirmed and propagated to Snowflake.
-{app_line}You can close this window now and go back where you started from.
-</body></html>"#
-        );
-        ("text/html", msg)
-    };
-
-    let mut builder = Response::builder()
-        .status(StatusCode::OK)
-        .header(CONTENT_TYPE, content_type)
-        .header(CONTENT_LENGTH, body.len().to_string());
-
-    if let Some(origin) = stored_origin {
-        builder = builder
-            .header("Access-Control-Allow-Origin", origin)
-            .header(VARY, "Accept-Encoding, Origin");
-    }
-
-    builder
-        .body(Full::new(Bytes::from(body)))
-        .expect("building OK callback response failed")
-}
-
-fn forbidden() -> Response<Full<Bytes>> {
-    Response::builder()
-        .status(StatusCode::FORBIDDEN)
-        .body(Full::new(Bytes::from_static(b"origin not allowed")))
-        .expect("building forbidden response failed")
-}
-
-fn extract_payload_from_query(query: Option<&str>) -> Option<CallbackPayload> {
-    query
-        .map(|q| parse_token_and_consent_from_pairs(url::form_urlencoded::parse(q.as_bytes())))
-        .and_then(parsed_to_payload)
-}
-
-fn parsed_to_payload(parsed: ParsedTokenAndConsent) -> Option<CallbackPayload> {
-    parsed.token.map(|token| CallbackPayload {
-        token,
-        consent: parsed.consent,
-    })
-}
-
-fn build_origin(protocol: &str, host: IpAddr, port: u16) -> String {
-    format!("{protocol}://{}", SocketAddr::new(host, port))
-}
-
-fn bind_listener(
-    cfg: &ListenerConfig,
-) -> Result<(TcpListener, SocketAddr), Box<dyn Error + Send + Sync>> {
-    let target_addr = SocketAddr::new(cfg.host, cfg.port);
-
-    let domain = match target_addr {
-        SocketAddr::V4(_) => Domain::IPV4,
-        SocketAddr::V6(_) => Domain::IPV6,
-    };
-
-    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
-    socket.set_nonblocking(true)?;
-    socket.set_reuse_address(true)?;
-    socket.bind(&target_addr.into())?;
-    socket.listen(128)?;
-
-    let listener = TcpListener::from_std(socket.into())?;
-    let local_addr = listener.local_addr()?;
-    Ok((listener, local_addr))
-}
-
-fn header_to_string(value: Option<&HeaderValue>) -> Option<String> {
-    value.and_then(|v| v.to_str().ok()).map(|s| s.to_string())
-}
-
-fn origin_allowed_value(origin: &str, expected: &str) -> bool {
-    origin.eq_ignore_ascii_case(expected)
-}
-
-fn requested_headers(req: &Request<Incoming>) -> Option<String> {
-    req.headers()
-        .get(ACCESS_CONTROL_REQUEST_HEADERS)
-        .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string())
-}
-
 #[cfg(test)]
 mod tests {
-    use std::io;
-    use std::net::TcpListener as StdTcpListener;
+    use std::{io, net::TcpListener as StdTcpListener};
 
     use reqwest::StatusCode as ReqwestStatusCode;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpStream;
-    use tokio::time::{Duration, sleep};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpStream,
+        time::{Duration, sleep},
+    };
 
+    use super::runtime::bind_listener;
     use super::*;
 
     async fn read_http_response(stream: &mut TcpStream) -> io::Result<String> {
@@ -550,101 +227,16 @@ mod tests {
         })
         .await
         .unwrap();
-        let base = format!("http://{}", running.addr);
+        let (addr, shutdown, handle, _) = running.into_parts();
+        let base = format!("http://{addr}");
 
         // give the server a moment to start accepting
         sleep(Duration::from_millis(50)).await;
 
         test(base).await;
 
-        let _ = running.shutdown.send(());
-        let _ = running.handle.await;
-    }
-
-    #[test]
-    fn extract_payload_from_body_json() {
-        let body = Bytes::from_static(br#"{"token":"t","consent":false}"#);
-        let payload = extract_payload_from_body(&body).unwrap();
-        assert_eq!(payload.token, "t");
-        assert_eq!(payload.consent, Some(false));
-    }
-
-    #[test]
-    fn extract_payload_from_body_form_urlencoded() {
-        let body = Bytes::from_static(b"token=t&consent=true");
-        let payload = extract_payload_from_body(&body).unwrap();
-        assert_eq!(payload.token, "t");
-        assert_eq!(payload.consent, Some(true));
-    }
-
-    #[test]
-    fn extract_payload_from_query_parses_consent() {
-        let payload = extract_payload_from_query(Some("token=t&consent=false")).unwrap();
-        assert_eq!(payload.token, "t");
-        assert_eq!(payload.consent, Some(false));
-    }
-
-    #[test]
-    fn extract_payload_from_query_prefers_first_token() {
-        let payload = extract_payload_from_query(Some("token=first&token=second")).unwrap();
-        assert_eq!(payload.token, "first");
-    }
-
-    #[tokio::test]
-    async fn ok_callback_response_cors_mode_returns_consent_only() {
-        let payload = CallbackPayload {
-            token: "secret".to_string(),
-            consent: Some(false),
-        };
-        let resp = ok_callback_response(Some(&payload), Some("http://localhost:1"), None);
-        assert_eq!(resp.status(), StatusCode::OK);
-        let headers = resp.headers().clone();
-
-        assert_eq!(
-            headers.get(CONTENT_TYPE).unwrap().to_str().unwrap(),
-            "text/html"
-        );
-        assert_eq!(
-            headers
-                .get("access-control-allow-origin")
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            "http://localhost:1"
-        );
-        assert_eq!(
-            headers.get(VARY).unwrap().to_str().unwrap(),
-            "Accept-Encoding, Origin"
-        );
-
-        let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let body_str = std::str::from_utf8(&body).unwrap();
-        assert!(body_str.contains("\"consent\":false"));
-        assert!(!body_str.contains("secret"));
-
-        let expected_len = body.len().to_string();
-        assert_eq!(
-            headers.get(CONTENT_LENGTH).unwrap().to_str().unwrap(),
-            expected_len
-        );
-    }
-
-    #[tokio::test]
-    async fn ok_callback_response_html_includes_app_line() {
-        let payload = CallbackPayload {
-            token: "t".to_string(),
-            consent: None,
-        };
-        let resp = ok_callback_response(Some(&payload), None, Some("myapp"));
-        assert_eq!(resp.status(), StatusCode::OK);
-        let headers = resp.headers().clone();
-        assert!(headers.get("access-control-allow-origin").is_none());
-        assert!(headers.get(VARY).is_none());
-        let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let body_str = std::str::from_utf8(&body).unwrap();
-        assert!(body_str.contains("You can close this window now"));
-        assert!(body_str.contains("Client application: myapp"));
-        assert!(!body_str.contains("token"));
+        let _ = shutdown.send(());
+        let _ = handle.await;
     }
 
     #[tokio::test]
@@ -690,7 +282,7 @@ mod tests {
                     .unwrap()
                     .to_str()
                     .unwrap(),
-                "text/html"
+                "application/json"
             );
             let body = resp.text().await.unwrap();
             assert!(body.contains("\"consent\""));
@@ -733,6 +325,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(resp.status(), ReqwestStatusCode::OK);
+
             let body = resp.text().await.unwrap();
             assert!(body.contains("You can close this window now"));
             assert!(body.contains("Client application: testapp"));
@@ -767,6 +360,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(resp.status(), ReqwestStatusCode::OK);
+
             let body = resp.text().await.unwrap();
             assert!(body.contains("You can close this window now"));
             assert!(body.contains("Client application: testapp"));
@@ -788,6 +382,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(resp.status(), ReqwestStatusCode::OK);
+
             let headers = resp.headers();
             assert_eq!(
                 headers.get("vary").unwrap().to_str().unwrap(),
@@ -816,8 +411,9 @@ mod tests {
     #[tokio::test]
     async fn post_json_propagates_consent_in_payload() {
         let running = spawn_listener(ListenerConfig::default()).await.unwrap();
-        let base = format!("http://{}", running.addr);
-        let mut rx = running.payloads.clone();
+        let (addr, shutdown, handle, payloads) = running.into_parts();
+        let base = format!("http://{addr}");
+        let mut rx = payloads;
 
         let client = reqwest::Client::new();
         let resp = client
@@ -833,15 +429,16 @@ mod tests {
         assert_eq!(payload.token, "example");
         assert_eq!(payload.consent, Some(false));
 
-        let _ = running.shutdown.send(());
-        let _ = running.handle.await;
+        let _ = shutdown.send(());
+        let _ = handle.await;
     }
 
     #[tokio::test]
     async fn form_encoded_payload_is_extracted() {
         let running = spawn_listener(ListenerConfig::default()).await.unwrap();
-        let base = format!("http://{}", running.addr);
-        let mut rx = running.payloads.clone();
+        let (addr, shutdown, handle, payloads) = running.into_parts();
+        let base = format!("http://{addr}");
+        let mut rx = payloads;
 
         let client = reqwest::Client::new();
         let resp = client
@@ -858,15 +455,16 @@ mod tests {
         assert_eq!(payload.token, "example");
         assert_eq!(payload.consent, Some(true));
 
-        let _ = running.shutdown.send(());
-        let _ = running.handle.await;
+        let _ = shutdown.send(());
+        let _ = handle.await;
     }
 
     #[tokio::test]
     async fn query_payload_is_extracted() {
         let running = spawn_listener(ListenerConfig::default()).await.unwrap();
-        let base = format!("http://{}", running.addr);
-        let mut rx = running.payloads.clone();
+        let (addr, shutdown, handle, payloads) = running.into_parts();
+        let base = format!("http://{addr}");
+        let mut rx = payloads;
 
         let client = reqwest::Client::new();
         let resp = client
@@ -881,15 +479,15 @@ mod tests {
         assert_eq!(payload.token, "example");
         assert_eq!(payload.consent, Some(false));
 
-        let _ = running.shutdown.send(());
-        let _ = running.handle.await;
+        let _ = shutdown.send(());
+        let _ = handle.await;
     }
 
     #[tokio::test]
     async fn dropping_running_listener_releases_bound_port() {
         let running = spawn_listener(ListenerConfig::default()).await.unwrap();
-        let port = running.addr.port();
-        let host = running.addr.ip();
+        let port = running.redirect_port();
+        let host = running.addr().ip();
 
         drop(running);
 
@@ -932,11 +530,11 @@ mod tests {
         .await
         .unwrap();
 
-        let mut stale_rx = running1.payloads.clone();
-        let mut stream = TcpStream::connect(running1.addr).await.unwrap();
+        let (addr1, shutdown1, handle1, payloads1) = running1.into_parts();
+        let mut stale_rx = payloads1;
+        let mut stream = TcpStream::connect(addr1).await.unwrap();
         let first_request = format!(
-            "GET /callback?token=first HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n\r\n",
-            running1.addr
+            "GET /callback?token=first HTTP/1.1\r\nHost: {addr1}\r\nConnection: keep-alive\r\n\r\n",
         );
         stream.write_all(first_request.as_bytes()).await.unwrap();
         let first_response = read_http_response(&mut stream).await.unwrap();
@@ -945,8 +543,8 @@ mod tests {
         let _ = stale_rx.changed().await;
         assert_eq!(stale_rx.borrow().as_ref().unwrap().token, "first");
 
-        let _ = running1.shutdown.send(());
-        let _ = running1.handle.await;
+        let _ = shutdown1.send(());
+        let _ = handle1.await;
 
         let mut closed_probe = [0_u8; 1];
         let close_result =
@@ -957,12 +555,12 @@ mod tests {
         assert_eq!(close_result, 0, "stale callback connection remained open");
 
         let running2 = spawn_listener(cfg).await.unwrap();
-        let mut next_rx = running2.payloads.clone();
+        let (addr2, shutdown2, handle2, payloads2) = running2.into_parts();
+        let mut next_rx = payloads2;
 
-        let mut second_stream = TcpStream::connect(running2.addr).await.unwrap();
+        let mut second_stream = TcpStream::connect(addr2).await.unwrap();
         let second_request = format!(
-            "GET /callback?token=second HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n\r\n",
-            running2.addr
+            "GET /callback?token=second HTTP/1.1\r\nHost: {addr2}\r\nConnection: keep-alive\r\n\r\n",
         );
         second_stream
             .write_all(second_request.as_bytes())
@@ -979,7 +577,7 @@ mod tests {
         );
         assert_eq!(next_rx.borrow().as_ref().unwrap().token, "second");
 
-        let _ = running2.shutdown.send(());
-        let _ = running2.handle.await;
+        let _ = shutdown2.send(());
+        let _ = handle2.await;
     }
 }

--- a/src/external_browser_listener/handler.rs
+++ b/src/external_browser_listener/handler.rs
@@ -1,0 +1,345 @@
+use std::convert::Infallible;
+
+use http_body_util::{BodyExt, Full};
+use hyper::{
+    body::{Bytes, Incoming},
+    header::{
+        ACCESS_CONTROL_REQUEST_HEADERS, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, ORIGIN, VARY,
+    },
+    http::StatusCode,
+    {Method, Request, Response},
+};
+use serde::Deserialize;
+use tokio::sync::{Mutex, watch};
+
+use crate::external_browser_payload::{
+    BrowserCallbackPayload, ParsedTokenAndConsent, parse_token_and_consent_from_pairs,
+};
+
+#[derive(Debug, Deserialize)]
+struct TokenPayload {
+    token: Option<String>,
+    consent: Option<bool>,
+}
+
+pub(super) struct CallbackHandler {
+    expected_origin: String,
+    application: Option<String>,
+    payload_tx: watch::Sender<Option<BrowserCallbackPayload>>,
+    validated_origin: Mutex<Option<String>>,
+}
+
+impl CallbackHandler {
+    pub(super) fn new(
+        expected_origin: String,
+        application: Option<String>,
+        payload_tx: watch::Sender<Option<BrowserCallbackPayload>>,
+    ) -> Self {
+        Self {
+            expected_origin,
+            application,
+            payload_tx,
+            validated_origin: Mutex::new(None),
+        }
+    }
+
+    pub(super) async fn handle(
+        &self,
+        req: Request<Incoming>,
+    ) -> Result<Response<Full<Bytes>>, Infallible> {
+        let request_origin = header_to_string(req.headers().get(ORIGIN));
+
+        match *req.method() {
+            Method::OPTIONS => self.handle_preflight(request_origin, &req).await,
+            Method::GET => {
+                let payload = extract_payload_from_query(req.uri().query());
+                self.handle_callback(payload).await
+            }
+            Method::POST => {
+                let whole_body = req
+                    .into_body()
+                    .collect()
+                    .await
+                    .map(|c| c.to_bytes())
+                    .unwrap_or_default();
+                let payload = extract_payload_from_body(&whole_body);
+                self.handle_callback(payload).await
+            }
+            _ => Ok(method_not_allowed_response()),
+        }
+    }
+
+    async fn handle_preflight(
+        &self,
+        request_origin: Option<String>,
+        req: &Request<Incoming>,
+    ) -> Result<Response<Full<Bytes>>, Infallible> {
+        let allowed_origin =
+            request_origin.filter(|origin| origin_allowed_value(origin, &self.expected_origin));
+        if allowed_origin.is_none() {
+            return Ok(forbidden_response());
+        }
+
+        let response_allowed_origin = allowed_origin
+            .as_deref()
+            .unwrap_or(self.expected_origin.as_str());
+        let allow_headers =
+            requested_headers(req).unwrap_or_else(|| "Content-Type, Origin".to_string());
+        let response = preflight_cors_response(response_allowed_origin, &allow_headers);
+
+        self.set_validated_origin(allowed_origin).await;
+
+        Ok(response)
+    }
+
+    async fn handle_callback(
+        &self,
+        payload: Option<BrowserCallbackPayload>,
+    ) -> Result<Response<Full<Bytes>>, Infallible> {
+        self.publish_payload(&payload);
+        let stored_origin = self.validated_origin().await;
+
+        let response = match payload.as_ref() {
+            None => missing_token_response(),
+            Some(p) if stored_origin.is_some() => {
+                cors_consent_response(p, stored_origin.as_deref().expect("checked above"))
+            }
+            Some(_) => html_close_page_response(self.application.as_deref()),
+        };
+        Ok(response)
+    }
+
+    fn publish_payload(&self, payload: &Option<BrowserCallbackPayload>) {
+        if let Some(payload) = payload {
+            let _ = self.payload_tx.send(Some(payload.clone()));
+        }
+    }
+
+    async fn set_validated_origin(&self, origin: Option<String>) {
+        let mut guard = self.validated_origin.lock().await;
+        *guard = origin;
+    }
+
+    async fn validated_origin(&self) -> Option<String> {
+        self.validated_origin.lock().await.clone()
+    }
+}
+
+fn extract_payload_from_body(body: &Bytes) -> Option<BrowserCallbackPayload> {
+    // 1) JSON: {"token": "...", "consent": true}
+    serde_json::from_slice::<TokenPayload>(body)
+        .ok()
+        .and_then(|parsed| {
+            parsed.token.map(|token| BrowserCallbackPayload {
+                token,
+                consent: parsed.consent,
+            })
+        })
+        // 2) x-www-form-urlencoded / key=value fallback
+        .or_else(|| {
+            std::str::from_utf8(body)
+                .ok()
+                .map(|body_str| {
+                    parse_token_and_consent_from_pairs(url::form_urlencoded::parse(
+                        body_str.as_bytes(),
+                    ))
+                })
+                .and_then(ParsedTokenAndConsent::into_payload)
+        })
+}
+
+fn extract_payload_from_query(query: Option<&str>) -> Option<BrowserCallbackPayload> {
+    query
+        .map(|q| parse_token_and_consent_from_pairs(url::form_urlencoded::parse(q.as_bytes())))
+        .and_then(ParsedTokenAndConsent::into_payload)
+}
+
+fn header_to_string(value: Option<&HeaderValue>) -> Option<String> {
+    value.and_then(|v| v.to_str().ok()).map(|s| s.to_string())
+}
+
+fn origin_allowed_value(origin: &str, expected: &str) -> bool {
+    origin.eq_ignore_ascii_case(expected)
+}
+
+fn requested_headers(req: &Request<Incoming>) -> Option<String> {
+    req.headers()
+        .get(ACCESS_CONTROL_REQUEST_HEADERS)
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+fn method_not_allowed_response() -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(StatusCode::METHOD_NOT_ALLOWED)
+        .body(Full::new(Bytes::from_static(b"method not allowed")))
+        .expect("building method not allowed response failed")
+}
+
+fn forbidden_response() -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .body(Full::new(Bytes::from_static(b"origin not allowed")))
+        .expect("building forbidden response failed")
+}
+
+fn preflight_cors_response(allowed_origin: &str, allow_headers: &str) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Access-Control-Allow-Origin", allowed_origin)
+        .header("Access-Control-Allow-Methods", "POST, GET")
+        .header("Access-Control-Allow-Headers", allow_headers)
+        .header("Access-Control-Max-Age", "86400")
+        .header(VARY, "Accept-Encoding, Origin")
+        .header(CONTENT_LENGTH, "0")
+        .body(Full::new(Bytes::new()))
+        .expect("building preflight response failed")
+}
+
+fn missing_token_response() -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "text/plain")
+        .header(CONTENT_LENGTH, "17")
+        .body(Full::new(Bytes::from_static(b"no token provided")))
+        .expect("building missing token response failed")
+}
+
+fn html_close_page_response(application: Option<&str>) -> Response<Full<Bytes>> {
+    let app_line = application
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|app| format!("Client application: {app}.\n"))
+        .unwrap_or_default();
+    let body = format!(
+        r#"<!DOCTYPE html><html><head><meta charset=\"UTF-8\"/>
+<link rel=\"icon\" href=\"data:,\">
+<title>SAML Response for Snowflake</title></head>
+<body>
+Your identity was confirmed and propagated to Snowflake.
+{app_line}You can close this window now and go back where you started from.
+</body></html>"#
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "text/html")
+        .header(CONTENT_LENGTH, body.len().to_string())
+        .body(Full::new(Bytes::from(body)))
+        .expect("building HTML close page response failed")
+}
+
+fn cors_consent_response(payload: &BrowserCallbackPayload, origin: &str) -> Response<Full<Bytes>> {
+    let consent = payload.consent.unwrap_or(true);
+    let body = serde_json::json!({"consent": consent}).to_string();
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/json")
+        .header(CONTENT_LENGTH, body.len().to_string())
+        .header("Access-Control-Allow-Origin", origin)
+        .header(VARY, "Accept-Encoding, Origin")
+        .body(Full::new(Bytes::from(body)))
+        .expect("building CORS consent response failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use http_body_util::BodyExt as _;
+    use hyper::{
+        body::Bytes,
+        header::{CONTENT_LENGTH, CONTENT_TYPE, VARY},
+        http::StatusCode,
+    };
+
+    use crate::external_browser_payload::BrowserCallbackPayload;
+
+    use super::{
+        cors_consent_response, extract_payload_from_body, extract_payload_from_query,
+        html_close_page_response,
+    };
+
+    #[test]
+    fn extract_payload_from_body_json() {
+        let body = Bytes::from_static(br#"{"token":"t","consent":false}"#);
+        let payload = extract_payload_from_body(&body).unwrap();
+        assert_eq!(payload.token, "t");
+        assert_eq!(payload.consent, Some(false));
+    }
+
+    #[test]
+    fn extract_payload_from_body_form_urlencoded() {
+        let body = Bytes::from_static(b"token=t&consent=true");
+        let payload = extract_payload_from_body(&body).unwrap();
+        assert_eq!(payload.token, "t");
+        assert_eq!(payload.consent, Some(true));
+    }
+
+    #[test]
+    fn extract_payload_from_query_parses_consent() {
+        let payload = extract_payload_from_query(Some("token=t&consent=false")).unwrap();
+        assert_eq!(payload.token, "t");
+        assert_eq!(payload.consent, Some(false));
+    }
+
+    #[test]
+    fn extract_payload_from_query_prefers_first_token() {
+        let payload = extract_payload_from_query(Some("token=first&token=second")).unwrap();
+        assert_eq!(payload.token, "first");
+    }
+
+    #[tokio::test]
+    async fn cors_consent_response_returns_json_without_token() {
+        let payload = BrowserCallbackPayload {
+            token: "secret".to_string(),
+            consent: Some(false),
+        };
+        let resp = cors_consent_response(&payload, "http://localhost:1");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let headers = resp.headers().clone();
+        assert_eq!(
+            headers.get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+            "application/json"
+        );
+        assert_eq!(
+            headers
+                .get("access-control-allow-origin")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "http://localhost:1"
+        );
+        assert_eq!(
+            headers.get(VARY).unwrap().to_str().unwrap(),
+            "Accept-Encoding, Origin"
+        );
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let body_str = std::str::from_utf8(&body).unwrap();
+        assert!(body_str.contains("\"consent\":false"));
+        assert!(!body_str.contains("secret"));
+
+        let expected_len = body.len().to_string();
+        assert_eq!(
+            headers.get(CONTENT_LENGTH).unwrap().to_str().unwrap(),
+            expected_len
+        );
+    }
+
+    #[tokio::test]
+    async fn html_close_page_response_includes_app_line() {
+        let resp = html_close_page_response(Some("myapp"));
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let headers = resp.headers().clone();
+        assert!(headers.get("access-control-allow-origin").is_none());
+        assert!(headers.get(VARY).is_none());
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let body_str = std::str::from_utf8(&body).unwrap();
+        assert!(body_str.contains("You can close this window now"));
+        assert!(body_str.contains("Client application: myapp"));
+        assert!(!body_str.contains("token"));
+    }
+}

--- a/src/external_browser_listener/runtime.rs
+++ b/src/external_browser_listener/runtime.rs
@@ -1,0 +1,171 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
+
+use hyper::{server::conn::http1, service::service_fn};
+use hyper_util::rt::TokioIo;
+use socket2::{Domain, Protocol, Socket, Type};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::{oneshot, watch},
+    task::{JoinError, JoinSet},
+};
+
+use crate::external_browser_payload::BrowserCallbackPayload;
+
+use super::ListenerError;
+use super::handler::CallbackHandler;
+
+type ConnectionTaskResult = Result<(), ListenerError>;
+
+struct ConnectionTasks {
+    shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
+    tasks: JoinSet<ConnectionTaskResult>,
+}
+
+impl ConnectionTasks {
+    fn new() -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Self {
+            shutdown_tx,
+            shutdown_rx,
+            tasks: JoinSet::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    fn spawn(&mut self, stream: TcpStream, shared: Arc<CallbackHandler>) {
+        let shutdown = self.shutdown_rx.clone();
+        self.tasks
+            .spawn(async move { run_connection(stream, shared, shutdown).await });
+    }
+
+    async fn join_next(&mut self) -> Option<Result<ConnectionTaskResult, JoinError>> {
+        self.tasks.join_next().await
+    }
+
+    async fn shutdown_and_drain(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+        while !self.is_empty() {
+            log_connection_task_result(self.join_next().await);
+        }
+    }
+}
+
+pub(super) struct ListenerRuntime {
+    listener: TcpListener,
+    shared: Arc<CallbackHandler>,
+    shutdown: oneshot::Receiver<()>,
+    connections: ConnectionTasks,
+}
+
+impl ListenerRuntime {
+    pub(super) fn new(
+        listener: TcpListener,
+        expected_origin: String,
+        application: Option<String>,
+        shutdown: oneshot::Receiver<()>,
+        payload_tx: watch::Sender<Option<BrowserCallbackPayload>>,
+    ) -> Self {
+        Self {
+            listener,
+            shared: Arc::new(CallbackHandler::new(
+                expected_origin,
+                application,
+                payload_tx,
+            )),
+            shutdown,
+            connections: ConnectionTasks::new(),
+        }
+    }
+
+    pub(super) async fn run(mut self) -> Result<(), ListenerError> {
+        loop {
+            tokio::select! {
+                join_result = self.connections.join_next(), if !self.connections.is_empty() => {
+                    log_connection_task_result(join_result);
+                }
+                res = self.listener.accept() => {
+                    let (stream, _peer) = match res {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!("accept error: {e}");
+                            continue;
+                        }
+                    };
+                    self.connections.spawn(stream, self.shared.clone());
+                }
+                _ = &mut self.shutdown => {
+                    break;
+                }
+            }
+        }
+
+        drop(self.listener);
+        self.connections.shutdown_and_drain().await;
+        Ok(())
+    }
+}
+
+async fn run_connection(
+    stream: TcpStream,
+    shared: Arc<CallbackHandler>,
+    mut shutdown: watch::Receiver<bool>,
+) -> ConnectionTaskResult {
+    let io = TokioIo::new(stream);
+    let svc = service_fn(move |req| {
+        let shared = shared.clone();
+        async move { shared.handle(req).await }
+    });
+    let conn = http1::Builder::new().serve_connection(io, svc);
+    tokio::pin!(conn);
+
+    tokio::select! {
+        res = conn.as_mut() => {
+            res.map_err(|err| Box::new(err) as ListenerError)
+        }
+        _ = shutdown.changed() => {
+            conn.as_mut().graceful_shutdown();
+            conn.await.map_err(|err| Box::new(err) as ListenerError)
+        }
+    }
+}
+
+fn log_connection_task_result(join_result: Option<Result<ConnectionTaskResult, JoinError>>) {
+    match join_result {
+        Some(Ok(Ok(()))) => {}
+        Some(Ok(Err(err))) => eprintln!("serve error: {err}"),
+        Some(Err(err)) => eprintln!("connection task join error: {err}"),
+        None => {}
+    }
+}
+
+pub(super) fn bind_listener(
+    cfg: &super::ListenerConfig,
+) -> Result<(TcpListener, SocketAddr), ListenerError> {
+    let target_addr = SocketAddr::new(cfg.host, cfg.port);
+
+    let domain = match target_addr {
+        SocketAddr::V4(_) => Domain::IPV4,
+        SocketAddr::V6(_) => Domain::IPV6,
+    };
+
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    socket.bind(&target_addr.into())?;
+    socket.listen(128)?;
+
+    let listener = TcpListener::from_std(socket.into())?;
+    let local_addr = listener.local_addr()?;
+    Ok((listener, local_addr))
+}
+
+pub(super) fn build_origin(protocol: &str, host: IpAddr, port: u16) -> String {
+    format!("{protocol}://{}", SocketAddr::new(host, port))
+}

--- a/src/external_browser_payload.rs
+++ b/src/external_browser_payload.rs
@@ -1,9 +1,24 @@
 use std::borrow::Cow;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrowserCallbackPayload {
+    pub(crate) token: String,
+    pub(crate) consent: Option<bool>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ParsedTokenAndConsent {
     pub(crate) token: Option<String>,
     pub(crate) consent: Option<bool>,
+}
+
+impl ParsedTokenAndConsent {
+    pub(crate) fn into_payload(self) -> Option<BrowserCallbackPayload> {
+        self.token.map(|token| BrowserCallbackPayload {
+            token,
+            consent: self.consent,
+        })
+    }
 }
 
 /// Parse `token` and `consent` from key/value pairs shared by both external-browser flows.


### PR DESCRIPTION
## Summary

Refactor `external_browser.rs` and `external_browser_listener.rs` to separate concerns by semantic role.
The only behavioral change is fixing the CORS consent response content-type from `text/html` to `application/json`.
