### PR TITLE
perf: add DynamicRow direct cell fast path

### DIFF
--- a/benches/result_table.rs
+++ b/benches/result_table.rs
@@ -14,13 +14,27 @@ use snowflake_connector_rs::bench_support::{
     decode_gzip_chunk, make_result_table_from_rows, make_schema, parse_remote_chunk_result_table,
     parse_remote_chunk_result_table_async_with_workload, parse_statement_envelope,
 };
-use snowflake_connector_rs::{ColumnType, DynamicRow, Schema};
+use snowflake_connector_rs::{ColumnType, DynamicRow, ResultTable, Schema};
 
 #[derive(snowflake_connector_rs::FromRow)]
 struct BenchRow {
     id: i64,
     name: String,
     ts: NaiveDateTime,
+}
+
+type BenchTuple = (i64, String, NaiveDateTime);
+
+fn materialize_tuple_rows(table: &ResultTable) {
+    for row in table.rows::<BenchTuple>().unwrap() {
+        black_box(row.unwrap());
+    }
+}
+
+fn materialize_dynamic_rows(table: &ResultTable) {
+    for row in table.dynamic_rows().unwrap() {
+        black_box(row.unwrap());
+    }
 }
 
 fn synthetic_chunk_bytes(row_count: usize, null_pct: u8, escaped_pct: u8) -> Bytes {
@@ -290,6 +304,24 @@ fn bench_decode_dynamic(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_decode_compare(c: &mut Criterion) {
+    let mut group = c.benchmark_group("table_rows_decode_compare");
+    let schema = build_schema();
+    for &rows in &[1_000usize, 10_000, 100_000] {
+        let bytes = synthetic_chunk_bytes(rows, 0, 0);
+        let table = parse_remote_chunk_result_table(Arc::clone(&schema), Arc::from("bench"), bytes)
+            .unwrap();
+        group.throughput(Throughput::Elements(rows as u64));
+        group.bench_with_input(BenchmarkId::new("tuple", rows), &table, |b, table| {
+            b.iter(|| materialize_tuple_rows(table))
+        });
+        group.bench_with_input(BenchmarkId::new("dynamic", rows), &table, |b, table| {
+            b.iter(|| materialize_dynamic_rows(table))
+        });
+    }
+    group.finish();
+}
+
 fn bench_make_result_table_from_rows(c: &mut Criterion) {
     let schema = build_schema();
     let rows = (0..10_000)
@@ -318,6 +350,7 @@ criterion_group!(
     bench_decode_tuple,
     bench_decode_derive,
     bench_decode_dynamic,
+    bench_decode_compare,
     bench_make_result_table_from_rows,
 );
 criterion_main!(benches);

--- a/src/result/dynamic.rs
+++ b/src/result/dynamic.rs
@@ -193,8 +193,8 @@ impl FromRow for DynamicRow {
 
     fn from_row_with_plan(row: RowRef<'_>, plan: &Self::Plan) -> Result<Self> {
         let mut values = Vec::with_capacity(plan.len());
-        for col in plan.columns() {
-            let cell = row.cell(col.index())?;
+        for (offset, col) in plan.columns().iter().enumerate() {
+            let cell = row.cell_at_offset(col, offset);
             values.push(decode_dynamic(cell)?);
         }
 

--- a/src/result/row.rs
+++ b/src/result/row.rs
@@ -7,7 +7,7 @@ use crate::{
         decode::{FromCell, FromRow},
         plan::RowPlanContext,
         result_table::{ResultTable, ResultTableStorage},
-        schema::{ColumnIndex, Schema},
+        schema::{Column, ColumnIndex, Schema},
     },
 };
 
@@ -41,6 +41,21 @@ impl<'a> RowRef<'a> {
             column,
             raw,
         })
+    }
+
+    // A fast path for DynamicRow.
+    // DynamicRow has columns in the correct order, so it can skip column lookups in `cell()`.
+    pub(crate) fn cell_at_offset(self, column: &'a Column, offset: usize) -> CellRef<'a> {
+        debug_assert_eq!(column.index().as_usize(), offset);
+
+        let cell = self.block.cell(self.local_row, offset);
+        let raw = self.block.cell_text(cell);
+
+        CellRef {
+            row: self.global_row,
+            column,
+            raw,
+        }
     }
 
     pub fn get<T: FromCell>(self, index: ColumnIndex) -> Result<T> {
@@ -133,7 +148,7 @@ mod tests {
 
     use crate::result::{
         ColumnType,
-        result_table::ResultTable,
+        result_table::{ResultTable, ResultTableStorage},
         test_data::{make_result_table_from_rows, make_schema},
     };
 
@@ -179,6 +194,45 @@ mod tests {
             assert_eq!(rows.len(), 2);
             rows.next().unwrap().unwrap();
             assert_eq!(rows.len(), 1);
+        }
+    }
+
+    #[test]
+    fn cell_at_offset_matches_checked_cell_path() {
+        let schema = make_schema(vec![
+            (
+                "ID".to_string(),
+                ColumnType::Fixed {
+                    precision: None,
+                    scale: Some(0),
+                },
+                false,
+            ),
+            ("NAME".to_string(), ColumnType::Text { length: None }, true),
+        ]);
+        let table = make_result_table_from_rows(
+            schema,
+            vec![vec![Some("1".to_string()), Some("alice".to_string())]],
+        )
+        .unwrap();
+
+        let block = match table.storage() {
+            ResultTableStorage::Single(block) => block.as_ref(),
+            ResultTableStorage::Chunks(_) => panic!("expected single block"),
+        };
+        let row = super::RowRef {
+            table: &table,
+            block,
+            global_row: 0,
+            local_row: 0,
+        };
+
+        for (offset, column) in table.schema().columns().iter().enumerate() {
+            let direct = row.cell_at_offset(column, offset);
+            let checked = row.cell(column.index()).unwrap();
+            assert_eq!(direct.raw(), checked.raw());
+            assert_eq!(direct.column().name(), checked.column().name());
+            assert_eq!(direct.row(), checked.row());
         }
     }
 }


### PR DESCRIPTION
## Summary

Added an internal fast path to `DynamicRow` row materialization that reads cells directly using the already-known schema order.
This avoids the extra column lookup that was previously performed for each column, resulting in a small performance improvement.

## Benchmark

Comparison command:

```bash
cargo bench --bench result_table --features bench-internals -- --noplot table_rows_decode_compare
```

Key results:

| rows | baseline dynamic | fast path dynamic | improvement |
| --- | ---: | ---: | ---: |
| 1,000 | 110.47 us | 109.18 us | -1.2% |
| 10,000 | 1.1031 ms | 1.0830 ms | -1.8% |
| 100,000 | 11.378 ms | 11.258 ms | -1.1% |
