### PR TITLE
feat: redesign FromRow derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,3 +147,10 @@ name = "external_browser_sso_without_callback_listener"
 required-features = [
     "external-browser-sso",
 ]
+
+[[example]]
+name = "derive_from_row"
+required-features = [
+    "derive",
+    "external-browser-sso",
+]

--- a/README.md
+++ b/README.md
@@ -93,11 +93,6 @@ let table = result.collect_table().await?;
 assert_eq!(table.row_count(), 2);
 ```
 
-The `derive` feature is enabled by default and re-exports `#[derive(FromRow)]`.
-For the full attribute reference, see the `snowflake-connector-rs-derive`
-rustdoc and run `cargo run --example derive_from_row --features derive`
-(requires Snowflake credentials).
-
 ### Custom Endpoint
 
 To override the default Snowflake endpoint (e.g. for testing or non-default network setups):

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ let table = result.collect_table().await?;
 assert_eq!(table.row_count(), 2);
 ```
 
+The `derive` feature is enabled by default and re-exports `#[derive(FromRow)]`.
+For the full attribute reference, see the `snowflake-connector-rs-derive`
+rustdoc and run `cargo run --example derive_from_row --features derive`
+(requires Snowflake credentials).
+
 ### Custom Endpoint
 
 To override the default Snowflake endpoint (e.g. for testing or non-default network setups):
@@ -135,6 +140,7 @@ These algorithms are considered insecure and should only be used for legacy comp
 
 - **`pkcs8-des`**: Enables DES decryption support
 - **`pkcs8-3des`**: Enables 3DES decryption support
+- **`derive`**: Re-exports the `FromRow` derive macro (enabled by default)
 - **`external-browser-sso`**: Enables external browser SSO authentication support
 
 > [!NOTE]

--- a/derive/src/attrs.rs
+++ b/derive/src/attrs.rs
@@ -32,7 +32,6 @@ impl Default for ContainerAttrs {
 #[derive(Default)]
 pub(crate) struct FieldAttrs {
     pub(crate) rename: Option<String>,
-    pub(crate) default: bool,
 }
 
 pub(crate) fn parse_container_attrs(input: &DeriveInput) -> Result<ContainerAttrs> {
@@ -102,7 +101,6 @@ pub(crate) fn parse_container_attrs(input: &DeriveInput) -> Result<ContainerAttr
 
 pub(crate) fn parse_field_attrs(field: &Field) -> Result<FieldAttrs> {
     let mut out = FieldAttrs::default();
-    let mut default_seen = false;
 
     for attr in &field.attrs {
         if !attr.path().is_ident("snowflake") {
@@ -121,13 +119,6 @@ pub(crate) fn parse_field_attrs(field: &Field) -> Result<FieldAttrs> {
                 return Err(meta.error(
                     "field-level `by_position` is not supported; use container-level `#[snowflake(by_position)]` instead",
                 ));
-            } else if meta.path.is_ident("default") {
-                if default_seen {
-                    return Err(meta.error("duplicate `default`"));
-                }
-
-                default_seen = true;
-                out.default = true;
             } else {
                 return Err(meta.error("unknown field attribute"));
             }

--- a/derive/src/attrs.rs
+++ b/derive/src/attrs.rs
@@ -1,8 +1,14 @@
 use syn::{DeriveInput, Field, LitStr, Path, Result};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RenameAll {
+    ScreamingSnake,
+    None,
+}
+
 pub(crate) struct ContainerAttrs {
-    /// Effective field-name conversion. Only `SCREAMING_SNAKE_CASE` is supported.
-    pub(crate) rename_all_screaming: bool,
+    /// Effective field-name conversion.
+    pub(crate) rename_all: RenameAll,
     /// `true` only if the user wrote `#[snowflake(rename_all = "...")]`
     /// explicitly. Used to reject `by_position` + explicit `rename_all`.
     pub(crate) rename_all_explicit: bool,
@@ -14,7 +20,7 @@ pub(crate) struct ContainerAttrs {
 impl Default for ContainerAttrs {
     fn default() -> Self {
         Self {
-            rename_all_screaming: true,
+            rename_all: RenameAll::ScreamingSnake,
             rename_all_explicit: false,
             by_position: false,
             crate_path: syn::parse_str("::snowflake_connector_rs").expect("default path"),
@@ -46,13 +52,16 @@ pub(crate) fn parse_container_attrs(input: &DeriveInput) -> Result<ContainerAttr
                 }
 
                 let value: LitStr = meta.value()?.parse()?;
-                if value.value() != "SCREAMING_SNAKE_CASE" {
-                    return Err(
-                        meta.error("only `rename_all = \"SCREAMING_SNAKE_CASE\"` is supported")
-                    );
-                }
+                out.rename_all = match value.value().as_str() {
+                    "SCREAMING_SNAKE_CASE" => RenameAll::ScreamingSnake,
+                    "none" => RenameAll::None,
+                    _ => {
+                        return Err(meta.error(
+                            "only `rename_all = \"SCREAMING_SNAKE_CASE\"` or `\"none\"` is supported",
+                        ));
+                    }
+                };
 
-                out.rename_all_screaming = true;
                 out.rename_all_explicit = true;
             } else if meta.path.is_ident("by_position") {
                 if by_position_seen {

--- a/derive/src/attrs.rs
+++ b/derive/src/attrs.rs
@@ -32,7 +32,6 @@ impl Default for ContainerAttrs {
 #[derive(Default)]
 pub(crate) struct FieldAttrs {
     pub(crate) rename: Option<String>,
-    pub(crate) by_position: bool,
     pub(crate) default: bool,
 }
 
@@ -103,7 +102,6 @@ pub(crate) fn parse_container_attrs(input: &DeriveInput) -> Result<ContainerAttr
 
 pub(crate) fn parse_field_attrs(field: &Field) -> Result<FieldAttrs> {
     let mut out = FieldAttrs::default();
-    let mut by_position_seen = false;
     let mut default_seen = false;
 
     for attr in &field.attrs {
@@ -120,12 +118,9 @@ pub(crate) fn parse_field_attrs(field: &Field) -> Result<FieldAttrs> {
                 let value: LitStr = meta.value()?.parse()?;
                 out.rename = Some(value.value());
             } else if meta.path.is_ident("by_position") {
-                if by_position_seen {
-                    return Err(meta.error("duplicate `by_position`"));
-                }
-
-                by_position_seen = true;
-                out.by_position = true;
+                return Err(meta.error(
+                    "field-level `by_position` is not supported; use container-level `#[snowflake(by_position)]` instead",
+                ));
             } else if meta.path.is_ident("default") {
                 if default_seen {
                     return Err(meta.error("duplicate `default`"));

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -63,7 +63,7 @@ fn build_plan_line(field: &FieldInfo, crate_path: &syn::Path) -> TokenStream2 {
             if field.has_default {
                 quote! {
                     let #ident: ::core::option::Option<#crate_path::ColumnIndex> =
-                        match schema.column_by_name_ci(#name) {
+                        match schema.column(#name) {
                             ::core::result::Result::Ok(idx) => ::core::option::Option::Some(idx),
                             ::core::result::Result::Err(
                                 #crate_path::SchemaError::MissingColumn { .. },
@@ -74,7 +74,7 @@ fn build_plan_line(field: &FieldInfo, crate_path: &syn::Path) -> TokenStream2 {
                         };
                 }
             } else {
-                quote! { let #ident = schema.column_by_name_ci(#name)?; }
+                quote! { let #ident = schema.column(#name)?; }
             }
         }
         FieldLookup::Position(pos) => {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -10,11 +10,7 @@ pub(crate) fn expand(model: &FromRowDerive) -> TokenStream2 {
 
     let plan_fields = model.fields.iter().map(|field| {
         let ident = &field.plan_ident;
-        if field.has_default {
-            quote! { #ident: ::core::option::Option<#crate_path::ColumnIndex> }
-        } else {
-            quote! { #ident: #crate_path::ColumnIndex }
-        }
+        quote! { #ident: #crate_path::ColumnIndex }
     });
 
     let build_plan_lines = model
@@ -26,7 +22,7 @@ pub(crate) fn expand(model: &FromRowDerive) -> TokenStream2 {
         .iter()
         .map(|field| &field.plan_ident)
         .collect::<Vec<_>>();
-    let row_body = row_body(model, crate_path);
+    let row_body = row_body(model);
 
     quote! {
         const _: () = {
@@ -59,87 +55,43 @@ pub(crate) fn expand(model: &FromRowDerive) -> TokenStream2 {
 fn build_plan_line(field: &FieldInfo, crate_path: &syn::Path) -> TokenStream2 {
     let ident = &field.plan_ident;
     match &field.lookup {
-        FieldLookup::Name(name) => {
-            if field.has_default {
-                quote! {
-                    let #ident: ::core::option::Option<#crate_path::ColumnIndex> =
-                        match schema.column(#name) {
-                            ::core::result::Result::Ok(idx) => ::core::option::Option::Some(idx),
-                            ::core::result::Result::Err(
-                                #crate_path::SchemaError::MissingColumn { .. },
-                            ) => ::core::option::Option::None,
-                            ::core::result::Result::Err(e) => {
-                                return ::core::result::Result::Err(e.into());
-                            }
-                        };
-                }
-            } else {
-                quote! { let #ident = schema.column(#name)?; }
-            }
-        }
+        FieldLookup::Name(name) => quote! { let #ident = schema.column(#name)?; },
         FieldLookup::Position(pos) => {
             let pos_lit = syn::Index::from(*pos);
-            if field.has_default {
-                quote! {
-                    let #ident: ::core::option::Option<#crate_path::ColumnIndex> = if schema.len() > #pos_lit {
-                        ::core::option::Option::Some(schema.columns()[#pos_lit].index())
-                    } else { ::core::option::Option::None };
+            quote! {
+                if schema.len() <= #pos_lit {
+                    return ::core::result::Result::Err(#crate_path::Error::Schema(
+                        #crate_path::SchemaError::ColumnCountMismatch {
+                            expected: #pos_lit + 1,
+                            actual: schema.len(),
+                        }
+                    ));
                 }
-            } else {
-                quote! {
-                    if schema.len() <= #pos_lit {
-                        return ::core::result::Result::Err(#crate_path::Error::Schema(
-                            #crate_path::SchemaError::ColumnCountMismatch {
-                                expected: #pos_lit + 1,
-                                actual: schema.len(),
-                            }
-                        ));
-                    }
-                    let #ident = schema.columns()[#pos_lit].index();
-                }
+                let #ident = schema.columns()[#pos_lit].index();
             }
         }
     }
 }
 
-fn row_body(model: &FromRowDerive, crate_path: &syn::Path) -> TokenStream2 {
+fn row_body(model: &FromRowDerive) -> TokenStream2 {
     match model.shape {
         StructShape::Named => {
             let assigns = model.fields.iter().map(|field| {
                 let field_ident = field.field_ident.as_ref().expect("named");
-                let value = decode_field_value(field, crate_path);
+                let value = decode_field_value(field);
                 quote! { #field_ident: #value }
             });
             quote! { ::core::result::Result::Ok(Self { #(#assigns),* }) }
         }
         StructShape::Tuple => {
-            let assigns = model
-                .fields
-                .iter()
-                .map(|field| decode_field_value(field, crate_path));
+            let assigns = model.fields.iter().map(decode_field_value);
             quote! { ::core::result::Result::Ok(Self ( #(#assigns),* )) }
         }
     }
 }
 
-fn decode_field_value(field: &FieldInfo, crate_path: &syn::Path) -> TokenStream2 {
+fn decode_field_value(field: &FieldInfo) -> TokenStream2 {
     let plan_ident = &field.plan_ident;
     let ty = &field.ty;
-    if field.has_default {
-        quote! {
-            match plan.#plan_ident {
-                ::core::option::Option::Some(idx) => {
-                    let cell = row.cell(idx)?;
-                    if cell.is_null() {
-                        <#ty as ::core::default::Default>::default()
-                    } else {
-                        <#ty as #crate_path::FromCell>::from_cell(cell)?
-                    }
-                }
-                ::core::option::Option::None => <#ty as ::core::default::Default>::default(),
-            }
-        }
-    } else {
-        quote! { row.get::<#ty>(plan.#plan_ident)? }
-    }
+    quote! { row.get::<#ty>(plan.#plan_ident)? }
 }

--- a/derive/src/input.rs
+++ b/derive/src/input.rs
@@ -100,26 +100,12 @@ fn parse_named(named: &syn::FieldsNamed, container: &ContainerAttrs) -> Result<V
 
         let field_attrs = parse_field_attrs(field)?;
         let has_default = field_attrs.default;
-        let field_by_position = field_attrs.by_position;
         let field_rename = field_attrs.rename;
         let ident = field.ident.clone().expect("named");
         let plan_ident = format_ident!("__plan_{}", ident);
 
-        if field_by_position && field_rename.is_some() {
-            return Err(syn::Error::new(
-                field.span(),
-                "by_position cannot be combined with rename",
-            ));
-        }
-        if field_by_position && container.rename_all_explicit {
-            return Err(syn::Error::new(
-                field.span(),
-                "field `by_position` cannot be combined with container `rename_all`",
-            ));
-        }
-
-        let lookup = if container.by_position || field_by_position {
-            if container.by_position && field_rename.is_some() {
+        let lookup = if container.by_position {
+            if field_rename.is_some() {
                 return Err(syn::Error::new(
                     field.span(),
                     "container `by_position` cannot be combined with field `rename`",

--- a/derive/src/input.rs
+++ b/derive/src/input.rs
@@ -2,7 +2,7 @@ use quote::format_ident;
 use syn::{Data, DeriveInput, Fields, Ident, Path, Result, spanned::Spanned};
 
 use crate::attrs::{ContainerAttrs, parse_container_attrs, parse_field_attrs};
-use crate::naming::{logical_ident_name, screaming_snake};
+use crate::naming::{apply_rename_all, logical_ident_name};
 
 pub(crate) struct FromRowDerive {
     pub(crate) struct_ident: Ident,
@@ -99,24 +99,27 @@ fn parse_named(named: &syn::FieldsNamed, container: &ContainerAttrs) -> Result<V
         }
 
         let field_attrs = parse_field_attrs(field)?;
+        let has_default = field_attrs.default;
+        let field_by_position = field_attrs.by_position;
+        let field_rename = field_attrs.rename;
         let ident = field.ident.clone().expect("named");
         let plan_ident = format_ident!("__plan_{}", ident);
 
-        if field_attrs.by_position && field_attrs.rename.is_some() {
+        if field_by_position && field_rename.is_some() {
             return Err(syn::Error::new(
                 field.span(),
                 "by_position cannot be combined with rename",
             ));
         }
-        if field_attrs.by_position && container.rename_all_explicit {
+        if field_by_position && container.rename_all_explicit {
             return Err(syn::Error::new(
                 field.span(),
                 "field `by_position` cannot be combined with container `rename_all`",
             ));
         }
 
-        let lookup = if container.by_position || field_attrs.by_position {
-            if container.by_position && field_attrs.rename.is_some() {
+        let lookup = if container.by_position || field_by_position {
+            if container.by_position && field_rename.is_some() {
                 return Err(syn::Error::new(
                     field.span(),
                     "container `by_position` cannot be combined with field `rename`",
@@ -124,17 +127,10 @@ fn parse_named(named: &syn::FieldsNamed, container: &ContainerAttrs) -> Result<V
             }
             FieldLookup::Position(i)
         } else {
-            let name = match field_attrs.rename {
-                Some(s) => s,
-                None => {
-                    let raw = logical_ident_name(&ident);
-                    if container.rename_all_screaming {
-                        screaming_snake(&raw)
-                    } else {
-                        raw
-                    }
-                }
-            };
+            let name = field_rename.unwrap_or_else(|| {
+                let raw = logical_ident_name(&ident);
+                apply_rename_all(&raw, container.rename_all)
+            });
             FieldLookup::Name(name)
         };
 
@@ -143,7 +139,7 @@ fn parse_named(named: &syn::FieldsNamed, container: &ContainerAttrs) -> Result<V
             plan_ident,
             ty: field.ty.clone(),
             lookup,
-            has_default: field_attrs.default,
+            has_default,
         });
     }
 

--- a/derive/src/input.rs
+++ b/derive/src/input.rs
@@ -26,7 +26,6 @@ pub(crate) struct FieldInfo {
     pub(crate) plan_ident: Ident,
     pub(crate) ty: syn::Type,
     pub(crate) lookup: FieldLookup,
-    pub(crate) has_default: bool,
 }
 
 pub(crate) fn analyze(input: DeriveInput) -> Result<FromRowDerive> {
@@ -99,7 +98,6 @@ fn parse_named(named: &syn::FieldsNamed, container: &ContainerAttrs) -> Result<V
         }
 
         let field_attrs = parse_field_attrs(field)?;
-        let has_default = field_attrs.default;
         let field_rename = field_attrs.rename;
         let ident = field.ident.clone().expect("named");
         let plan_ident = format_ident!("__plan_{}", ident);
@@ -125,7 +123,6 @@ fn parse_named(named: &syn::FieldsNamed, container: &ContainerAttrs) -> Result<V
             plan_ident,
             ty: field.ty.clone(),
             lookup,
-            has_default,
         });
     }
 
@@ -166,7 +163,6 @@ fn parse_unnamed(
             plan_ident,
             ty: field.ty.clone(),
             lookup: FieldLookup::Position(i),
-            has_default: field_attrs.default,
         });
     }
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -42,7 +42,8 @@ use syn::{DeriveInput, parse_macro_input};
 /// - `rename_all = "SCREAMING_SNAKE_CASE"`: compile-time field-name conversion
 ///   used by named structs. This is the default.
 /// - `rename_all = "none"`: use each logical field name as-is.
-/// - `by_position`: decode every field by ordinal instead of by label.
+/// - `by_position`: decode every field by ordinal instead of by label on named
+///   structs. Tuple structs already decode by position automatically.
 /// - `crate = "::path"`: override the crate path used in generated code.
 ///
 /// ```rust,ignore
@@ -56,13 +57,27 @@ use syn::{DeriveInput, parse_macro_input};
 /// ```rust,ignore
 /// #[derive(snowflake_connector_rs::FromRow)]
 /// #[snowflake(by_position)]
-/// struct PositionalRow(i64, String);
+/// struct PositionalRow {
+///     id: i64,
+///     name: String,
+/// }
+/// ```
+///
+/// # Tuple structs
+///
+/// Tuple structs decode by ordinal automatically; you do not need to add
+/// `#[snowflake(by_position)]`. The container attribute remains accepted as a
+/// no-op for backward source compatibility but is not required and is omitted
+/// from the examples.
+///
+/// ```rust,ignore
+/// #[derive(snowflake_connector_rs::FromRow)]
+/// struct PositionalPair(i64, String);
 /// ```
 ///
 /// # Field attributes
 ///
 /// - `rename = "..."`: use the exact raw result label for this field.
-/// - `by_position`: decode this field by ordinal in a named struct.
 /// - `default`: use `Default::default()` when the named lookup fails with
 ///   `MissingColumn`.
 ///

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -57,6 +57,10 @@ use syn::{DeriveInput, parse_macro_input};
 ///   structs. Tuple structs already decode by position automatically.
 /// - `crate = "::path"`: override the crate path used in generated code.
 ///
+/// `rename_all` cannot be combined with `by_position`; positional decoding does
+/// not use field names. `rename_all` also cannot be applied to tuple structs,
+/// which are implicitly positional.
+///
 /// ```rust,ignore
 /// #[derive(snowflake_connector_rs::FromRow)]
 /// #[snowflake(rename_all = "none")]
@@ -79,7 +83,7 @@ use syn::{DeriveInput, parse_macro_input};
 /// Tuple structs decode by ordinal automatically; you do not need to add
 /// `#[snowflake(by_position)]`. The container attribute remains accepted as a
 /// no-op for backward source compatibility but is not required and is omitted
-/// from the examples.
+/// from the examples. `rename_all` cannot be applied to tuple structs.
 ///
 /// ```rust,ignore
 /// #[derive(snowflake_connector_rs::FromRow)]
@@ -89,8 +93,6 @@ use syn::{DeriveInput, parse_macro_input};
 /// # Field attributes
 ///
 /// - `rename = "..."`: use the exact raw result label for this field.
-/// - `default`: use `Default::default()` when the named column is missing or the
-///   cell value is `NULL`. Cell decode errors are still propagated as-is.
 ///
 /// ```rust,ignore
 /// #[derive(snowflake_connector_rs::FromRow)]
@@ -100,27 +102,34 @@ use syn::{DeriveInput, parse_macro_input};
 /// }
 /// ```
 ///
+/// # SQL NULL
+///
+/// Use `Option<T>` when a projected column may carry SQL `NULL`. Missing columns
+/// still raise `MissingColumn`; if you need a non-`Option` default, project it
+/// explicitly in SQL.
+///
 /// ```rust,ignore
 /// #[derive(snowflake_connector_rs::FromRow)]
-/// struct PartialRow {
+/// struct NullableNote {
 ///     id: i64,
-///     #[snowflake(default)]
 ///     note: Option<String>,
 /// }
 /// ```
+///
+/// `SELECT id, NULL AS note FROM users` decodes to `note: None`, while
+/// `SELECT id, COALESCE(note, '') AS note FROM users` keeps `note` non-optional.
 ///
 /// # Error behavior
 ///
 /// The generated implementation propagates schema and row access errors:
 ///
-/// - `MissingColumn` for required named lookups.
+/// - `MissingColumn` for required named lookups, including `Option<T>` fields.
 /// - `AmbiguousColumn` when the schema contains duplicate raw labels.
 /// - `ColumnCountMismatch` when required positional fields exceed the schema.
 /// - `InvalidColumnIndex` and cell decode errors from row access.
 ///
-/// `#[snowflake(default)]` substitutes a default value when either the column is
-/// missing (`MissingColumn`) or the cell carries a `NULL` value. It does not
-/// swallow `AmbiguousColumn` or row decode errors.
+/// SQL `NULL` only maps to `None` for `Option<T>`. Other field types propagate
+/// their normal `FromCell` decode error.
 #[proc_macro_derive(FromRow, attributes(snowflake))]
 pub fn derive_from_row(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -37,11 +37,22 @@ use syn::{DeriveInput, parse_macro_input};
 /// provided raw label verbatim. `#[snowflake(rename_all = "none")]` keeps the
 /// logical field name unchanged.
 ///
+/// Snowflake stores and resolves unquoted aliases as uppercase. `SELECT 1 AS name`
+/// returns the raw label `NAME`, so the default `SCREAMING_SNAKE_CASE` rule keeps
+/// matching unannotated structs against typical SELECT queries.
+///
+/// `rename_all = "none"` is intended for results whose raw labels intentionally
+/// preserve case or use lowercase, such as quoted aliases (`SELECT 1 AS "name"`)
+/// or `SHOW` / `DESCRIBE` queries (whose output columns are lowercase and have to
+/// be referenced via double-quoted identifiers).
+///
 /// # Container attributes
 ///
 /// - `rename_all = "SCREAMING_SNAKE_CASE"`: compile-time field-name conversion
 ///   used by named structs. This is the default.
-/// - `rename_all = "none"`: use each logical field name as-is.
+/// - `rename_all = "none"`: use each logical field name as-is. Pair this with
+///   quoted aliases or `SHOW` / `DESCRIBE` results that intentionally keep
+///   labels in lowercase or mixed case.
 /// - `by_position`: decode every field by ordinal instead of by label on named
 ///   structs. Tuple structs already decode by position automatically.
 /// - `crate = "::path"`: override the crate path used in generated code.
@@ -78,8 +89,8 @@ use syn::{DeriveInput, parse_macro_input};
 /// # Field attributes
 ///
 /// - `rename = "..."`: use the exact raw result label for this field.
-/// - `default`: use `Default::default()` when the named lookup fails with
-///   `MissingColumn`.
+/// - `default`: use `Default::default()` when the named column is missing or the
+///   cell value is `NULL`. Cell decode errors are still propagated as-is.
 ///
 /// ```rust,ignore
 /// #[derive(snowflake_connector_rs::FromRow)]
@@ -107,14 +118,15 @@ use syn::{DeriveInput, parse_macro_input};
 /// - `ColumnCountMismatch` when required positional fields exceed the schema.
 /// - `InvalidColumnIndex` and cell decode errors from row access.
 ///
-/// `#[snowflake(default)]` only substitutes a default value for
-/// `MissingColumn`. It does not swallow `AmbiguousColumn` or row decode errors.
+/// `#[snowflake(default)]` substitutes a default value when either the column is
+/// missing (`MissingColumn`) or the cell carries a `NULL` value. It does not
+/// swallow `AmbiguousColumn` or row decode errors.
 ///
 /// # Using the macro
 ///
 /// `snowflake-connector-rs` re-exports this macro when its `derive` feature is
-/// enabled. See the base crate docs and the `derive_from_row` example for a
-/// full walkthrough of the supported attribute combinations.
+/// enabled. The repository ships a runnable walkthrough at
+/// `examples/derive_from_row.rs`.
 #[proc_macro_derive(FromRow, attributes(snowflake))]
 pub fn derive_from_row(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -121,12 +121,6 @@ use syn::{DeriveInput, parse_macro_input};
 /// `#[snowflake(default)]` substitutes a default value when either the column is
 /// missing (`MissingColumn`) or the cell carries a `NULL` value. It does not
 /// swallow `AmbiguousColumn` or row decode errors.
-///
-/// # Using the macro
-///
-/// `snowflake-connector-rs` re-exports this macro when its `derive` feature is
-/// enabled. The repository ships a runnable walkthrough at
-/// `examples/derive_from_row.rs`.
 #[proc_macro_derive(FromRow, attributes(snowflake))]
 pub fn derive_from_row(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,4 +1,19 @@
 //! Derive macros for `snowflake-connector-rs`.
+//!
+//! Enable the `derive` feature on `snowflake-connector-rs` to use
+//! `#[derive(FromRow)]` on your row types. The macro resolves named fields
+//! against exact raw result labels from the Snowflake schema.
+//!
+//! ```rust,ignore
+//! use snowflake_connector_rs::FromRow;
+//!
+//! #[derive(Debug, FromRow, PartialEq)]
+//! struct UserRow {
+//!     id: i64,
+//!     #[snowflake(rename = "USER_NAME")]
+//!     name: String,
+//! }
+//! ```
 
 mod attrs;
 mod codegen;
@@ -8,6 +23,83 @@ mod naming;
 use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
 
+/// Derives `snowflake_connector_rs::FromRow` for a struct.
+///
+/// # Name lookup
+///
+/// Named-field structs resolve columns by exact raw result label. When no field
+/// attribute overrides the lookup, the macro converts each logical field name to
+/// `SCREAMING_SNAKE_CASE` at compile time, so `created_at` looks up
+/// `CREATED_AT`. Raw identifier prefixes such as `r#type` are stripped before
+/// the lookup name is finalized.
+///
+/// `#[snowflake(rename = "...")]` bypasses container-level renaming and uses the
+/// provided raw label verbatim. `#[snowflake(rename_all = "none")]` keeps the
+/// logical field name unchanged.
+///
+/// # Container attributes
+///
+/// - `rename_all = "SCREAMING_SNAKE_CASE"`: compile-time field-name conversion
+///   used by named structs. This is the default.
+/// - `rename_all = "none"`: use each logical field name as-is.
+/// - `by_position`: decode every field by ordinal instead of by label.
+/// - `crate = "::path"`: override the crate path used in generated code.
+///
+/// ```rust,ignore
+/// #[derive(snowflake_connector_rs::FromRow)]
+/// #[snowflake(rename_all = "none")]
+/// struct LowercaseLabels {
+///     name: String,
+/// }
+/// ```
+///
+/// ```rust,ignore
+/// #[derive(snowflake_connector_rs::FromRow)]
+/// #[snowflake(by_position)]
+/// struct PositionalRow(i64, String);
+/// ```
+///
+/// # Field attributes
+///
+/// - `rename = "..."`: use the exact raw result label for this field.
+/// - `by_position`: decode this field by ordinal in a named struct.
+/// - `default`: use `Default::default()` when the named lookup fails with
+///   `MissingColumn`.
+///
+/// ```rust,ignore
+/// #[derive(snowflake_connector_rs::FromRow)]
+/// struct RenamedField {
+///     #[snowflake(rename = "display name")]
+///     display_name: String,
+/// }
+/// ```
+///
+/// ```rust,ignore
+/// #[derive(snowflake_connector_rs::FromRow)]
+/// struct PartialRow {
+///     id: i64,
+///     #[snowflake(default)]
+///     note: Option<String>,
+/// }
+/// ```
+///
+/// # Error behavior
+///
+/// The generated implementation propagates schema and row access errors:
+///
+/// - `MissingColumn` for required named lookups.
+/// - `AmbiguousColumn` when the schema contains duplicate raw labels.
+/// - `ColumnCountMismatch` when required positional fields exceed the schema.
+/// - `InvalidColumnIndex` and cell decode errors from row access.
+///
+/// `#[snowflake(default)]` only substitutes a default value for
+/// `MissingColumn`. It does not swallow `AmbiguousColumn` or row decode errors.
+///
+/// # Using the macro
+///
+/// `snowflake-connector-rs` re-exports this macro when its `derive` feature is
+/// enabled. See the base crate docs and the `derive_from_row` example for a
+/// full walkthrough of the supported attribute combinations.
 #[proc_macro_derive(FromRow, attributes(snowflake))]
 pub fn derive_from_row(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/derive/src/naming.rs
+++ b/derive/src/naming.rs
@@ -1,5 +1,7 @@
 use syn::Ident;
 
+use crate::attrs::RenameAll;
+
 pub(crate) fn logical_ident_name(ident: &Ident) -> String {
     let ident = ident.to_string();
     ident
@@ -22,4 +24,11 @@ pub(crate) fn screaming_snake(s: &str) -> String {
         prev_lower = ch.is_ascii_lowercase() || ch.is_ascii_digit();
     }
     out
+}
+
+pub(crate) fn apply_rename_all(s: &str, rename_all: RenameAll) -> String {
+    match rename_all {
+        RenameAll::ScreamingSnake => screaming_snake(s),
+        RenameAll::None => s.to_string(),
+    }
 }

--- a/examples/derive_from_row.rs
+++ b/examples/derive_from_row.rs
@@ -12,13 +12,7 @@ use snowflake_connector_rs::{
 struct DefaultLabels {
     id: i64,
     user_name: String,
-}
-
-#[derive(Debug, PartialEq, FromRow)]
-#[snowflake(rename_all = "none")]
-struct LowercaseLabels {
-    name: String,
-    value: String,
+    note: Option<String>,
 }
 
 #[derive(Debug, PartialEq, FromRow)]
@@ -38,10 +32,10 @@ struct NamedByPosition {
 }
 
 #[derive(Debug, PartialEq, FromRow)]
-struct OptionalNote {
-    id: i64,
-    #[snowflake(default)]
-    note: Option<String>,
+#[snowflake(rename_all = "none")]
+struct LowercaseLabels {
+    name: String,
+    value: String,
 }
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
@@ -60,7 +54,6 @@ async fn async_main() -> Result<()> {
     run_rename_all_none_example(&session).await?;
     run_exact_rename_example(&session).await?;
     run_position_examples(&session).await?;
-    run_default_example(&session).await?;
     run_streaming_example(&session).await?;
 
     Ok(())
@@ -69,7 +62,9 @@ async fn async_main() -> Result<()> {
 async fn run_default_mapping_example(session: &SnowflakeSession) -> Result<()> {
     // Default field-name mapping uses compile-time SCREAMING_SNAKE_CASE labels.
     let rows = session
-        .query_as::<DefaultLabels, _>(r#"SELECT 1 AS id, 'alice' AS user_name"#)
+        .query_as::<DefaultLabels, _>(
+            r#"SELECT 1 AS id, 'alice' AS user_name, NULL::STRING AS note"#,
+        )
         .await?
         .collect()
         .await?;
@@ -78,6 +73,7 @@ async fn run_default_mapping_example(session: &SnowflakeSession) -> Result<()> {
         vec![DefaultLabels {
             id: 1,
             user_name: "alice".to_string(),
+            note: None,
         }]
     );
     println!("default mapping: {rows:?}");
@@ -148,25 +144,14 @@ async fn run_position_examples(session: &SnowflakeSession) -> Result<()> {
     Ok(())
 }
 
-async fn run_default_example(session: &SnowflakeSession) -> Result<()> {
-    // `default` fills when the named column is missing OR when the cell is NULL.
-    // Here only the missing-column path is exercised; the NULL fallback follows
-    // the same `Default::default()` substitution.
-    let rows = session
-        .query_as::<OptionalNote, _>(r#"SELECT 1 AS id"#)
-        .await?
-        .collect()
-        .await?;
-    assert_eq!(rows, vec![OptionalNote { id: 1, note: None }]);
-    println!("default: {rows:?}");
-    Ok(())
-}
-
 async fn run_streaming_example(session: &SnowflakeSession) -> Result<()> {
     // Typed results can be streamed table by table instead of collected eagerly.
     let mut result = session
         .query_as::<DefaultLabels, _>(
-            r#"SELECT 1 AS id, 'alice' AS user_name UNION ALL SELECT 2 AS id, 'bob' AS user_name ORDER BY id"#,
+            r#"SELECT 1 AS id, 'alice' AS user_name, NULL::STRING AS note
+               UNION ALL
+               SELECT 2 AS id, 'bob' AS user_name, 'ready' AS note
+               ORDER BY id"#,
         )
         .await?;
 

--- a/examples/derive_from_row.rs
+++ b/examples/derive_from_row.rs
@@ -28,14 +28,12 @@ struct ExactLabels {
 }
 
 #[derive(Debug, PartialEq, FromRow)]
-#[snowflake(by_position)]
 struct TupleByPosition(i64, String);
 
 #[derive(Debug, PartialEq, FromRow)]
+#[snowflake(by_position)]
 struct NamedByPosition {
-    #[snowflake(by_position)]
     id: i64,
-    #[snowflake(by_position)]
     label: String,
 }
 
@@ -122,7 +120,8 @@ async fn run_exact_rename_example(session: &SnowflakeSession) -> Result<()> {
 }
 
 async fn run_position_examples(session: &SnowflakeSession) -> Result<()> {
-    // Container-level and field-level `by_position` both decode by ordinal.
+    // Tuple structs decode by position automatically; named structs opt in with
+    // container-level `#[snowflake(by_position)]`.
     let tuple_rows = session
         .query_as::<TupleByPosition, _>(r#"SELECT 7, 'tuple row'"#)
         .await?

--- a/examples/derive_from_row.rs
+++ b/examples/derive_from_row.rs
@@ -1,0 +1,237 @@
+use std::env;
+
+use url::Url;
+
+use snowflake_connector_rs::{
+    ExternalBrowserConfig, FromRow, Result, SnowflakeAuthMethod, SnowflakeClient,
+    SnowflakeClientConfig, SnowflakeEndpointConfig, SnowflakeQueryConfig, SnowflakeSession,
+    SnowflakeSessionConfig,
+};
+
+#[derive(Debug, PartialEq, FromRow)]
+struct DefaultLabels {
+    id: i64,
+    user_name: String,
+}
+
+#[derive(Debug, PartialEq, FromRow)]
+#[snowflake(rename_all = "none")]
+struct LowercaseLabels {
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, PartialEq, FromRow)]
+struct ExactLabels {
+    #[snowflake(rename = "display name")]
+    display_name: String,
+}
+
+#[derive(Debug, PartialEq, FromRow)]
+#[snowflake(by_position)]
+struct TupleByPosition(i64, String);
+
+#[derive(Debug, PartialEq, FromRow)]
+struct NamedByPosition {
+    #[snowflake(by_position)]
+    id: i64,
+    #[snowflake(by_position)]
+    label: String,
+}
+
+#[derive(Debug, PartialEq, FromRow)]
+struct OptionalNote {
+    id: i64,
+    #[snowflake(default)]
+    note: Option<String>,
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(async_main())?;
+    Ok(())
+}
+
+async fn async_main() -> Result<()> {
+    let client = connect_with_configs(session_config(), SnowflakeQueryConfig::default())?;
+    let session = client.create_session().await?;
+
+    run_default_mapping_example(&session).await?;
+    run_rename_all_none_example(&session).await?;
+    run_exact_rename_example(&session).await?;
+    run_position_examples(&session).await?;
+    run_default_example(&session).await?;
+    run_streaming_example(&session).await?;
+
+    Ok(())
+}
+
+async fn run_default_mapping_example(session: &SnowflakeSession) -> Result<()> {
+    // Default field-name mapping uses compile-time SCREAMING_SNAKE_CASE labels.
+    let rows = session
+        .query_as::<DefaultLabels, _>(r#"SELECT 1 AS id, 'alice' AS user_name"#)
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(
+        rows,
+        vec![DefaultLabels {
+            id: 1,
+            user_name: "alice".to_string(),
+        }]
+    );
+    println!("default mapping: {rows:?}");
+    Ok(())
+}
+
+async fn run_rename_all_none_example(session: &SnowflakeSession) -> Result<()> {
+    // Lowercase quoted labels can opt out of the default renaming rule.
+    let rows = session
+        .query_as::<LowercaseLabels, _>(r#"SELECT 'TIMEZONE' AS "name", 'Asia/Tokyo' AS "value""#)
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(
+        rows,
+        vec![LowercaseLabels {
+            name: "TIMEZONE".to_string(),
+            value: "Asia/Tokyo".to_string(),
+        }]
+    );
+    println!("rename_all = none: {rows:?}");
+    Ok(())
+}
+
+async fn run_exact_rename_example(session: &SnowflakeSession) -> Result<()> {
+    // `rename` targets the exact raw label, including spaces.
+    let rows = session
+        .query_as::<ExactLabels, _>(r#"SELECT 'Alice Example' AS "display name""#)
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(
+        rows,
+        vec![ExactLabels {
+            display_name: "Alice Example".to_string(),
+        }]
+    );
+    println!("rename: {rows:?}");
+    Ok(())
+}
+
+async fn run_position_examples(session: &SnowflakeSession) -> Result<()> {
+    // Container-level and field-level `by_position` both decode by ordinal.
+    let tuple_rows = session
+        .query_as::<TupleByPosition, _>(r#"SELECT 7, 'tuple row'"#)
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(
+        tuple_rows,
+        vec![TupleByPosition(7, "tuple row".to_string())]
+    );
+
+    let named_rows = session
+        .query_as::<NamedByPosition, _>(r#"SELECT 9, 'named row'"#)
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(
+        named_rows,
+        vec![NamedByPosition {
+            id: 9,
+            label: "named row".to_string(),
+        }]
+    );
+    println!("by_position: tuple={tuple_rows:?}, named={named_rows:?}");
+    Ok(())
+}
+
+async fn run_default_example(session: &SnowflakeSession) -> Result<()> {
+    // `default` fills only when the named column is missing.
+    let rows = session
+        .query_as::<OptionalNote, _>(r#"SELECT 1 AS id"#)
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(rows, vec![OptionalNote { id: 1, note: None }]);
+    println!("default: {rows:?}");
+    Ok(())
+}
+
+async fn run_streaming_example(session: &SnowflakeSession) -> Result<()> {
+    // Typed results can be streamed table by table instead of collected eagerly.
+    let mut result = session
+        .query_as::<DefaultLabels, _>(
+            r#"SELECT 1 AS id, 'alice' AS user_name UNION ALL SELECT 2 AS id, 'bob' AS user_name ORDER BY id"#,
+        )
+        .await?;
+
+    while let Some(table) = result.next_table().await? {
+        for row in table.rows() {
+            let row = row?;
+            println!("streamed row: {row:?}");
+        }
+    }
+
+    Ok(())
+}
+
+fn connect_with_configs(
+    session_config: SnowflakeSessionConfig,
+    query_config: SnowflakeQueryConfig,
+) -> Result<SnowflakeClient> {
+    let username = env::var("SNOWFLAKE_USERNAME").expect("set SNOWFLAKE_USERNAME");
+    let account = env::var("SNOWFLAKE_ACCOUNT").expect("set SNOWFLAKE_ACCOUNT");
+    let host = env::var("SNOWFLAKE_HOST").ok();
+    let port = env::var("SNOWFLAKE_PORT")
+        .ok()
+        .and_then(|var| var.parse().ok());
+    let protocol = env::var("SNOWFLAKE_PROTOCOL").ok();
+
+    let mut client_config = SnowflakeClientConfig::new(
+        &username,
+        &account,
+        SnowflakeAuthMethod::ExternalBrowser(ExternalBrowserConfig::default()),
+    )
+    .with_session(session_config)
+    .with_query(query_config);
+
+    if let Some(host) = host {
+        let scheme = protocol.unwrap_or_else(|| "https".to_string());
+        let mut url = Url::parse(&format!("{scheme}://{host}"))
+            .map_err(|e| snowflake_connector_rs::Error::Url(e.to_string()))?;
+        if let Some(port) = port {
+            url.set_port(Some(port))
+                .map_err(|_| snowflake_connector_rs::Error::Url("invalid base url port".into()))?;
+        }
+        client_config = client_config.with_endpoint(SnowflakeEndpointConfig::custom_base_url(url));
+    }
+
+    SnowflakeClient::new(client_config)
+}
+
+fn session_config() -> SnowflakeSessionConfig {
+    let role = env::var("SNOWFLAKE_ROLE").ok();
+    let warehouse = env::var("SNOWFLAKE_WAREHOUSE").ok();
+    let database = env::var("SNOWFLAKE_DATABASE").ok();
+    let schema = env::var("SNOWFLAKE_SCHEMA").ok();
+
+    let mut session_config = SnowflakeSessionConfig::default();
+    if let Some(warehouse) = warehouse {
+        session_config = session_config.with_warehouse(warehouse);
+    }
+    if let Some(database) = database {
+        session_config = session_config.with_database(database);
+    }
+    if let Some(schema) = schema {
+        session_config = session_config.with_schema(schema);
+    }
+    if let Some(role) = role {
+        session_config = session_config.with_role(role);
+    }
+
+    session_config
+}

--- a/examples/derive_from_row.rs
+++ b/examples/derive_from_row.rs
@@ -149,7 +149,9 @@ async fn run_position_examples(session: &SnowflakeSession) -> Result<()> {
 }
 
 async fn run_default_example(session: &SnowflakeSession) -> Result<()> {
-    // `default` fills only when the named column is missing.
+    // `default` fills when the named column is missing OR when the cell is NULL.
+    // Here only the missing-column path is exercised; the NULL fallback follows
+    // the same `Default::default()` substitution.
     let rows = session
         .query_as::<OptionalNote, _>(r#"SELECT 1 AS id"#)
         .await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //! A Rust client for Snowflake. Query results are materialized into a
 //! [`ResultTable`] and decoded with the [`FromRow`] / [`FromCell`] traits.
+//! The `derive` feature is enabled by default and re-exports
+//! `#[derive(FromRow)]`. See the `snowflake-connector-rs-derive` rustdoc and the
+//! `derive_from_row` example for attribute details and a runnable end-to-end
+//! example.
 //!
 //! ```rust,no_run
 //! # use snowflake_connector_rs::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,6 @@
 //!
 //! A Rust client for Snowflake. Query results are materialized into a
 //! [`ResultTable`] and decoded with the [`FromRow`] / [`FromCell`] traits.
-//! The `derive` feature is enabled by default and re-exports
-//! `#[derive(FromRow)]`. See the `snowflake-connector-rs-derive` rustdoc and the
-//! `derive_from_row` example for attribute details and a runnable end-to-end
-//! example.
 //!
 //! ```rust,no_run
 //! # use snowflake_connector_rs::{

--- a/src/result/schema.rs
+++ b/src/result/schema.rs
@@ -250,27 +250,6 @@ impl Schema {
     pub fn column(&self, name: &str) -> std::result::Result<ColumnIndex, SchemaError> {
         lookup_result(name, self.indices.get(name))
     }
-
-    #[doc(hidden)]
-    pub fn column_by_name_ci(&self, name: &str) -> std::result::Result<ColumnIndex, SchemaError> {
-        let mut hits = Vec::new();
-        for col in self.columns.iter() {
-            if col.name().eq_ignore_ascii_case(name) {
-                hits.push(col.index());
-            }
-        }
-
-        match hits.len() {
-            0 => Err(SchemaError::MissingColumn {
-                name: Box::from(name),
-            }),
-            1 => Ok(hits[0]),
-            _ => Err(SchemaError::AmbiguousColumn {
-                name: Box::from(name),
-                candidates: hits.into_boxed_slice(),
-            }),
-        }
-    }
 }
 
 fn lookup_result(
@@ -360,60 +339,6 @@ mod tests {
                 );
             }
             other => panic!("expected label ambiguity, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn schema_name_ci_lookup_matches_lowercase_labels() {
-        let schema = Schema::from_columns(vec![Column::new(
-            "value",
-            0,
-            false,
-            ColumnType::Text { length: None },
-        )])
-        .unwrap();
-
-        assert_eq!(schema.column_by_name_ci("VALUE").unwrap().as_usize(), 0);
-        assert_eq!(schema.column_by_name_ci("value").unwrap().as_usize(), 0);
-    }
-
-    #[test]
-    fn schema_name_ci_lookup_reports_case_insensitive_ambiguity() {
-        let schema = Schema::from_columns(vec![
-            Column::new(
-                "ID",
-                0,
-                false,
-                ColumnType::Fixed {
-                    precision: None,
-                    scale: Some(0),
-                },
-            ),
-            Column::new(
-                "id",
-                1,
-                false,
-                ColumnType::Fixed {
-                    precision: None,
-                    scale: Some(0),
-                },
-            ),
-        ])
-        .unwrap();
-
-        let err = schema.column_by_name_ci("id").unwrap_err();
-        match err {
-            SchemaError::AmbiguousColumn { name, candidates } => {
-                assert_eq!(name.as_ref(), "id");
-                assert_eq!(
-                    candidates
-                        .iter()
-                        .map(|candidate| candidate.as_usize())
-                        .collect::<Vec<_>>(),
-                    vec![0, 1]
-                );
-            }
-            other => panic!("expected case-insensitive ambiguity, got {other:?}"),
         }
     }
 

--- a/tests/cases/test_derive.rs
+++ b/tests/cases/test_derive.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDateTime;
+
 use snowflake_connector_rs::{DecimalValue, Error, FromRow, Result, SchemaError};
 
 use super::common;
@@ -58,35 +59,31 @@ struct QuotedAliasRow {
 
 #[derive(Debug, FromRow, PartialEq)]
 #[snowflake(rename_all = "none")]
-struct LowercaseLabels {
-    name: String,
+struct SessionParameterRow {
+    key: String,
     value: String,
+    level: String,
+}
+
+#[derive(Debug, FromRow, PartialEq)]
+#[snowflake(by_position)]
+struct NamedByPosition {
+    id: i64,
+    label: String,
 }
 
 #[tokio::test]
-async fn derive_named_struct_decodes_query_results() -> Result<()> {
+async fn derive_named_lookup_variants_decode_expected_rows() -> Result<()> {
     let client = common::connect()?;
     let session = client.create_session().await?;
 
-    session
-        .query(
-            "CREATE TEMPORARY TABLE derive_users (
-                id NUMBER,
-                user_name STRING,
-                is_active BOOLEAN
-            )",
-        )
-        .await?;
-    session
-        .query(
-            "INSERT INTO derive_users VALUES
-                (1, 'alice', TRUE),
-                (2, 'bob',   FALSE)",
-        )
-        .await?;
-
     let users = session
-        .query_as::<UserRow, _>("SELECT id, user_name, is_active FROM derive_users ORDER BY id")
+        .query_as::<UserRow, _>(
+            "SELECT 1 AS id, 'alice' AS user_name, TRUE AS is_active
+             UNION ALL
+             SELECT 2 AS id, 'bob' AS user_name, FALSE AS is_active
+             ORDER BY 1",
+        )
         .await?
         .collect()
         .await?;
@@ -106,25 +103,84 @@ async fn derive_named_struct_decodes_query_results() -> Result<()> {
             },
         ]
     );
+
+    session.query("ALTER SESSION SET TIMEZONE = 'UTC'").await?;
+
+    let events = session
+        .query_as::<EventRow, _>(
+            "SELECT 1 AS id, '2024-01-01 00:00:00'::TIMESTAMP_NTZ AS created_at",
+        )
+        .await?
+        .collect()
+        .await?;
+
+    assert_eq!(
+        events,
+        vec![EventRow {
+            id: 1,
+            created_at: NaiveDateTime::parse_from_str("2024-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
+                .unwrap(),
+        }]
+    );
+
+    let prices = session
+        .query_as::<PriceRow, _>(
+            "SELECT 1 AS id, 99.99::DECIMAL(10,2) AS price
+             UNION ALL
+             SELECT 2 AS id, 149.99::DECIMAL(10,2) AS price
+             ORDER BY 1",
+        )
+        .await?
+        .collect()
+        .await?;
+
+    assert_eq!(
+        prices,
+        vec![
+            PriceRow {
+                id: 1,
+                price: DecimalValue::new("99.99", Some(10), Some(2)),
+            },
+            PriceRow {
+                id: 2,
+                price: DecimalValue::new("149.99", Some(10), Some(2)),
+            },
+        ]
+    );
+
+    let keywords = session
+        .query_as::<KeywordRow, _>("SELECT 1 AS TYPE")
+        .await?
+        .collect()
+        .await?;
+
+    assert_eq!(keywords, vec![KeywordRow { r#type: 1 }]);
+
+    let renamed = session
+        .query_as::<QuotedAliasRow, _>(r#"SELECT 1 AS "value""#)
+        .await?
+        .collect()
+        .await?;
+
+    assert_eq!(renamed, vec![QuotedAliasRow { v: 1 }]);
+
     Ok(())
 }
 
+#[derive(Debug, FromRow, PartialEq)]
+struct AmbiguousIdWithDefault {
+    /// `#[snowflake(default)]` must not swallow duplicate raw labels.
+    #[snowflake(default)]
+    id: Option<i64>,
+}
+
 #[tokio::test]
-async fn derive_default_attribute_handles_missing_column() -> Result<()> {
+async fn derive_default_behavior_distinguishes_missing_null_and_ambiguity() -> Result<()> {
     let client = common::connect()?;
     let session = client.create_session().await?;
 
-    session
-        .query("CREATE TEMPORARY TABLE derive_users_no_bio (id NUMBER, user_name STRING)")
-        .await?;
-    session
-        .query("INSERT INTO derive_users_no_bio VALUES (1, 'alice')")
-        .await?;
-
-    // `bio` is absent from the result schema; `#[snowflake(default)]` makes
-    // the field default to `None` instead of erroring.
     let users = session
-        .query_as::<UserWithDefault, _>("SELECT id, user_name FROM derive_users_no_bio")
+        .query_as::<UserWithDefault, _>("SELECT 1 AS id, 'alice' AS user_name")
         .await?
         .collect()
         .await?;
@@ -137,13 +193,6 @@ async fn derive_default_attribute_handles_missing_column() -> Result<()> {
             bio: None,
         }]
     );
-    Ok(())
-}
-
-#[tokio::test]
-async fn derive_default_attribute_handles_null_column() -> Result<()> {
-    let client = common::connect()?;
-    let session = client.create_session().await?;
 
     let users = session
         .query_as::<UserWithNullDefault, _>("SELECT 1 AS id, NULL::STRING AS bio")
@@ -158,130 +207,6 @@ async fn derive_default_attribute_handles_null_column() -> Result<()> {
             bio: String::new(),
         }]
     );
-    Ok(())
-}
-
-#[tokio::test]
-async fn derive_by_position_tuple_struct() -> Result<()> {
-    let client = common::connect()?;
-    let session = client.create_session().await?;
-
-    let rows = session
-        .query_as::<CountAndName, _>("SELECT 42, 'hi' UNION ALL SELECT 7, 'lo' ORDER BY 1 DESC")
-        .await?
-        .collect()
-        .await?;
-
-    assert_eq!(
-        rows,
-        vec![
-            CountAndName(42, "hi".to_string()),
-            CountAndName(7, "lo".to_string()),
-        ]
-    );
-    Ok(())
-}
-
-#[tokio::test]
-async fn derive_default_screaming_snake_case_mapping() -> Result<()> {
-    let client = common::connect()?;
-    let session = client.create_session().await?;
-
-    session.query("ALTER SESSION SET TIMEZONE = 'UTC'").await?;
-    session
-        .query(
-            "CREATE TEMPORARY TABLE derive_events (
-                id NUMBER,
-                created_at TIMESTAMP_NTZ
-            )",
-        )
-        .await?;
-    session
-        .query(
-            "INSERT INTO derive_events VALUES
-                (1, '2024-01-01 00:00:00')",
-        )
-        .await?;
-
-    let events = session
-        .query_as::<EventRow, _>("SELECT id, created_at FROM derive_events")
-        .await?
-        .collect()
-        .await?;
-
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].id, 1);
-    assert_eq!(
-        events[0].created_at,
-        NaiveDateTime::parse_from_str("2024-01-01 00:00:00", "%Y-%m-%d %H:%M:%S").unwrap()
-    );
-    Ok(())
-}
-
-#[tokio::test]
-async fn derive_decimal_value_field_decodes_query_results() -> Result<()> {
-    let client = common::connect()?;
-    let session = client.create_session().await?;
-
-    session
-        .query("CREATE TEMPORARY TABLE derive_prices (id NUMBER, price DECIMAL(10,2))")
-        .await?;
-    session
-        .query(
-            "INSERT INTO derive_prices VALUES
-                (1, 99.99),
-                (2, 149.99)",
-        )
-        .await?;
-
-    let rows = session
-        .query_as::<PriceRow, _>("SELECT id, price FROM derive_prices ORDER BY id")
-        .await?
-        .collect()
-        .await?;
-
-    assert_eq!(
-        rows,
-        vec![
-            PriceRow {
-                id: 1,
-                price: DecimalValue::new("99.99", Some(10), Some(2)),
-            },
-            PriceRow {
-                id: 2,
-                price: DecimalValue::new("149.99", Some(10), Some(2)),
-            },
-        ]
-    );
-    Ok(())
-}
-
-#[tokio::test]
-async fn derive_raw_identifier_uses_logical_field_name() -> Result<()> {
-    let client = common::connect()?;
-    let session = client.create_session().await?;
-
-    let rows = session
-        .query_as::<KeywordRow, _>("SELECT 1 AS TYPE")
-        .await?
-        .collect()
-        .await?;
-
-    assert_eq!(rows, vec![KeywordRow { r#type: 1 }]);
-    Ok(())
-}
-
-#[derive(Debug, FromRow, PartialEq)]
-struct AmbiguousIdWithDefault {
-    /// `#[snowflake(default)]` must not swallow duplicate raw labels.
-    #[snowflake(default)]
-    id: Option<i64>,
-}
-
-#[tokio::test]
-async fn derive_default_does_not_swallow_ambiguous_column() -> Result<()> {
-    let client = common::connect()?;
-    let session = client.create_session().await?;
 
     let err = session
         .query_as::<AmbiguousIdWithDefault, _>("SELECT 1 AS id, 2 AS ID")
@@ -297,36 +222,54 @@ async fn derive_default_does_not_swallow_ambiguous_column() -> Result<()> {
 }
 
 #[tokio::test]
-async fn derive_rename_resolves_quoted_lowercase_alias() -> Result<()> {
+async fn derive_nondefault_lookup_modes_cover_metadata_and_named_position_paths() -> Result<()> {
     let client = common::connect()?;
     let session = client.create_session().await?;
 
-    let rows = session
-        .query_as::<QuotedAliasRow, _>(r#"SELECT 1 AS "value""#)
-        .await?
-        .collect()
+    session
+        .query("ALTER SESSION SET TIMEZONE = 'Asia/Tokyo'")
         .await?;
 
-    assert_eq!(rows, vec![QuotedAliasRow { v: 1 }]);
-    Ok(())
-}
-
-#[tokio::test]
-async fn derive_rename_all_none_matches_lowercase_labels() -> Result<()> {
-    let client = common::connect()?;
-    let session = client.create_session().await?;
-
     let rows = session
-        .query_as::<LowercaseLabels, _>(r#"SELECT 'TIMEZONE' AS "name", 'Asia/Tokyo' AS "value""#)
+        .query_as::<SessionParameterRow, _>("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION")
         .await?
         .collect()
         .await?;
 
     assert_eq!(
         rows,
-        vec![LowercaseLabels {
-            name: "TIMEZONE".to_string(),
+        vec![SessionParameterRow {
+            key: "TIMEZONE".to_string(),
             value: "Asia/Tokyo".to_string(),
+            level: "SESSION".to_string(),
+        }]
+    );
+
+    let rows = session
+        .query_as::<CountAndName, _>("SELECT 42, 'hi' UNION ALL SELECT 7, 'lo' ORDER BY 1 DESC")
+        .await?
+        .collect()
+        .await?;
+
+    assert_eq!(
+        rows,
+        vec![
+            CountAndName(42, "hi".to_string()),
+            CountAndName(7, "lo".to_string()),
+        ]
+    );
+
+    let rows = session
+        .query_as::<NamedByPosition, _>(r#"SELECT 9, 'named row'"#)
+        .await?
+        .collect()
+        .await?;
+
+    assert_eq!(
+        rows,
+        vec![NamedByPosition {
+            id: 9,
+            label: "named row".to_string(),
         }]
     );
     Ok(())

--- a/tests/cases/test_derive.rs
+++ b/tests/cases/test_derive.rs
@@ -10,23 +10,23 @@ struct UserRow {
     #[snowflake(rename = "USER_NAME")]
     name: String,
     is_active: bool,
-}
-
-#[derive(Debug, FromRow, PartialEq)]
-struct UserWithDefault {
-    id: i64,
-    #[snowflake(rename = "USER_NAME")]
-    name: String,
-    /// `bio` doesn't exist in the result; `default` lets it materialise as None.
-    #[snowflake(default)]
     bio: Option<String>,
 }
 
 #[derive(Debug, FromRow, PartialEq)]
-struct UserWithNullDefault {
+struct RequiredNoteRow {
     id: i64,
-    #[snowflake(default)]
-    bio: String,
+    note: String,
+}
+
+#[derive(Debug, FromRow, PartialEq)]
+struct DefaultCaseValueRow {
+    value: i64,
+}
+
+#[derive(Debug, FromRow, PartialEq)]
+struct AmbiguousIdRow {
+    id: i64,
 }
 
 #[derive(Debug, FromRow, PartialEq)]
@@ -79,9 +79,9 @@ async fn derive_named_lookup_variants_decode_expected_rows() -> Result<()> {
 
     let users = session
         .query_as::<UserRow, _>(
-            "SELECT 1 AS id, 'alice' AS user_name, TRUE AS is_active
+            "SELECT 1 AS id, 'alice' AS user_name, TRUE AS is_active, NULL::STRING AS bio
              UNION ALL
-             SELECT 2 AS id, 'bob' AS user_name, FALSE AS is_active
+             SELECT 2 AS id, 'bob' AS user_name, FALSE AS is_active, 'hello' AS bio
              ORDER BY 1",
         )
         .await?
@@ -95,11 +95,13 @@ async fn derive_named_lookup_variants_decode_expected_rows() -> Result<()> {
                 id: 1,
                 name: "alice".to_string(),
                 is_active: true,
+                bio: None,
             },
             UserRow {
                 id: 2,
                 name: "bob".to_string(),
                 is_active: false,
+                bio: Some("hello".to_string()),
             },
         ]
     );
@@ -167,57 +169,73 @@ async fn derive_named_lookup_variants_decode_expected_rows() -> Result<()> {
     Ok(())
 }
 
-#[derive(Debug, FromRow, PartialEq)]
-struct AmbiguousIdWithDefault {
-    /// `#[snowflake(default)]` must not swallow duplicate raw labels.
-    #[snowflake(default)]
-    id: Option<i64>,
-}
-
 #[tokio::test]
-async fn derive_default_behavior_distinguishes_missing_null_and_ambiguity() -> Result<()> {
+async fn derive_required_fields_surface_schema_and_decode_errors() -> Result<()> {
     let client = common::connect()?;
     let session = client.create_session().await?;
 
-    let users = session
-        .query_as::<UserWithDefault, _>("SELECT 1 AS id, 'alice' AS user_name")
-        .await?
-        .collect()
-        .await?;
-
-    assert_eq!(
-        users,
-        vec![UserWithDefault {
-            id: 1,
-            name: "alice".to_string(),
-            bio: None,
-        }]
-    );
-
-    let users = session
-        .query_as::<UserWithNullDefault, _>("SELECT 1 AS id, NULL::STRING AS bio")
-        .await?
-        .collect()
-        .await?;
-
-    assert_eq!(
-        users,
-        vec![UserWithNullDefault {
-            id: 1,
-            bio: String::new(),
-        }]
-    );
-
     let err = session
-        .query_as::<AmbiguousIdWithDefault, _>("SELECT 1 AS id, 2 AS ID")
+        .query_as::<UserRow, _>("SELECT 1 AS id, 'alice' AS user_name, TRUE AS is_active")
         .await
         .err()
-        .expect("duplicate raw labels should not silently default");
+        .expect("missing named column should fail during plan building");
+
+    match err {
+        Error::Schema(SchemaError::MissingColumn { name }) => assert_eq!(name.as_ref(), "BIO"),
+        other => panic!("expected MissingColumn, got: {other:?}"),
+    }
+
+    let err = session
+        .query_as::<DefaultCaseValueRow, _>(r#"SELECT 1 AS "value""#)
+        .await
+        .err()
+        .expect("default lookup should not match lowercase quoted labels");
+
+    match err {
+        Error::Schema(SchemaError::MissingColumn { name }) => assert_eq!(name.as_ref(), "VALUE"),
+        other => panic!("expected MissingColumn, got: {other:?}"),
+    }
+
+    let err = session
+        .query_as::<CountAndName, _>("SELECT 42")
+        .await
+        .err()
+        .expect("short positional row should fail during plan building");
+
+    match err {
+        Error::Schema(SchemaError::ColumnCountMismatch { expected, actual }) => {
+            assert_eq!(expected, 2);
+            assert_eq!(actual, 1);
+        }
+        other => panic!("expected ColumnCountMismatch, got: {other:?}"),
+    }
+
+    let err = session
+        .query_as::<RequiredNoteRow, _>("SELECT 1 AS id, NULL::STRING AS note")
+        .await?
+        .collect()
+        .await
+        .expect_err("non-Option NULL should surface the decode error");
+
+    match err {
+        Error::Decode(err) => {
+            assert_eq!(err.column_name(), "NOTE");
+            assert_eq!(err.reason(), "value is NULL");
+        }
+        other => panic!("expected Decode error, got: {other:?}"),
+    }
+
+    let err = session
+        .query_as::<AmbiguousIdRow, _>("SELECT 1 AS id, 2 AS ID")
+        .await
+        .err()
+        .expect("duplicate raw labels should fail during plan building");
 
     match err {
         Error::Schema(SchemaError::AmbiguousColumn { .. }) => {}
         other => panic!("expected AmbiguousColumn, got: {other:?}"),
     }
+
     Ok(())
 }
 

--- a/tests/cases/test_derive.rs
+++ b/tests/cases/test_derive.rs
@@ -56,6 +56,13 @@ struct QuotedAliasRow {
     v: i64,
 }
 
+#[derive(Debug, FromRow, PartialEq)]
+#[snowflake(rename_all = "none")]
+struct LowercaseLabels {
+    name: String,
+    value: String,
+}
+
 #[tokio::test]
 async fn derive_named_struct_decodes_query_results() -> Result<()> {
     let client = common::connect()?;
@@ -266,9 +273,7 @@ async fn derive_raw_identifier_uses_logical_field_name() -> Result<()> {
 
 #[derive(Debug, FromRow, PartialEq)]
 struct AmbiguousIdWithDefault {
-    /// `id` resolves through derive's temporary case-insensitive compatibility
-    /// lookup. If the result schema contains two labels that differ only by
-    /// ASCII case, `#[snowflake(default)]` must NOT swallow that ambiguity.
+    /// `#[snowflake(default)]` must not swallow duplicate raw labels.
     #[snowflake(default)]
     id: Option<i64>,
 }
@@ -279,10 +284,10 @@ async fn derive_default_does_not_swallow_ambiguous_column() -> Result<()> {
     let session = client.create_session().await?;
 
     let err = session
-        .query_as::<AmbiguousIdWithDefault, _>(r#"SELECT 1 AS id, 2 AS "id""#)
+        .query_as::<AmbiguousIdWithDefault, _>("SELECT 1 AS id, 2 AS ID")
         .await
         .err()
-        .expect("ambiguous case-insensitive lookup should not silently default");
+        .expect("duplicate raw labels should not silently default");
 
     match err {
         Error::Schema(SchemaError::AmbiguousColumn { .. }) => {}
@@ -303,5 +308,26 @@ async fn derive_rename_resolves_quoted_lowercase_alias() -> Result<()> {
         .await?;
 
     assert_eq!(rows, vec![QuotedAliasRow { v: 1 }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn derive_rename_all_none_matches_lowercase_labels() -> Result<()> {
+    let client = common::connect()?;
+    let session = client.create_session().await?;
+
+    let rows = session
+        .query_as::<LowercaseLabels, _>(r#"SELECT 'TIMEZONE' AS "name", 'Asia/Tokyo' AS "value""#)
+        .await?
+        .collect()
+        .await?;
+
+    assert_eq!(
+        rows,
+        vec![LowercaseLabels {
+            name: "TIMEZONE".to_string(),
+            value: "Asia/Tokyo".to_string(),
+        }]
+    );
     Ok(())
 }

--- a/tests/derive_compile_fail/by_position_with_rename_all_none.rs
+++ b/tests/derive_compile_fail/by_position_with_rename_all_none.rs
@@ -1,0 +1,7 @@
+use snowflake_connector_rs::FromRow;
+
+#[derive(FromRow)]
+#[snowflake(by_position, rename_all = "none")]
+struct Bad(i64, String);
+
+fn main() {}

--- a/tests/derive_compile_fail/by_position_with_rename_all_none.stderr
+++ b/tests/derive_compile_fail/by_position_with_rename_all_none.stderr
@@ -1,0 +1,5 @@
+error: `by_position` cannot be combined with `rename_all`
+ --> tests/derive_compile_fail/by_position_with_rename_all_none.rs:5:8
+  |
+5 | struct Bad(i64, String);
+  |        ^^^

--- a/tests/derive_compile_fail/duplicate_default.rs
+++ b/tests/derive_compile_fail/duplicate_default.rs
@@ -1,9 +1,0 @@
-use snowflake_connector_rs::FromRow;
-
-#[derive(FromRow)]
-struct Bad {
-    #[snowflake(default, default)]
-    x: Option<String>,
-}
-
-fn main() {}

--- a/tests/derive_compile_fail/duplicate_default.stderr
+++ b/tests/derive_compile_fail/duplicate_default.stderr
@@ -1,5 +1,0 @@
-error: duplicate `default`
- --> tests/derive_compile_fail/duplicate_default.rs:5:26
-  |
-5 |     #[snowflake(default, default)]
-  |                          ^^^^^^^

--- a/tests/derive_compile_fail/field_by_position_rejected.rs
+++ b/tests/derive_compile_fail/field_by_position_rejected.rs
@@ -1,11 +1,9 @@
 use snowflake_connector_rs::FromRow;
 
 #[derive(FromRow)]
-#[snowflake(rename_all = "SCREAMING_SNAKE_CASE")]
 struct Bad {
-    id: i64,
     #[snowflake(by_position)]
-    name: String,
+    id: i64,
 }
 
 fn main() {}

--- a/tests/derive_compile_fail/field_by_position_rejected.stderr
+++ b/tests/derive_compile_fail/field_by_position_rejected.stderr
@@ -1,0 +1,5 @@
+error: field-level `by_position` is not supported; use container-level `#[snowflake(by_position)]` instead
+ --> tests/derive_compile_fail/field_by_position_rejected.rs:5:17
+  |
+5 |     #[snowflake(by_position)]
+  |                 ^^^^^^^^^^^

--- a/tests/derive_compile_fail/field_by_position_with_rename_all.stderr
+++ b/tests/derive_compile_fail/field_by_position_with_rename_all.stderr
@@ -1,5 +1,0 @@
-error: field `by_position` cannot be combined with container `rename_all`
- --> tests/derive_compile_fail/field_by_position_with_rename_all.rs:7:5
-  |
-7 |     #[snowflake(by_position)]
-  |     ^

--- a/tests/derive_compile_fail/tuple_struct_with_rename_all_none.rs
+++ b/tests/derive_compile_fail/tuple_struct_with_rename_all_none.rs
@@ -1,0 +1,7 @@
+use snowflake_connector_rs::FromRow;
+
+#[derive(FromRow)]
+#[snowflake(rename_all = "none")]
+struct Bad(i64, String);
+
+fn main() {}

--- a/tests/derive_compile_fail/tuple_struct_with_rename_all_none.stderr
+++ b/tests/derive_compile_fail/tuple_struct_with_rename_all_none.stderr
@@ -1,0 +1,5 @@
+error: `rename_all` cannot be applied to a tuple struct (implicit `by_position`)
+ --> tests/derive_compile_fail/tuple_struct_with_rename_all_none.rs:5:11
+  |
+5 | struct Bad(i64, String);
+  |           ^^^^^^^^^^^^^

--- a/tests/derive_compile_fail/unsupported_rename_all_value.rs
+++ b/tests/derive_compile_fail/unsupported_rename_all_value.rs
@@ -1,0 +1,9 @@
+use snowflake_connector_rs::FromRow;
+
+#[derive(FromRow)]
+#[snowflake(rename_all = "snake_case")]
+struct Bad {
+    value: i64,
+}
+
+fn main() {}

--- a/tests/derive_compile_fail/unsupported_rename_all_value.stderr
+++ b/tests/derive_compile_fail/unsupported_rename_all_value.stderr
@@ -1,0 +1,5 @@
+error: only `rename_all = "SCREAMING_SNAKE_CASE"` or `"none"` is supported
+ --> tests/derive_compile_fail/unsupported_rename_all_value.rs:4:13
+  |
+4 | #[snowflake(rename_all = "snake_case")]
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/derive_compile_pass/rename_all_none.rs
+++ b/tests/derive_compile_pass/rename_all_none.rs
@@ -1,0 +1,14 @@
+use snowflake_connector_rs::FromRow;
+
+#[derive(FromRow)]
+#[snowflake(rename_all = "none")]
+struct LowercaseRow {
+    value: i64,
+}
+
+fn assert_from_row<T: snowflake_connector_rs::FromRow>() {}
+
+fn main() {
+    let _ = LowercaseRow { value: 1 };
+    assert_from_row::<LowercaseRow>();
+}


### PR DESCRIPTION
## FromRow Derive Design

### Name Resolution Rules

`FromRow` derive resolves fields in named structs against Snowflake raw result labels using case-sensitive exact matching.
Because Snowflake returns unquoted aliases as uppercase raw labels, ordinary SELECT statements work with the default settings.

```rust
#[derive(FromRow)]
struct UserRow {
    id: i64,              // raw label "ID"
    user_name: String,    // raw label "USER_NAME"
}
```

### Field Name Conversion

For named structs, choose the field-name-to-raw-label conversion with a container attribute.

| Attribute | Behavior | Main Use Case |
| --- | --- | --- |
| none / `#[snowflake(rename_all = "SCREAMING_SNAKE_CASE")]` | Resolves `created_at` as `"CREATED_AT"` | Ordinary SELECT statements |
| `#[snowflake(rename_all = "none")]` | Resolves each field name as the raw label unchanged | `SHOW` / `DESCRIBE` output with lowercase labels, quoted aliases |

When `rename_all` is not specified, the default is `SCREAMING_SNAKE_CASE`.

```rust
#[derive(FromRow)]
#[snowflake(rename_all = "none")]
struct ShowParameter {
    key: String,      // raw label "key"
    value: String,    // raw label "value"
}
```

Use `rename` when a field needs to specify its raw label directly. `rename` takes precedence over the container-level `rename_all`.

```rust
#[derive(FromRow)]
struct DisplayRow {
    #[snowflake(rename = "display name")]
    display_name: String,
}
```

### Position Decode

Tuple structs always decode by ordinal. No attribute is required.

```rust
#[derive(FromRow)]
struct Pair(i64, String);
```

Use container-level `by_position` when a named struct should decode by ordinal.

```rust
#[derive(FromRow)]
#[snowflake(by_position)]
struct PairRow {
    id: i64,
    label: String,
}
```

`rename_all` cannot be combined with `by_position`.
Also, `rename_all` cannot be applied to tuple structs.

### Attribute List

container-level:

- `rename_all = "SCREAMING_SNAKE_CASE"`
- `rename_all = "none"`
- `by_position`
- `crate = "::path"`

field-level:

- `rename = "..."`
