### PR TITLE
refactor(error)!: redesign public error types around ErrorKind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,6 @@ dependencies = [
  "shell-words",
  "snowflake-connector-rs-derive",
  "socket2",
- "thiserror 2.0.18",
  "tokio",
  "trybuild",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ serde_json = { version = "1.0", features = [
     "raw_value",
 ] }
 sha2 = "0.11"
-thiserror = "2.0"
 tokio = { version = "1.52", features = [
     "rt",
     "sync",

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -60,12 +60,12 @@ fn build_plan_line(field: &FieldInfo, crate_path: &syn::Path) -> TokenStream2 {
             let pos_lit = syn::Index::from(*pos);
             quote! {
                 if schema.len() <= #pos_lit {
-                    return ::core::result::Result::Err(#crate_path::Error::Schema(
-                        #crate_path::SchemaError::ColumnCountMismatch {
-                            expected: #pos_lit + 1,
-                            actual: schema.len(),
-                        }
-                    ));
+                    return ::core::result::Result::Err(
+                        #crate_path::SchemaError::ColumnCountMismatch(
+                            #crate_path::ColumnCountMismatchError::new(#pos_lit + 1, schema.len())
+                        )
+                        .into()
+                    );
                 }
                 let #ident = schema.columns()[#pos_lit].index();
             }

--- a/examples/derive_from_row.rs
+++ b/examples/derive_from_row.rs
@@ -188,10 +188,10 @@ fn connect_with_configs(
     if let Some(host) = host {
         let scheme = protocol.unwrap_or_else(|| "https".to_string());
         let mut url = Url::parse(&format!("{scheme}://{host}"))
-            .map_err(|e| snowflake_connector_rs::Error::Url(e.to_string()))?;
+            .map_err(|e| snowflake_connector_rs::Error::other(e.to_string()))?;
         if let Some(port) = port {
             url.set_port(Some(port))
-                .map_err(|_| snowflake_connector_rs::Error::Url("invalid base url port".into()))?;
+                .map_err(|_| snowflake_connector_rs::Error::other("invalid base url port"))?;
         }
         client_config = client_config.with_endpoint(SnowflakeEndpointConfig::custom_base_url(url));
     }

--- a/src/auth/external_browser.rs
+++ b/src/auth/external_browser.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
 use reqwest::{Client, Url};
 use serde::Deserialize;
@@ -12,8 +12,11 @@ mod manual_input_unix;
 mod manual_redirect_input;
 mod payload;
 
-use crate::auth::client::AUTH_REQUEST_TIMEOUT;
-use crate::{Error, Result};
+use crate::{
+    Result,
+    auth::client::AUTH_REQUEST_TIMEOUT,
+    error::{AuthError, ConfigError, NetworkError, ProtocolError, TimeoutError},
+};
 
 use launcher::{BrowserLauncher, LaunchOutcome, SystemCommandRunner};
 use listener::{CallbackWaitError, ListenerConfig, RunningListener, spawn_listener};
@@ -25,6 +28,7 @@ pub use config::{
 };
 
 const EXTERNAL_BROWSER_CALLBACK_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+const ALLOWED_BROWSER_URL_SCHEMES: &[&str] = &["http", "https"];
 
 pub(crate) struct ExternalBrowserResult {
     pub(crate) token: String,
@@ -81,9 +85,9 @@ async fn run_external_browser_flow_with_listener(
         config_with_listener.callback_socket_port(),
         "http".to_string(),
     );
-    let listener = spawn_listener(listener_config)
-        .await
-        .map_err(|e| Error::Communication(e.to_string()))?;
+    let listener = spawn_listener(listener_config).await.map_err(|e| {
+        AuthError::external_browser_with_source("failed to spawn callback listener", e)
+    })?;
     let redirect_port = listener.redirect_port();
 
     let auth =
@@ -103,8 +107,12 @@ async fn run_external_browser_flow_with_listener(
         return Err(err);
     }
 
-    let payload =
-        resolve_payload_with_listener(listener, EXTERNAL_BROWSER_CALLBACK_WAIT_TIMEOUT).await?;
+    let payload = resolve_payload_with_listener_with_fallback(
+        listener,
+        EXTERNAL_BROWSER_CALLBACK_WAIT_TIMEOUT,
+        manual_redirect_input::manual_token_flow,
+    )
+    .await?;
     Ok(ExternalBrowserResult::new(payload.token, auth.proof_key))
 }
 
@@ -138,7 +146,9 @@ async fn request_external_browser_challenge(
     base_url: &Url,
     redirect_port: u16,
 ) -> Result<ExternalBrowserChallenge> {
-    let url = base_url.join("session/authenticator-request")?;
+    let url = base_url
+        .join("session/authenticator-request")
+        .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
 
     let body = challenge_request_body(username, account, redirect_port);
 
@@ -147,38 +157,76 @@ async fn request_external_browser_challenge(
         .timeout(AUTH_REQUEST_TIMEOUT)
         .json(&body)
         .send()
-        .await?;
+        .await
+        .map_err(NetworkError::request)?;
     let status = resp.status();
-    let text = resp.text().await?;
+    let text = resp.text().await.map_err(NetworkError::request)?;
     if !status.is_success() {
-        return Err(Error::Communication(format!("HTTP {status}: {text}")));
+        return Err(NetworkError::http_status(status.as_u16(), text.as_bytes()).into());
     }
 
-    let parsed: ExternalBrowserChallengeResponse =
-        serde_json::from_str(&text).map_err(|e| Error::Json(e, text.clone()))?;
-    if !parsed.success {
-        return Err(Error::Communication(parsed.message.unwrap_or_default()));
-    }
+    parse_external_browser_challenge_response(&text)
+}
 
-    let data = parsed
-        .data
-        .ok_or_else(|| Error::Communication("missing challenge response data".to_string()))?;
-    Ok(data)
+#[derive(Debug)]
+struct ExternalBrowserChallenge {
+    sso_url: Url,
+    proof_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-struct ExternalBrowserChallenge {
+struct RawExternalBrowserChallenge {
     #[serde(rename = "ssoUrl")]
-    sso_url: String,
+    sso_url: Option<String>,
     #[serde(rename = "proofKey")]
     proof_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct ExternalBrowserChallengeResponse {
-    data: Option<ExternalBrowserChallenge>,
+    data: Option<RawExternalBrowserChallenge>,
     message: Option<String>,
     success: bool,
+}
+
+fn parse_external_browser_challenge_response(body: &str) -> Result<ExternalBrowserChallenge> {
+    let parsed: ExternalBrowserChallengeResponse =
+        serde_json::from_str(body).map_err(|e| ProtocolError::json_parse(e, body))?;
+    if !parsed.success {
+        return Err(AuthError::login_rejected(parsed.message).into());
+    }
+
+    let data = parsed
+        .data
+        .ok_or_else(|| ProtocolError::missing_field("data"))?;
+
+    let sso_url = data
+        .sso_url
+        .ok_or_else(|| ProtocolError::missing_field("data.ssoUrl"))?;
+
+    if sso_url.trim().is_empty() {
+        return Err(ProtocolError::invalid_field("data.ssoUrl", "must not be empty").into());
+    }
+
+    let sso_url = Url::parse(&sso_url)
+        .map_err(|e| ProtocolError::invalid_response_url("data.ssoUrl", &sso_url, e))?;
+
+    if !ALLOWED_BROWSER_URL_SCHEMES.contains(&sso_url.scheme()) {
+        return Err(ProtocolError::invalid_field(
+            "data.ssoUrl",
+            format!(
+                "unsupported URL scheme '{}' (expected one of: {})",
+                sso_url.scheme(),
+                ALLOWED_BROWSER_URL_SCHEMES.join(", ")
+            ),
+        )
+        .into());
+    }
+
+    Ok(ExternalBrowserChallenge {
+        sso_url,
+        proof_key: data.proof_key,
+    })
 }
 
 fn challenge_request_body(username: &str, account: &str, redirect_port: u16) -> serde_json::Value {
@@ -193,19 +241,21 @@ fn challenge_request_body(username: &str, account: &str, redirect_port: u16) -> 
     })
 }
 
-fn open_auth_page(sso_url: &str, mode: BrowserLaunchMode) -> Result<()> {
+fn open_auth_page(sso_url: &Url, mode: BrowserLaunchMode) -> Result<()> {
     match mode {
         BrowserLaunchMode::Manual => {
             eprintln!(
                 "{}",
-                BrowserLauncher::<SystemCommandRunner>::manual_open_message(sso_url)
+                BrowserLauncher::<SystemCommandRunner>::manual_open_message(sso_url.as_str())
             );
             Ok(())
         }
         BrowserLaunchMode::Auto => {
             let outcome = BrowserLauncher::new()
-                .open(sso_url)
-                .map_err(|err| Error::Communication(format!("failed to open browser: {err}")))?;
+                .open(sso_url.as_str())
+                .map_err(|err| {
+                    AuthError::external_browser_with_source("failed to open browser", err)
+                })?;
 
             if let LaunchOutcome::ManualOpen { url } = outcome {
                 eprintln!(
@@ -218,24 +268,137 @@ fn open_auth_page(sso_url: &str, mode: BrowserLaunchMode) -> Result<()> {
     }
 }
 
-async fn resolve_payload_with_listener(
+async fn resolve_payload_with_listener_with_fallback<F, Fut>(
     mut listener: RunningListener,
     timeout: Duration,
-) -> Result<BrowserCallbackPayload> {
+    manual_fallback: F,
+) -> Result<BrowserCallbackPayload>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<BrowserCallbackPayload>>,
+{
     let callback_result = listener.wait_for_payload(timeout).await;
     listener.shutdown().await;
+    let mut manual_fallback = Some(manual_fallback);
 
     match callback_result {
         Ok(payload) => Ok(payload),
         Err(CallbackWaitError::TimedOut) => {
-            eprintln!("Callback was not received in time. Falling back to manual URL input.");
-            manual_redirect_input::manual_token_flow().await
+            let timeout_error: crate::Error = TimeoutError::browser_callback().into();
+            eprintln!("{timeout_error}. Continue with manual URL input.");
+            manual_fallback
+                .take()
+                .expect("manual fallback is available")()
+            .await
         }
         Err(CallbackWaitError::ListenerStopped) => {
             eprintln!(
                 "Local callback listener stopped before receiving token. Continue with manual URL input."
             );
-            manual_redirect_input::manual_token_flow().await
+            manual_fallback
+                .take()
+                .expect("manual fallback is available")()
+            .await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::Ipv4Addr, time::Duration};
+
+    use super::*;
+    use crate::ErrorKind;
+
+    #[test]
+    fn parse_external_browser_challenge_missing_data_is_protocol_error() {
+        let err = parse_external_browser_challenge_response(r#"{"success":true}"#).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(err.snowflake_message(), None);
+    }
+
+    #[test]
+    fn parse_external_browser_challenge_missing_sso_url_is_protocol_error() {
+        let err =
+            parse_external_browser_challenge_response(r#"{"success":true,"data":{}}"#).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "missing required field in Snowflake response: data.ssoUrl"
+        );
+    }
+
+    #[test]
+    fn parse_external_browser_challenge_empty_sso_url_is_protocol_error() {
+        let err = parse_external_browser_challenge_response(
+            r#"{"success":true,"data":{"ssoUrl":"   "}}"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "invalid Snowflake response field data.ssoUrl: must not be empty"
+        );
+    }
+
+    #[test]
+    fn parse_external_browser_challenge_invalid_sso_url_is_protocol_error() {
+        let err = parse_external_browser_challenge_response(
+            r#"{"success":true,"data":{"ssoUrl":"http://[::1"}}"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert!(err.to_string().contains("data.ssoUrl"));
+    }
+
+    #[test]
+    fn parse_external_browser_challenge_rejects_non_http_schemes() {
+        for raw in ["javascript:alert(1)", "file:///tmp/token.txt"] {
+            let body = format!(r#"{{"success":true,"data":{{"ssoUrl":"{raw}"}}}}"#);
+            let err = parse_external_browser_challenge_response(&body)
+                .expect_err("non-http scheme must fail");
+
+            assert_eq!(err.kind(), ErrorKind::Protocol);
+            assert!(err.to_string().contains("unsupported URL scheme"));
+        }
+    }
+
+    #[test]
+    fn parse_external_browser_challenge_rejected_without_message_preserves_absence() {
+        let err = parse_external_browser_challenge_response(r#"{"success":false}"#).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Auth);
+        assert_eq!(err.snowflake_message(), None);
+        assert_eq!(err.to_string(), "authentication rejected");
+    }
+
+    #[tokio::test]
+    async fn callback_wait_timeout_falls_back_to_manual_input() {
+        let listener = spawn_listener(ListenerConfig::new(
+            Some("test-app".to_string()),
+            Ipv4Addr::LOCALHOST.into(),
+            0,
+            "http".to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let expected = BrowserCallbackPayload {
+            token: "fallback-token".to_string(),
+            consent: Some(true),
+        };
+        let payload =
+            resolve_payload_with_listener_with_fallback(listener, Duration::from_millis(10), {
+                let expected = expected.clone();
+                move || async move { Ok(expected) }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(payload, expected);
     }
 }

--- a/src/auth/external_browser/launcher.rs
+++ b/src/auth/external_browser/launcher.rs
@@ -3,7 +3,6 @@ use std::io;
 use std::process::{Command, Stdio};
 
 use indexmap::IndexSet;
-use thiserror::Error;
 
 /// Result of attempting to launch a browser.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,11 +13,20 @@ pub(crate) enum LaunchOutcome {
     ManualOpen { url: String },
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub(crate) enum BrowserError {
-    #[error("URL must not be empty")]
     EmptyUrl,
 }
+
+impl std::fmt::Display for BrowserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyUrl => f.write_str("URL must not be empty"),
+        }
+    }
+}
+
+impl std::error::Error for BrowserError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Platform {

--- a/src/auth/external_browser/manual_input_unix.rs
+++ b/src/auth/external_browser/manual_input_unix.rs
@@ -4,7 +4,7 @@ use std::ops::ControlFlow;
 use nix::sys::termios::{self, LocalFlags, SetArg, SpecialCharacterIndices, Termios};
 
 use super::manual_redirect_input::validate_redirected_url_input;
-use crate::{Error, Result};
+use crate::{Result, error::AuthError};
 
 pub(super) fn try_read_redirected_url_line_noncanonical() -> Option<Result<String>> {
     let stdin = io::stdin();
@@ -34,7 +34,7 @@ fn read_line_noncanonical() -> Result<String> {
     loop {
         let n = handle
             .read(&mut buf)
-            .map_err(|e| Error::Communication(format!("failed to read input: {e}")))?;
+            .map_err(|e| AuthError::external_browser_with_source("failed to read input", e))?;
         if n == 0 {
             break;
         }
@@ -76,8 +76,10 @@ fn apply_chunk_to_line(initial: Vec<u8>, chunk: &[u8]) -> LineChunkState {
 }
 
 fn bytes_to_utf8(bytes: Vec<u8>) -> Result<String> {
-    String::from_utf8(bytes)
-        .map_err(|e| Error::Communication(format!("redirected URL is not valid UTF-8: {e}")))
+    String::from_utf8(bytes).map_err(|e| {
+        AuthError::external_browser_with_source("redirected URL input was not valid UTF-8", e)
+            .into()
+    })
 }
 
 struct NonCanonicalModeGuard {
@@ -112,6 +114,7 @@ fn nix_error_to_io(err: nix::errno::Errno) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ErrorKind;
 
     #[test]
     fn apply_chunk_to_line_accumulates_without_newline() {
@@ -149,6 +152,7 @@ mod tests {
     #[test]
     fn bytes_to_utf8_rejects_invalid_utf8() {
         let err = bytes_to_utf8(vec![0xff]).unwrap_err();
-        assert!(format!("{err}").contains("not valid UTF-8"));
+        assert_eq!(err.kind(), ErrorKind::Auth);
+        assert!(format!("{err}").contains("redirected URL input was not valid UTF-8"));
     }
 }

--- a/src/auth/external_browser/manual_redirect_input.rs
+++ b/src/auth/external_browser/manual_redirect_input.rs
@@ -3,7 +3,10 @@ use std::io::{self, Write};
 use reqwest::Url;
 
 use super::payload::{BrowserCallbackPayload, parse_token_and_consent_from_pairs};
-use crate::{Error, Result};
+use crate::{
+    Result,
+    error::{AuthError, InternalError},
+};
 
 #[cfg(unix)]
 use super::manual_input_unix;
@@ -11,7 +14,7 @@ use super::manual_input_unix;
 pub(super) async fn manual_token_flow() -> Result<BrowserCallbackPayload> {
     tokio::task::spawn_blocking(manual_token_flow_blocking)
         .await
-        .map_err(|e| Error::Communication(format!("manual input task failed: {e}")))?
+        .map_err(InternalError::future_join)?
 }
 
 fn manual_token_flow_blocking() -> Result<BrowserCallbackPayload> {
@@ -40,16 +43,14 @@ fn read_redirected_url_line() -> Result<String> {
     let mut input = String::new();
     io::stdin()
         .read_line(&mut input)
-        .map_err(|e| Error::Communication(format!("failed to read input: {e}")))?;
+        .map_err(|e| AuthError::external_browser_with_source("failed to read input", e))?;
 
     validate_redirected_url_input(input)
 }
 
 pub(super) fn validate_redirected_url_input(input: String) -> Result<String> {
     if input.trim().is_empty() {
-        return Err(Error::Communication(
-            "No redirected URL was provided".to_string(),
-        ));
+        return Err(AuthError::external_browser("No redirected URL was provided").into());
     }
     Ok(input)
 }
@@ -72,10 +73,10 @@ fn extract_payload_from_url(url: &str) -> Option<BrowserCallbackPayload> {
 
 fn payload_from_redirect_input(input: &str) -> Result<BrowserCallbackPayload> {
     extract_payload_from_url(input).ok_or_else(|| {
-        Error::Communication(
-            "Unable to extract token from redirected URL (expected query or fragment token=...)"
-                .to_string(),
+        AuthError::external_browser(
+            "Unable to extract token from redirected URL (expected query or fragment token=...)",
         )
+        .into()
     })
 }
 

--- a/src/auth/key_pair.rs
+++ b/src/auth/key_pair.rs
@@ -5,7 +5,7 @@ use rsa::RsaPrivateKey;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
-use crate::Result;
+use crate::{Result, error::AuthError};
 
 pub(super) fn generate_jwt_from_key_pair(
     pem: &str,
@@ -21,12 +21,12 @@ pub(super) fn generate_jwt_from_key_pair(
         .unwrap_or_default();
     let username = username.to_ascii_uppercase();
     let private = if let Some(password) = password {
-        RsaPrivateKey::from_pkcs8_encrypted_pem(pem, password)
+        RsaPrivateKey::from_pkcs8_encrypted_pem(pem, password).map_err(AuthError::key_parse)?
     } else {
-        RsaPrivateKey::from_pkcs8_pem(pem)
-    }?;
+        RsaPrivateKey::from_pkcs8_pem(pem).map_err(AuthError::key_parse)?
+    };
     let public = private.to_public_key();
-    let der = public.to_public_key_der()?;
+    let der = public.to_public_key_der().map_err(AuthError::der_parse)?;
     let mut hasher = Sha256::new();
     hasher.update(der);
     let hash = hasher.finalize();
@@ -38,7 +38,10 @@ pub(super) fn generate_jwt_from_key_pair(
         "iat": timestamp,
         "exp": timestamp + 600
     });
-    let key = EncodingKey::from_rsa_pem(private.to_pkcs8_pem(LineEnding::LF)?.as_bytes())?;
+    let pem = private
+        .to_pkcs8_pem(LineEnding::LF)
+        .map_err(AuthError::key_parse)?;
+    let key = EncodingKey::from_rsa_pem(pem.as_bytes()).map_err(AuthError::jwt_sign)?;
     let jwt = jsonwebtoken::encode(
         &Header {
             alg: Algorithm::RS256,
@@ -46,7 +49,8 @@ pub(super) fn generate_jwt_from_key_pair(
         },
         &payload,
         &key,
-    )?;
+    )
+    .map_err(AuthError::jwt_sign)?;
     Ok(jwt)
 }
 

--- a/src/auth/login.rs
+++ b/src/auth/login.rs
@@ -4,7 +4,10 @@ use reqwest::{Client, Url};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::{Error, Result, SnowflakeAuthMethod, SnowflakeClientConfig};
+use crate::{
+    Result, SnowflakeAuthMethod, SnowflakeClientConfig,
+    error::{AuthError, ConfigError, NetworkError, ProtocolError},
+};
 
 use super::client::AUTH_REQUEST_TIMEOUT;
 #[cfg(feature = "external-browser-sso")]
@@ -29,7 +32,9 @@ pub(crate) async fn login(
     let auth = config.auth();
     let session = config.session();
 
-    let url = base_url.join("session/v1/login-request")?;
+    let url = base_url
+        .join("session/v1/login-request")
+        .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
 
     let mut queries: Vec<(&str, &str)> = vec![];
     if let Some(warehouse) = session.warehouse() {
@@ -113,24 +118,32 @@ pub(crate) async fn login(
         );
     }
 
-    let resp = request.send().await?;
+    let resp = request.send().await.map_err(NetworkError::request)?;
 
     let status = resp.status();
-    let body = resp.text().await?;
+    let body = resp.text().await.map_err(NetworkError::request)?;
     if !status.is_success() {
-        return Err(Error::Communication(format!("HTTP {status}: {body}")));
+        return Err(NetworkError::http_status(status.as_u16(), body.as_bytes()).into());
     }
 
-    let parsed: Response = serde_json::from_str(&body).map_err(|e| Error::Json(e, body))?;
+    let token = parse_login_response(&body)?;
+
+    Ok(token)
+}
+
+fn parse_login_response(body: &str) -> Result<String> {
+    let parsed: Response =
+        serde_json::from_str(body).map_err(|e| ProtocolError::json_parse(e, body))?;
     if !parsed.success {
-        return Err(Error::Communication(parsed.message.unwrap_or_default()));
+        return Err(AuthError::login_rejected(parsed.message).into());
     }
 
     let data = parsed
         .data
-        .ok_or_else(|| Error::Communication("missing login-response data".to_string()))?;
+        .ok_or_else(|| ProtocolError::missing_field("data"))?;
 
-    Ok(data.token)
+    data.token
+        .ok_or_else(|| ProtocolError::missing_field("data.token").into())
 }
 
 fn login_request_data(username: &str, account: &str, auth: &SnowflakeAuthMethod) -> Result<Value> {
@@ -180,16 +193,14 @@ fn login_request_data(username: &str, account: &str, auth: &SnowflakeAuthMethod)
             "TOKEN": token
         })),
         #[cfg(feature = "external-browser-sso")]
-        SnowflakeAuthMethod::ExternalBrowser(_) => Err(Error::UnsupportedFormat(
-            "external browser flow should be handled upstream".into(),
-        )),
+        SnowflakeAuthMethod::ExternalBrowser(_) => unreachable!("handled in caller"),
     }
 }
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct LoginResponseData {
-    token: String,
+    token: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -197,4 +208,47 @@ struct Response {
     data: Option<LoginResponseData>,
     message: Option<String>,
     success: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ErrorKind;
+
+    #[test]
+    fn parse_login_response_missing_data_is_protocol_error() {
+        let err = parse_login_response(r#"{"success":true}"#).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(err.snowflake_message(), None);
+    }
+
+    #[test]
+    fn parse_login_response_missing_token_is_protocol_error() {
+        let err = parse_login_response(r#"{"success":true,"data":{}}"#).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "missing required field in Snowflake response: data.token"
+        );
+    }
+
+    #[test]
+    fn parse_login_response_rejected_keeps_auth_classification() {
+        let err =
+            parse_login_response(r#"{"success":false,"message":"bad credentials"}"#).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Auth);
+        assert_eq!(err.snowflake_message(), Some("bad credentials"));
+    }
+
+    #[test]
+    fn parse_login_response_rejected_without_message_preserves_absence() {
+        let err = parse_login_response(r#"{"success":false}"#).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Auth);
+        assert_eq!(err.snowflake_message(), None);
+        assert_eq!(err.to_string(), "authentication rejected");
+    }
 }

--- a/src/chunk/downloader.rs
+++ b/src/chunk/downloader.rs
@@ -1,11 +1,13 @@
-use std::{io, sync::Arc, time::Duration};
+use std::{fmt, io, sync::Arc, time::Duration};
 
+use bytes::Bytes;
 use http::HeaderMap;
 use reqwest::StatusCode;
 use tokio::time::sleep;
 
 use crate::{
     Error, Result,
+    error::NetworkError,
     query_result::partition_source::FetchContext,
     result::{ResultTable, Schema},
     rowset::{ParseWorkload, parser::parse_remote_chunk_result_table_async},
@@ -31,13 +33,13 @@ impl DownloadFailure {
 
 impl From<reqwest::Error> for DownloadFailure {
     fn from(e: reqwest::Error) -> Self {
-        Self::Retryable(Error::Reqwest(e))
+        Self::Retryable(NetworkError::request(e))
     }
 }
 
 impl From<io::Error> for DownloadFailure {
     fn from(e: io::Error) -> Self {
-        Self::Retryable(Error::IO(e))
+        Self::Retryable(NetworkError::io(e).into())
     }
 }
 
@@ -85,13 +87,7 @@ impl ChunkDownloader {
         let response = self.client.get(url).headers(headers).send().await?;
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            let error = Error::ChunkDownload(body);
-            return if is_retryable_status(status) {
-                Err(DownloadFailure::Retryable(error))
-            } else {
-                Err(DownloadFailure::Fatal(error))
-            };
+            return Err(classify_failed_status(status, response.bytes().await));
         }
 
         let body = response.bytes().await?;
@@ -117,6 +113,29 @@ impl ChunkDownloader {
     }
 }
 
+fn classify_failed_status<E>(
+    status: StatusCode,
+    body: std::result::Result<Bytes, E>,
+) -> DownloadFailure
+where
+    E: fmt::Display,
+{
+    let error: Error = match body {
+        Ok(body) => NetworkError::chunk_download(status.as_u16(), body).into(),
+        Err(err) => NetworkError::chunk_download(
+            status.as_u16(),
+            format!("<failed to read response body: {err}>"),
+        )
+        .into(),
+    };
+
+    if is_retryable_status(status) {
+        DownloadFailure::Retryable(error)
+    } else {
+        DownloadFailure::Fatal(error)
+    }
+}
+
 fn is_retryable_status(status: StatusCode) -> bool {
     status.is_server_error()
         || status == StatusCode::TOO_MANY_REQUESTS
@@ -131,6 +150,7 @@ fn retry_delay(retries: usize) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ErrorKind;
 
     #[test]
     fn retryable_status_codes() {
@@ -156,5 +176,54 @@ mod tests {
         assert_eq!(retry_delay(4), Duration::from_secs(16));
         assert_eq!(retry_delay(5), Duration::from_secs(16));
         assert_eq!(retry_delay(6), Duration::from_secs(16));
+    }
+
+    #[test]
+    fn body_read_failure_keeps_non_retryable_status_fatal() {
+        match classify_failed_status(StatusCode::FORBIDDEN, Err("body read failed")) {
+            DownloadFailure::Fatal(error) => {
+                assert_eq!(error.kind(), ErrorKind::Network);
+                assert_eq!(
+                    error.to_string(),
+                    "chunk download failed with HTTP 403: <failed to read response body: body read failed>"
+                );
+            }
+            DownloadFailure::Retryable(error) => {
+                panic!("expected fatal classification, got retryable: {error}")
+            }
+        }
+    }
+
+    #[test]
+    fn body_read_failure_keeps_retryable_status_retryable() {
+        match classify_failed_status(StatusCode::BAD_GATEWAY, Err("body read failed")) {
+            DownloadFailure::Retryable(error) => {
+                assert_eq!(error.kind(), ErrorKind::Network);
+                assert_eq!(
+                    error.to_string(),
+                    "chunk download failed with HTTP 502: <failed to read response body: body read failed>"
+                );
+            }
+            DownloadFailure::Fatal(error) => {
+                panic!("expected retryable classification, got fatal: {error}")
+            }
+        }
+    }
+
+    #[test]
+    fn non_utf8_body_keeps_lossy_preview() {
+        match classify_failed_status(
+            StatusCode::FORBIDDEN,
+            Ok::<Bytes, &str>(Bytes::from_static(b"\xfffoo")),
+        ) {
+            DownloadFailure::Fatal(error) => {
+                assert_eq!(error.kind(), ErrorKind::Network);
+                assert!(error.to_string().contains("foo"));
+                assert!(!error.to_string().contains("<failed to read response body"));
+            }
+            DownloadFailure::Retryable(error) => {
+                panic!("expected fatal classification, got retryable: {error}")
+            }
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use url::Url;
 
-use crate::{Error, Result, SnowflakeAuthMethod};
+use crate::{Result, SnowflakeAuthMethod, error::ConfigError};
 
 /// Top-level configuration for a [`SnowflakeClient`](crate::SnowflakeClient).
 #[derive(Clone)]
@@ -244,9 +244,10 @@ impl SnowflakeEndpointConfig {
 
     pub(crate) fn resolve(&self, account: &str) -> Result<Url> {
         match self {
-            Self::AccountDefault => {
-                Url::parse(&format!("https://{account}.snowflakecomputing.com")).map_err(Into::into)
-            }
+            Self::AccountDefault => Ok(Url::parse(&format!(
+                "https://{account}.snowflakecomputing.com"
+            ))
+            .map_err(|e| ConfigError::invalid_url(e.to_string()))?),
             Self::CustomBaseUrl(url) => validate_custom_base_url(url.clone()),
         }
     }
@@ -256,26 +257,25 @@ const ALLOWED_ENDPOINT_SCHEMES: &[&str] = &["http", "https"];
 
 fn validate_custom_base_url(mut url: Url) -> Result<Url> {
     if !ALLOWED_ENDPOINT_SCHEMES.contains(&url.scheme()) {
-        return Err(Error::Url(format!(
+        return Err(ConfigError::invalid_url(format!(
             "unsupported custom base URL scheme '{}'; allowed: {}",
             url.scheme(),
             ALLOWED_ENDPOINT_SCHEMES.join(", "),
-        )));
+        ))
+        .into());
     }
     if url.query().is_some() || url.fragment().is_some() {
-        return Err(Error::Url(
-            "custom base URL must not contain query or fragment".to_string(),
-        ));
+        return Err(
+            ConfigError::invalid_url("custom base URL must not contain query or fragment").into(),
+        );
     }
     if !url.username().is_empty() || url.password().is_some() {
-        return Err(Error::Url(
-            "custom base URL must not contain credentials".to_string(),
-        ));
+        return Err(
+            ConfigError::invalid_url("custom base URL must not contain credentials").into(),
+        );
     }
     if url.path() != "/" && !url.path().is_empty() {
-        return Err(Error::Url(
-            "custom base URL must not contain a path".to_string(),
-        ));
+        return Err(ConfigError::invalid_url("custom base URL must not contain a path").into());
     }
     url.set_path("/");
     Ok(url)
@@ -310,7 +310,9 @@ impl SnowflakeTransportConfig {
             builder
         };
 
-        Ok(builder.build()?)
+        Ok(builder
+            .build()
+            .map_err(ConfigError::client_builder_failure)?)
     }
 }
 
@@ -336,7 +338,8 @@ impl SnowflakeProxyConfig {
 
     pub(crate) fn to_reqwest_proxy(&self) -> Result<reqwest::Proxy> {
         let url = validate_proxy_url(self.url.clone())?;
-        let mut proxy = reqwest::Proxy::all(url.as_str())?;
+        let mut proxy =
+            reqwest::Proxy::all(url.as_str()).map_err(ConfigError::client_builder_failure)?;
 
         if let SnowflakeProxyAuth::Basic { username, password } = &self.auth {
             proxy = proxy.basic_auth(username, password);
@@ -350,21 +353,23 @@ const ALLOWED_PROXY_SCHEMES: &[&str] = &["http", "https"];
 
 fn validate_proxy_url(url: Url) -> Result<Url> {
     if !ALLOWED_PROXY_SCHEMES.contains(&url.scheme()) {
-        return Err(Error::Url(format!(
+        return Err(ConfigError::invalid_url(format!(
             "unsupported proxy URL scheme '{}'; allowed: {}",
             url.scheme(),
             ALLOWED_PROXY_SCHEMES.join(", "),
-        )));
+        ))
+        .into());
     }
     if !url.username().is_empty() || url.password().is_some() {
-        return Err(Error::Url(
-            "proxy URL must not contain credentials; use SnowflakeProxyConfig::with_basic_auth() instead".to_string(),
-        ));
+        return Err(ConfigError::invalid_url(
+            "proxy URL must not contain credentials; use SnowflakeProxyConfig::with_basic_auth() instead",
+        )
+        .into());
     }
     if url.query().is_some() || url.fragment().is_some() {
-        return Err(Error::Url(
-            "proxy URL must not contain query or fragment".to_string(),
-        ));
+        return Err(
+            ConfigError::invalid_url("proxy URL must not contain query or fragment").into(),
+        );
     }
     Ok(url)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,289 +1,761 @@
-use std::{borrow::Cow, string::FromUtf8Error};
+mod decode;
+mod display;
+mod parse;
+mod repr;
+mod schema;
+
+use std::{error::Error as StdError, fmt};
 
 use reqwest::header::InvalidHeaderValue;
 use tokio::task::JoinError;
 
-use crate::result::{ColumnIndex, ColumnType};
+pub use decode::CellDecodeError;
+pub(crate) use parse::RowsetParseError;
+use repr::Repr;
+pub(crate) use repr::{
+    AuthError, ConfigError, InternalError, NetworkError, ProtocolError, ServerError,
+    SessionExpiredError, TimeoutError,
+};
+pub use schema::{
+    AmbiguousColumnError, ColumnCountMismatchError, DuplicateColumnNameError,
+    InvalidColumnIndexError, MissingColumnError, SchemaError,
+};
+
+const VALUE_PREVIEW_MAX_CHARS: usize = 128;
+const JSON_BODY_PREVIEW_MAX_BYTES: usize = 1024;
 
 /// An error that can occur when interacting with Snowflake.
 ///
 /// Note: Errors may include sensitive information from Snowflake.
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("HTTP client error: {0}")]
-    Reqwest(#[from] reqwest::Error),
-
-    #[error("communication error: {0}")]
-    Communication(String),
-
-    #[error("invalid header value: {0}")]
-    InvalidHeader(#[from] InvalidHeaderValue),
-
-    #[error("http error: {0}")]
-    Http(#[from] http::Error),
-
-    #[error("session expired")]
-    SessionExpired,
-
-    #[error("chunk download error: {0}")]
-    ChunkDownload(String),
-
-    #[error("io error: {0}")]
-    IO(#[from] std::io::Error),
-
-    #[error("json parse error: {0} {1}")]
-    Json(serde_json::Error, String),
-
-    #[error("utf-8 error: {0}")]
-    Utf8Error(#[from] FromUtf8Error),
-
-    #[error("future join error: {0}")]
-    FutureJoin(#[from] JoinError),
-
-    #[error("decode error: {0}")]
-    Decode(DecodeError),
-
-    #[error("schema error: {0}")]
-    Schema(SchemaError),
-
-    #[error("parse error: {0}")]
-    Parse(ParseError),
-
-    #[error("decrypt error: {0}")]
-    Decryption(#[from] pkcs8::Error),
-
-    #[error("der error: {0}")]
-    Der(#[from] pkcs8::spki::Error),
-
-    #[error("jwt error: {0}")]
-    JWT(#[from] jsonwebtoken::errors::Error),
-
-    #[error("url error: {0}")]
-    Url(String),
-
-    #[error("unsupported format: {0}")]
-    UnsupportedFormat(String),
-
-    #[error("async response doesn't contain a URL to poll for results")]
-    NoPollingUrlAsyncQuery,
-
-    #[error("timed out waiting for query results")]
-    TimedOut,
+///
+/// Use [`Error::kind`] for stable categorization, and [`std::error::Error::source`]
+/// to inspect the underlying cause chain when one exists. The concrete source
+/// type returned by downcasting is not covered by semver guarantees.
+pub struct Error {
+    repr: Box<Repr>,
 }
 
-/// A `Result` alias where the `Err` case is `snowflake::Error`.
-pub type Result<T> = std::result::Result<T, Error>;
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct SourceDebug<'a>(Option<&'a (dyn StdError + 'static)>);
 
-impl From<url::ParseError> for Error {
-    fn from(err: url::ParseError) -> Self {
-        Error::Url(err.to_string())
+        impl fmt::Debug for SourceDebug<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    Some(source) => f.debug_tuple("Some").field(&source.to_string()).finish(),
+                    None => f.write_str("None"),
+                }
+            }
+        }
+
+        f.debug_struct("Error")
+            .field("kind", &self.kind())
+            .field("message", &self.to_string())
+            .field("source", &SourceDebug(StdError::source(self)))
+            .finish()
     }
 }
 
-impl From<DecodeError> for Error {
-    fn from(err: DecodeError) -> Self {
-        Error::Decode(err)
+/// Semantic categories for [`Error`].
+///
+/// Variants are partitioned by the action a caller would take, not by the
+/// internal type that produced the error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// Client configuration or URL construction failed.
+    Config,
+    /// Authentication or session creation failed.
+    Auth,
+    /// HTTP or IO failures occurred while communicating with remote services.
+    Network,
+    /// Snowflake rejected the request and returned a server-side error message.
+    Server,
+    /// The current session token is no longer valid.
+    SessionExpired,
+    /// The connector timed out while waiting for a response.
+    Timeout,
+    /// The Snowflake protocol payload was malformed or unsupported.
+    ///
+    /// Includes the connector's internal `RowsetParseError` failures (chunk parser
+    /// limits, malformed payload tokens). These are surfaced as `Protocol`
+    /// rather than a separate kind because callers cannot recover from them.
+    Protocol,
+    /// Connector-internal runtime work failed, such as a cancelled or panicked task join.
+    Internal,
+    /// Caller-supplied fallback error created via [`Error::other`].
+    Other,
+    /// The result schema or a cell value did not match the caller's
+    /// expectations. Use [`Error::as_schema_error`] for column-lookup level
+    /// mismatches and [`Error::as_cell_decode_error`] for cell decoding failures.
+    Decode,
+}
+
+/// A `Result` alias where the `Err` case is [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+    fn new(repr: Repr) -> Self {
+        Self {
+            repr: Box::new(repr),
+        }
+    }
+
+    pub fn kind(&self) -> ErrorKind {
+        match &*self.repr {
+            Repr::Config(_) => ErrorKind::Config,
+            Repr::Auth(_) => ErrorKind::Auth,
+            Repr::Network(_) => ErrorKind::Network,
+            Repr::Server(_) => ErrorKind::Server,
+            Repr::SessionExpired(_) => ErrorKind::SessionExpired,
+            Repr::Timeout(_) => ErrorKind::Timeout,
+            Repr::Protocol(_) => ErrorKind::Protocol,
+            Repr::Internal(_) => ErrorKind::Internal,
+            Repr::Other(_) => ErrorKind::Other,
+            Repr::Schema(_) | Repr::CellDecode(_) => ErrorKind::Decode,
+        }
+    }
+
+    /// Returns the Snowflake-provided message when one is available.
+    pub fn snowflake_message(&self) -> Option<&str> {
+        match &*self.repr {
+            Repr::Auth(AuthError::LoginRejected { message }) => message.as_deref(),
+            Repr::SessionExpired(SessionExpiredError { message, .. }) => message.as_deref(),
+            Repr::Server(ServerError { message, .. }) => message.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Returns the Snowflake error code when one is available.
+    pub fn snowflake_code(&self) -> Option<&str> {
+        match &*self.repr {
+            Repr::SessionExpired(SessionExpiredError { code, .. }) => code.as_deref(),
+            Repr::Server(ServerError { code, .. }) => code.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Returns the related Snowflake query ID when one is available.
+    pub fn query_id(&self) -> Option<&str> {
+        match &*self.repr {
+            Repr::Server(ServerError { query_id, .. }) => query_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    pub fn is_session_expired(&self) -> bool {
+        matches!(&*self.repr, Repr::SessionExpired(_))
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        matches!(&*self.repr, Repr::Timeout(_))
+    }
+
+    pub fn is_server_error(&self) -> bool {
+        matches!(&*self.repr, Repr::Server(_))
+    }
+
+    pub fn as_cell_decode_error(&self) -> Option<&CellDecodeError> {
+        match &*self.repr {
+            Repr::CellDecode(error) => Some(error),
+            _ => None,
+        }
+    }
+
+    pub fn as_schema_error(&self) -> Option<&SchemaError> {
+        match &*self.repr {
+            Repr::Schema(error) => Some(error),
+            _ => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn as_rowset_parse_error(&self) -> Option<&RowsetParseError> {
+        match &*self.repr {
+            Repr::Protocol(ProtocolError::RowsetParse(error)) => Some(error),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn session_expired(code: Option<String>, message: Option<String>) -> Self {
+        SessionExpiredError::new(code, message).into()
+    }
+
+    pub fn other(message: impl Into<String>) -> Self {
+        Self::new(Repr::Other(message.into().into_boxed_str()))
+    }
+}
+
+impl From<ConfigError> for Error {
+    fn from(error: ConfigError) -> Self {
+        Self::new(Repr::Config(error))
+    }
+}
+
+impl From<AuthError> for Error {
+    fn from(error: AuthError) -> Self {
+        Self::new(Repr::Auth(error))
+    }
+}
+
+impl From<NetworkError> for Error {
+    fn from(error: NetworkError) -> Self {
+        Self::new(Repr::Network(error))
+    }
+}
+
+impl From<ServerError> for Error {
+    fn from(error: ServerError) -> Self {
+        Self::new(Repr::Server(error))
+    }
+}
+
+impl From<SessionExpiredError> for Error {
+    fn from(error: SessionExpiredError) -> Self {
+        Self::new(Repr::SessionExpired(error))
+    }
+}
+
+impl From<TimeoutError> for Error {
+    fn from(error: TimeoutError) -> Self {
+        Self::new(Repr::Timeout(error))
+    }
+}
+
+impl From<ProtocolError> for Error {
+    fn from(error: ProtocolError) -> Self {
+        Self::new(Repr::Protocol(error))
+    }
+}
+
+impl From<InternalError> for Error {
+    fn from(error: InternalError) -> Self {
+        Self::new(Repr::Internal(error))
+    }
+}
+
+impl From<CellDecodeError> for Error {
+    fn from(error: CellDecodeError) -> Self {
+        Self::new(Repr::CellDecode(error))
     }
 }
 
 impl From<SchemaError> for Error {
-    fn from(err: SchemaError) -> Self {
-        Error::Schema(err)
+    fn from(error: SchemaError) -> Self {
+        Self::new(Repr::Schema(error))
     }
 }
 
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Error::Parse(err)
+impl From<RowsetParseError> for Error {
+    fn from(error: RowsetParseError) -> Self {
+        ProtocolError::RowsetParse(error).into()
     }
 }
 
-const VALUE_PREVIEW_MAX_CHARS: usize = 128;
+impl ConfigError {
+    pub(crate) fn invalid_url(message: impl Into<String>) -> Self {
+        Self::InvalidUrl(message.into().into_boxed_str())
+    }
 
-/// Cell decode failure with row/column context.
-#[derive(Debug, Clone)]
-pub struct DecodeError {
-    row: usize,
-    column: ColumnIndex,
-    column_name: Box<str>,
-    expected: Cow<'static, str>,
-    actual: ColumnType,
-    value_preview: Option<Box<str>>,
-    reason: Box<str>,
+    pub(crate) fn client_builder_failure(source: reqwest::Error) -> Self {
+        Self::HttpClientBuild(source)
+    }
 }
 
-impl DecodeError {
-    #[allow(clippy::too_many_arguments)]
+impl AuthError {
+    pub(crate) fn login_rejected(message: Option<String>) -> Self {
+        Self::LoginRejected {
+            message: message.map(String::into_boxed_str),
+        }
+    }
+
+    pub(crate) fn key_parse(source: pkcs8::Error) -> Self {
+        Self::KeyParse(Box::new(source))
+    }
+
+    pub(crate) fn der_parse(source: pkcs8::spki::Error) -> Self {
+        Self::DerParse(Box::new(source))
+    }
+
+    pub(crate) fn jwt_sign(source: jsonwebtoken::errors::Error) -> Self {
+        Self::JwtSign(Box::new(source))
+    }
+
+    #[cfg(feature = "external-browser-sso")]
+    pub(crate) fn external_browser(message: impl Into<String>) -> Self {
+        Self::ExternalBrowser {
+            message: message.into().into_boxed_str(),
+            source: None,
+        }
+    }
+
+    #[cfg(feature = "external-browser-sso")]
+    pub(crate) fn external_browser_with_source(
+        message: impl Into<String>,
+        source: impl Into<Box<dyn StdError + Send + Sync>>,
+    ) -> Self {
+        Self::ExternalBrowser {
+            message: message.into().into_boxed_str(),
+            source: Some(source.into()),
+        }
+    }
+}
+
+impl NetworkError {
+    pub(crate) fn request(source: reqwest::Error) -> Error {
+        if source.is_timeout() {
+            TimeoutError::request(source).into()
+        } else {
+            Self::Http(source).into()
+        }
+    }
+
+    pub(crate) fn io(source: std::io::Error) -> Self {
+        Self::Io(source)
+    }
+
+    pub(crate) fn http_status(status: u16, body: impl AsRef<[u8]>) -> Self {
+        Self::HttpStatus {
+            status,
+            body: truncate_preview_lossy_bytes(body.as_ref(), JSON_BODY_PREVIEW_MAX_BYTES),
+        }
+    }
+
+    pub(crate) fn chunk_download(status: u16, body: impl AsRef<[u8]>) -> Self {
+        Self::ChunkDownload {
+            status,
+            body: truncate_preview_lossy_bytes(body.as_ref(), JSON_BODY_PREVIEW_MAX_BYTES),
+        }
+    }
+}
+
+impl ServerError {
     pub(crate) fn new(
-        row: usize,
-        column: ColumnIndex,
-        column_name: impl Into<Box<str>>,
-        expected: impl Into<Cow<'static, str>>,
-        actual: ColumnType,
-        value_preview: Option<&str>,
-        reason: impl Into<Box<str>>,
+        code: Option<String>,
+        message: Option<String>,
+        query_id: Option<String>,
     ) -> Self {
         Self {
-            row,
-            column,
-            column_name: column_name.into(),
-            expected: expected.into(),
-            actual,
-            value_preview: value_preview.map(truncate_preview),
-            reason: reason.into(),
+            code: code.map(String::into_boxed_str),
+            message: message.map(String::into_boxed_str),
+            query_id: query_id.map(String::into_boxed_str),
         }
-    }
-
-    pub fn row(&self) -> usize {
-        self.row
-    }
-    pub fn column(&self) -> ColumnIndex {
-        self.column
-    }
-    pub fn column_name(&self) -> &str {
-        &self.column_name
-    }
-    pub fn expected(&self) -> &str {
-        &self.expected
-    }
-    pub fn actual(&self) -> &ColumnType {
-        &self.actual
-    }
-    pub fn value_preview(&self) -> Option<&str> {
-        self.value_preview.as_deref()
-    }
-    pub fn reason(&self) -> &str {
-        &self.reason
     }
 }
 
-impl std::fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "row {} column {:?} ({}): expected {}, found {:?}",
-            self.row, self.column, self.column_name, self.expected, self.actual
-        )?;
-        if let Some(p) = &self.value_preview {
-            write!(f, ", value: {p:?}")?;
+impl SessionExpiredError {
+    pub(crate) fn new(code: Option<String>, message: Option<String>) -> Self {
+        Self {
+            code: code.map(String::into_boxed_str),
+            message: message.map(String::into_boxed_str),
         }
-        if !self.reason.is_empty() {
-            write!(f, " ({})", self.reason)?;
-        }
-        Ok(())
     }
 }
 
-fn truncate_preview(s: &str) -> Box<str> {
-    if s.chars().count() <= VALUE_PREVIEW_MAX_CHARS {
-        return Box::from(s);
+impl TimeoutError {
+    pub(crate) fn request(source: reqwest::Error) -> Self {
+        Self::Request(source)
     }
-    let mut out = String::with_capacity(VALUE_PREVIEW_MAX_CHARS * 4 + 3);
-    for ch in s.chars().take(VALUE_PREVIEW_MAX_CHARS) {
-        out.push(ch);
+
+    pub(crate) fn query() -> Self {
+        Self::Query
     }
+
+    #[cfg(feature = "external-browser-sso")]
+    pub(crate) fn browser_callback() -> Self {
+        Self::BrowserCallback
+    }
+}
+
+impl ProtocolError {
+    pub(crate) fn json_parse(source: serde_json::Error, body: impl AsRef<[u8]>) -> Self {
+        Self::JsonParse {
+            source: Box::new(source),
+            body_preview: truncate_preview_lossy_bytes(body.as_ref(), JSON_BODY_PREVIEW_MAX_BYTES),
+        }
+    }
+
+    pub(crate) fn invalid_response_url(
+        path: &'static str,
+        value: impl AsRef<str>,
+        source: url::ParseError,
+    ) -> Self {
+        Self::InvalidResponseUrl {
+            path,
+            value_preview: truncate_preview_bytes(value.as_ref(), JSON_BODY_PREVIEW_MAX_BYTES),
+            source,
+        }
+    }
+
+    pub(crate) fn invalid_field(path: &'static str, reason: impl Into<String>) -> Self {
+        Self::InvalidField {
+            path,
+            reason: reason.into().into_boxed_str(),
+        }
+    }
+
+    pub(crate) fn missing_field(field: &'static str) -> Self {
+        Self::MissingField { field }
+    }
+
+    pub(crate) fn header_conversion(source: http::Error) -> Self {
+        Self::HeaderConversion(source)
+    }
+
+    pub(crate) fn invalid_response_header_value(source: InvalidHeaderValue) -> Self {
+        Self::InvalidResponseHeaderValue(source)
+    }
+
+    pub(crate) fn no_polling_url() -> Self {
+        Self::NoPollingUrlAsyncQuery
+    }
+
+    pub(crate) fn unsupported_result_format(message: impl Into<String>) -> Self {
+        Self::UnsupportedResultFormat(message.into().into_boxed_str())
+    }
+
+    pub(crate) fn chunk_format(message: impl Into<String>) -> Self {
+        Self::InvalidChunkFormat {
+            message: message.into().into_boxed_str(),
+            source: None,
+        }
+    }
+
+    pub(crate) fn gzip_decode(source: std::io::Error) -> Self {
+        Self::InvalidChunkFormat {
+            message: Box::from("gzip decompression failed"),
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
+impl InternalError {
+    pub(crate) fn future_join(source: JoinError) -> Self {
+        Self::FutureJoin(source)
+    }
+}
+
+pub(crate) fn truncate_preview_chars(input: &str, max_chars: usize) -> Box<str> {
+    match input.char_indices().nth(max_chars) {
+        Some((end, _)) => truncate_preview_at_byte(input, end),
+        None => Box::from(input),
+    }
+}
+
+fn truncate_preview_bytes(input: &str, max_bytes: usize) -> Box<str> {
+    if input.len() <= max_bytes {
+        return Box::from(input);
+    }
+
+    let mut end = max_bytes;
+    while !input.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    truncate_preview_at_byte(input, end)
+}
+
+fn truncate_preview_at_byte(input: &str, end: usize) -> Box<str> {
+    let mut out = String::with_capacity(end.saturating_add(3));
+    out.push_str(&input[..end]);
     out.push_str("...");
     out.into_boxed_str()
 }
 
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum SchemaError {
-    #[error("missing column: {name}")]
-    MissingColumn { name: Box<str> },
-    #[error("ambiguous column: {name}")]
-    AmbiguousColumn {
-        name: Box<str>,
-        candidates: Box<[ColumnIndex]>,
-    },
-    #[error("invalid column index {index:?} for schema with {len} columns")]
-    InvalidColumnIndex { index: ColumnIndex, len: usize },
-    #[error("duplicate column name in result: {name}")]
-    DuplicateColumnName { name: Box<str> },
-    #[error("column count mismatch (expected {expected}, actual {actual})")]
-    ColumnCountMismatch { expected: usize, actual: usize },
-    #[error("schema mismatch")]
-    SchemaMismatch,
+fn truncate_preview_lossy_bytes(input: &[u8], max_bytes: usize) -> Box<str> {
+    if input.len() <= max_bytes {
+        return String::from_utf8_lossy(input).into_owned().into_boxed_str();
+    }
+
+    let mut out = String::from_utf8_lossy(&input[..max_bytes]).into_owned();
+    out.push_str("...");
+    out.into_boxed_str()
 }
 
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum ParseError {
-    #[error("unexpected token at offset {offset}: expected {expected}")]
-    UnexpectedToken {
-        offset: usize,
-        expected: &'static str,
-    },
-    #[error("invalid string at offset {offset}: {reason}")]
-    InvalidString { offset: usize, reason: Box<str> },
-    #[error("invalid unicode escape at offset {offset}")]
-    InvalidUnicodeEscape { offset: usize },
-    #[error("row length mismatch at row {row} (expected {expected}, actual {actual})")]
-    RowLengthMismatch {
-        row: usize,
-        expected: usize,
-        actual: usize,
-    },
-    #[error("span overflow: {scope} exceeded {limit} bytes (actual {actual})")]
-    SpanOverflow {
-        limit: u64,
-        actual: u64,
-        scope: &'static str,
-    },
-    #[error("capacity overflow")]
-    CapacityOverflow,
-}
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync + 'static>() {}
+    assert_send_sync::<Error>();
+    assert_send_sync::<CellDecodeError>();
+    assert_send_sync::<SchemaError>();
+};
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use tokio::net::TcpListener;
+
+    use crate::result::{ColumnIndex, ColumnType};
+
     use super::*;
 
-    fn index(value: usize) -> ColumnIndex {
-        ColumnIndex::new(value).unwrap()
+    #[test]
+    fn error_accessors_expose_structured_details() {
+        let err: Error = ServerError::new(
+            Some("12345".to_string()),
+            Some("statement failed".to_string()),
+            Some("query-id".to_string()),
+        )
+        .into();
+
+        assert_eq!(err.kind(), ErrorKind::Server);
+        assert_eq!(err.snowflake_code(), Some("12345"));
+        assert_eq!(err.snowflake_message(), Some("statement failed"));
+        assert_eq!(err.query_id(), Some("query-id"));
+        assert!(err.is_server_error());
+        assert!(!err.is_timeout());
     }
 
     #[test]
-    fn schema_error_display_formats_missing_and_ambiguous_variants() {
-        assert_eq!(
-            SchemaError::MissingColumn {
-                name: Box::from("value"),
-            }
-            .to_string(),
-            "missing column: value"
+    fn error_accessors_preserve_missing_message_fields() {
+        let auth_err: Error = AuthError::login_rejected(None).into();
+        assert_eq!(auth_err.kind(), ErrorKind::Auth);
+        assert_eq!(auth_err.snowflake_message(), None);
+        assert_eq!(auth_err.to_string(), "authentication rejected");
+
+        let server_err: Error = ServerError::new(Some("390100".to_string()), None, None).into();
+        assert_eq!(server_err.kind(), ErrorKind::Server);
+        assert_eq!(server_err.snowflake_code(), Some("390100"));
+        assert_eq!(server_err.snowflake_message(), None);
+        assert_eq!(server_err.to_string(), "Snowflake server error 390100");
+    }
+
+    #[test]
+    fn session_expired_preserves_snowflake_fields() {
+        let err = Error::session_expired(
+            Some("390112".to_string()),
+            Some("Your session has expired. Please login again.".to_string()),
         );
+
+        assert_eq!(err.kind(), ErrorKind::SessionExpired);
+        assert!(err.is_session_expired());
+        assert_eq!(err.snowflake_code(), Some("390112"));
         assert_eq!(
-            SchemaError::AmbiguousColumn {
-                name: Box::from("value"),
-                candidates: vec![index(0), index(1)].into_boxed_slice(),
-            }
-            .to_string(),
-            "ambiguous column: value"
+            err.snowflake_message(),
+            Some("Your session has expired. Please login again.")
+        );
+        assert_eq!(err.to_string(), "session expired");
+    }
+
+    #[test]
+    fn json_parse_truncates_large_body_preview() {
+        let body = "x".repeat(JSON_BODY_PREVIEW_MAX_BYTES + 10);
+        let err: Error = ProtocolError::json_parse(
+            serde_json::from_str::<serde_json::Value>("{").unwrap_err(),
+            body.as_bytes(),
+        )
+        .into();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("JSON parse error"));
+        assert!(rendered.contains("..."));
+    }
+
+    #[test]
+    fn bytes_preview_truncates_large_http_and_json_bodies_without_full_string_input() {
+        let body = vec![b'x'; JSON_BODY_PREVIEW_MAX_BYTES + 10];
+
+        let json_err: Error = ProtocolError::json_parse(
+            serde_json::from_str::<serde_json::Value>("{").unwrap_err(),
+            &body,
+        )
+        .into();
+        assert!(json_err.to_string().contains("..."));
+
+        let http_err: Error = NetworkError::http_status(500, &body).into();
+        assert!(http_err.to_string().contains("..."));
+
+        let chunk_err: Error = NetworkError::chunk_download(500, &body).into();
+        assert!(chunk_err.to_string().contains("..."));
+    }
+
+    #[test]
+    fn chunk_download_preview_handles_non_utf8_body_bytes() {
+        let err: Error = NetworkError::chunk_download(500, [0xff, b'x']).into();
+
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert!(err.to_string().contains("x"));
+        assert!(!err.to_string().contains("<failed to read response body"));
+    }
+
+    #[test]
+    fn body_preview_truncates_by_bytes_on_utf8_boundary() {
+        let body = "あ".repeat(JSON_BODY_PREVIEW_MAX_BYTES);
+        let preview = truncate_preview_bytes(&body, JSON_BODY_PREVIEW_MAX_BYTES);
+        let prefix = preview.strip_suffix("...").expect("truncated preview");
+
+        assert_eq!(
+            prefix.len(),
+            JSON_BODY_PREVIEW_MAX_BYTES - (JSON_BODY_PREVIEW_MAX_BYTES % 'あ'.len_utf8())
+        );
+        assert!(preview.ends_with("..."));
+    }
+
+    #[test]
+    fn other_errors_use_dedicated_kind_and_display_prefix() {
+        let err = Error::other("boom");
+
+        assert_eq!(err.kind(), ErrorKind::Other);
+        assert_eq!(err.to_string(), "snowflake connector error: boom");
+    }
+
+    #[test]
+    fn chunk_format_is_protocol_kind() {
+        let err: Error = ProtocolError::chunk_format("invalid chunk format").into();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "chunk download error: invalid chunk format"
         );
     }
 
     #[test]
-    fn schema_error_display_formats_remaining_variants() {
+    fn invalid_response_header_value_is_protocol_kind() {
+        let source = "bad\nvalue"
+            .parse::<reqwest::header::HeaderValue>()
+            .unwrap_err();
+        let err: Error = ProtocolError::invalid_response_header_value(source).into();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert!(StdError::source(&err).is_some());
+    }
+
+    #[test]
+    fn invalid_response_url_preview_is_truncated() {
+        let source = url::Url::parse("http://[::1").unwrap_err();
+        let value = "x".repeat(JSON_BODY_PREVIEW_MAX_BYTES + 10);
+        let err: Error =
+            ProtocolError::invalid_response_url("data.getResultUrl", &value, source).into();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("data.getResultUrl"));
+        assert!(rendered.contains("..."));
+    }
+
+    #[test]
+    fn invalid_field_is_protocol_kind() {
+        let err: Error = ProtocolError::invalid_field("data.ssoUrl", "must not be empty").into();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
         assert_eq!(
-            SchemaError::InvalidColumnIndex {
-                index: index(7),
-                len: 3,
-            }
-            .to_string(),
-            "invalid column index ColumnIndex(7) for schema with 3 columns"
+            err.to_string(),
+            "invalid Snowflake response field data.ssoUrl: must not be empty"
         );
+    }
+
+    #[test]
+    fn wrapped_errors_choose_source_over_display_duplication() {
+        let io_err = std::io::Error::other("boom");
+        let err: Error = NetworkError::io(io_err).into();
+
+        assert_eq!(err.to_string(), "io error");
         assert_eq!(
-            SchemaError::DuplicateColumnName {
-                name: Box::from("id"),
-            }
-            .to_string(),
-            "duplicate column name in result: id"
+            StdError::source(&err).map(std::string::ToString::to_string),
+            Some("boom".to_string())
         );
-        assert_eq!(
-            SchemaError::ColumnCountMismatch {
-                expected: 4,
-                actual: 2,
-            }
-            .to_string(),
-            "column count mismatch (expected 4, actual 2)"
-        );
-        assert_eq!(SchemaError::SchemaMismatch.to_string(), "schema mismatch");
+    }
+
+    #[test]
+    fn schema_decode_and_parse_errors_do_not_repeat_as_sources() {
+        let schema_error: Error = SchemaError::MissingColumn(MissingColumnError::new("col")).into();
+        assert!(StdError::source(&schema_error).is_none());
+
+        let decode_error: Error = CellDecodeError::new(
+            0,
+            ColumnIndex::new(0),
+            "COL",
+            "integer",
+            ColumnType::Text { length: None },
+            Some("x"),
+            "bad value",
+        )
+        .into();
+        assert!(StdError::source(&decode_error).is_none());
+
+        let parse_error: Error = RowsetParseError::CapacityOverflow.into();
+        assert_eq!(parse_error.kind(), ErrorKind::Protocol);
+        assert!(StdError::source(&parse_error).is_none());
+    }
+
+    #[test]
+    fn schema_and_cell_decode_share_decode_kind() {
+        let schema_error: Error = SchemaError::MissingColumn(MissingColumnError::new("col")).into();
+        assert_eq!(schema_error.kind(), ErrorKind::Decode);
+        assert!(schema_error.as_schema_error().is_some());
+        assert!(schema_error.as_cell_decode_error().is_none());
+
+        let decode_error: Error = CellDecodeError::new(
+            0,
+            ColumnIndex::new(0),
+            "COL",
+            "integer",
+            ColumnType::Text { length: None },
+            Some("x"),
+            "bad value",
+        )
+        .into();
+        assert_eq!(decode_error.kind(), ErrorKind::Decode);
+        assert!(decode_error.as_cell_decode_error().is_some());
+        assert!(decode_error.as_schema_error().is_none());
+    }
+
+    #[test]
+    fn parse_error_is_classified_as_protocol() {
+        let err: Error = RowsetParseError::CapacityOverflow.into();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert!(err.as_rowset_parse_error().is_some());
+    }
+
+    #[test]
+    fn debug_output_is_normalized() {
+        let err: Error = NetworkError::io(std::io::Error::other("boom")).into();
+        let rendered = format!("{err:?}");
+
+        assert!(rendered.contains("Error { kind: Network"));
+        assert!(rendered.contains("message: \"io error\""));
+        assert!(rendered.contains("source: Some(\"boom\")"));
+        assert!(!rendered.contains("repr"));
+    }
+
+    #[tokio::test]
+    async fn future_join_uses_internal_kind() {
+        let handle = tokio::spawn(std::future::pending::<()>());
+        handle.abort();
+
+        let err: Error = InternalError::future_join(handle.await.unwrap_err()).into();
+        assert_eq!(err.kind(), ErrorKind::Internal);
+    }
+
+    #[tokio::test]
+    async fn network_request_timeout_uses_timeout_kind() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(50))
+            .build()
+            .unwrap();
+        let err = client
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .unwrap_err();
+
+        assert!(err.is_timeout());
+
+        let err = NetworkError::request(err);
+        assert_eq!(err.kind(), ErrorKind::Timeout);
+        assert!(err.is_timeout());
+        assert!(StdError::source(&err).is_some());
+        assert_eq!(err.to_string(), "network request timed out");
+
+        server.abort();
+        let _ = server.await;
     }
 }

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -1,0 +1,88 @@
+use std::borrow::Cow;
+
+use crate::result::{ColumnIndex, ColumnType};
+
+use super::{VALUE_PREVIEW_MAX_CHARS, truncate_preview_chars};
+
+/// Cell decode failure with row/column context.
+#[derive(Debug, Clone)]
+pub struct CellDecodeError {
+    row: usize,
+    column: ColumnIndex,
+    column_name: Box<str>,
+    expected: Cow<'static, str>,
+    actual: ColumnType,
+    value_preview: Option<Box<str>>,
+    reason: Box<str>,
+}
+
+impl CellDecodeError {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        row: usize,
+        column: ColumnIndex,
+        column_name: impl Into<Box<str>>,
+        expected: impl Into<Cow<'static, str>>,
+        actual: ColumnType,
+        value_preview: Option<&str>,
+        reason: impl Into<Box<str>>,
+    ) -> Self {
+        Self {
+            row,
+            column,
+            column_name: column_name.into(),
+            expected: expected.into(),
+            actual,
+            value_preview: value_preview
+                .map(|preview| truncate_preview_chars(preview, VALUE_PREVIEW_MAX_CHARS)),
+            reason: reason.into(),
+        }
+    }
+
+    pub fn row(&self) -> usize {
+        self.row
+    }
+
+    pub fn column(&self) -> ColumnIndex {
+        self.column
+    }
+
+    pub fn column_name(&self) -> &str {
+        &self.column_name
+    }
+
+    pub fn expected(&self) -> &str {
+        &self.expected
+    }
+
+    pub fn actual(&self) -> &ColumnType {
+        &self.actual
+    }
+
+    pub fn value_preview(&self) -> Option<&str> {
+        self.value_preview.as_deref()
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+impl std::fmt::Display for CellDecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "row {} column {:?} ({}): expected {}, found {:?}",
+            self.row, self.column, self.column_name, self.expected, self.actual
+        )?;
+        if let Some(preview) = &self.value_preview {
+            write!(f, ", value: {preview:?}")?;
+        }
+        if !self.reason.is_empty() {
+            write!(f, " ({})", self.reason)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for CellDecodeError {}

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -1,0 +1,145 @@
+use std::{error::Error as StdError, fmt};
+
+use super::Error;
+use super::repr::{
+    AuthError, ConfigError, InternalError, NetworkError, ProtocolError, Repr, ServerError,
+    TimeoutError,
+};
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &*self.repr {
+            Repr::Config(ConfigError::InvalidUrl(message)) => write!(f, "invalid URL: {message}"),
+            Repr::Config(ConfigError::HttpClientBuild(_source)) => {
+                f.write_str("HTTP client build error")
+            }
+            Repr::Auth(AuthError::LoginRejected {
+                message: Some(message),
+            }) => write!(f, "authentication rejected: {message}"),
+            Repr::Auth(AuthError::LoginRejected { message: None }) => {
+                f.write_str("authentication rejected")
+            }
+            Repr::Auth(AuthError::KeyParse(_source)) => f.write_str("private key error"),
+            Repr::Auth(AuthError::DerParse(_source)) => f.write_str("DER error"),
+            Repr::Auth(AuthError::JwtSign(_source)) => f.write_str("JWT error"),
+            #[cfg(feature = "external-browser-sso")]
+            Repr::Auth(AuthError::ExternalBrowser { message, .. }) => {
+                write!(f, "external browser authentication error: {message}")
+            }
+            Repr::Network(NetworkError::Http(_source)) => f.write_str("network error"),
+            Repr::Network(NetworkError::Io(_source)) => f.write_str("io error"),
+            Repr::Network(NetworkError::HttpStatus { status, body }) => {
+                write!(f, "HTTP {status}: {body}")
+            }
+            Repr::Network(NetworkError::ChunkDownload { status, body }) => {
+                write!(f, "chunk download failed with HTTP {status}: {body}")
+            }
+            Repr::Server(ServerError {
+                code,
+                message,
+                query_id,
+            }) => {
+                match (code.as_deref(), message.as_deref()) {
+                    (Some(code), Some(message)) => {
+                        write!(f, "Snowflake server error {code}: {message}")?
+                    }
+                    (Some(code), None) => write!(f, "Snowflake server error {code}")?,
+                    (None, Some(message)) => write!(f, "Snowflake server error: {message}")?,
+                    (None, None) => f.write_str("Snowflake server error")?,
+                }
+                if let Some(query_id) = query_id {
+                    write!(f, " (query id: {query_id})")?;
+                }
+                Ok(())
+            }
+            Repr::SessionExpired(_) => f.write_str("session expired"),
+            Repr::Timeout(TimeoutError::Request(_)) => f.write_str("network request timed out"),
+            Repr::Timeout(TimeoutError::Query) => {
+                f.write_str("timed out waiting for query results")
+            }
+            #[cfg(feature = "external-browser-sso")]
+            Repr::Timeout(TimeoutError::BrowserCallback) => {
+                f.write_str("timed out waiting for external browser callback")
+            }
+            Repr::Protocol(ProtocolError::JsonParse {
+                source: _source,
+                body_preview,
+            }) => write!(f, "JSON parse error; body preview: {body_preview:?}"),
+            Repr::Protocol(ProtocolError::InvalidResponseUrl {
+                path,
+                value_preview,
+                source: _source,
+            }) => write!(
+                f,
+                "invalid URL in Snowflake response field {path}; value: {value_preview}"
+            ),
+            Repr::Protocol(ProtocolError::InvalidField { path, reason }) => {
+                write!(f, "invalid Snowflake response field {path}: {reason}")
+            }
+            Repr::Protocol(ProtocolError::MissingField { field }) => {
+                write!(f, "missing required field in Snowflake response: {field}")
+            }
+            Repr::Protocol(ProtocolError::HeaderConversion(_source)) => {
+                f.write_str("header conversion error")
+            }
+            Repr::Protocol(ProtocolError::InvalidResponseHeaderValue(_source)) => {
+                f.write_str("invalid header value in Snowflake response")
+            }
+            Repr::Protocol(ProtocolError::NoPollingUrlAsyncQuery) => {
+                f.write_str("async response doesn't contain a URL to poll for results")
+            }
+            Repr::Protocol(ProtocolError::UnsupportedResultFormat(message)) => {
+                write!(f, "unsupported result format: {message}")
+            }
+            Repr::Protocol(ProtocolError::InvalidChunkFormat {
+                message,
+                source: Some(_source),
+            }) => {
+                write!(f, "chunk download error: {message}")
+            }
+            Repr::Protocol(ProtocolError::InvalidChunkFormat {
+                message,
+                source: None,
+            }) => {
+                write!(f, "chunk download error: {message}")
+            }
+            Repr::Protocol(ProtocolError::RowsetParse(error)) => fmt::Display::fmt(error, f),
+            Repr::Internal(InternalError::FutureJoin(_source)) => f.write_str("future join error"),
+            Repr::Other(message) => write!(f, "snowflake connector error: {message}"),
+            Repr::Schema(error) => fmt::Display::fmt(error, f),
+            Repr::CellDecode(error) => fmt::Display::fmt(error, f),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match &*self.repr {
+            Repr::Config(ConfigError::HttpClientBuild(source)) => Some(source),
+            Repr::Auth(AuthError::KeyParse(source)) => Some(source.as_ref()),
+            Repr::Auth(AuthError::DerParse(source)) => Some(source.as_ref()),
+            Repr::Auth(AuthError::JwtSign(source)) => Some(source.as_ref()),
+            #[cfg(feature = "external-browser-sso")]
+            Repr::Auth(AuthError::ExternalBrowser {
+                source: Some(source),
+                ..
+            }) => Some(source.as_ref()),
+            Repr::Timeout(TimeoutError::Request(source)) => Some(source),
+            Repr::Network(NetworkError::Http(source)) => Some(source),
+            Repr::Network(NetworkError::Io(source)) => Some(source),
+            Repr::Protocol(ProtocolError::JsonParse { source, .. }) => Some(source.as_ref()),
+            Repr::Protocol(ProtocolError::InvalidResponseUrl { source, .. }) => Some(source),
+            Repr::Protocol(ProtocolError::HeaderConversion(source)) => Some(source),
+            Repr::Protocol(ProtocolError::InvalidResponseHeaderValue(source)) => Some(source),
+            Repr::Protocol(ProtocolError::InvalidChunkFormat {
+                source: Some(source),
+                ..
+            }) => Some(source.as_ref()),
+            Repr::Internal(InternalError::FutureJoin(source)) => Some(source),
+            Repr::Protocol(ProtocolError::RowsetParse(_)) => None,
+            Repr::Schema(_) => None,
+            Repr::CellDecode(_) => None,
+            _ => None,
+        }
+    }
+}

--- a/src/error/parse.rs
+++ b/src/error/parse.rs
@@ -1,0 +1,65 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RowsetParseError {
+    UnexpectedToken {
+        offset: usize,
+        expected: &'static str,
+    },
+    InvalidString {
+        offset: usize,
+        reason: Box<str>,
+    },
+    InvalidUnicodeEscape {
+        offset: usize,
+    },
+    RowLengthMismatch {
+        row: usize,
+        expected: usize,
+        actual: usize,
+    },
+    SpanOverflow {
+        limit: u64,
+        actual: u64,
+        scope: &'static str,
+    },
+    CapacityOverflow,
+}
+
+impl fmt::Display for RowsetParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedToken { offset, expected } => {
+                write!(
+                    f,
+                    "unexpected token at offset {offset}: expected {expected}"
+                )
+            }
+            Self::InvalidString { offset, reason } => {
+                write!(f, "invalid string at offset {offset}: {reason}")
+            }
+            Self::InvalidUnicodeEscape { offset } => {
+                write!(f, "invalid unicode escape at offset {offset}")
+            }
+            Self::RowLengthMismatch {
+                row,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "row length mismatch at row {row} (expected {expected}, actual {actual})"
+            ),
+            Self::SpanOverflow {
+                limit,
+                actual,
+                scope,
+            } => write!(
+                f,
+                "span overflow: {scope} exceeded {limit} bytes (actual {actual})"
+            ),
+            Self::CapacityOverflow => f.write_str("capacity overflow"),
+        }
+    }
+}
+
+impl std::error::Error for RowsetParseError {}

--- a/src/error/repr.rs
+++ b/src/error/repr.rs
@@ -1,0 +1,105 @@
+use std::error::Error as StdError;
+
+use reqwest::header::InvalidHeaderValue;
+use tokio::task::JoinError;
+
+use super::{CellDecodeError, RowsetParseError, SchemaError};
+
+#[derive(Debug)]
+pub(crate) enum Repr {
+    Config(ConfigError),
+    Auth(AuthError),
+    Network(NetworkError),
+    Server(ServerError),
+    SessionExpired(SessionExpiredError),
+    Timeout(TimeoutError),
+    Protocol(ProtocolError),
+    Internal(InternalError),
+    Other(Box<str>),
+    Schema(SchemaError),
+    CellDecode(CellDecodeError),
+}
+
+#[derive(Debug)]
+pub(crate) enum ConfigError {
+    InvalidUrl(Box<str>),
+    HttpClientBuild(reqwest::Error),
+}
+
+#[derive(Debug)]
+pub(crate) enum AuthError {
+    LoginRejected {
+        message: Option<Box<str>>,
+    },
+    KeyParse(Box<dyn StdError + Send + Sync>),
+    DerParse(Box<dyn StdError + Send + Sync>),
+    JwtSign(Box<dyn StdError + Send + Sync>),
+    #[cfg(feature = "external-browser-sso")]
+    ExternalBrowser {
+        message: Box<str>,
+        source: Option<Box<dyn StdError + Send + Sync>>,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) enum NetworkError {
+    Http(reqwest::Error),
+    Io(std::io::Error),
+    HttpStatus { status: u16, body: Box<str> },
+    ChunkDownload { status: u16, body: Box<str> },
+}
+
+#[derive(Debug)]
+pub(crate) struct ServerError {
+    pub(crate) code: Option<Box<str>>,
+    pub(crate) message: Option<Box<str>>,
+    pub(crate) query_id: Option<Box<str>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SessionExpiredError {
+    pub(crate) code: Option<Box<str>>,
+    pub(crate) message: Option<Box<str>>,
+}
+
+#[derive(Debug)]
+pub(crate) enum TimeoutError {
+    Request(reqwest::Error),
+    Query,
+    #[cfg(feature = "external-browser-sso")]
+    BrowserCallback,
+}
+
+#[derive(Debug)]
+pub(crate) enum ProtocolError {
+    JsonParse {
+        source: Box<dyn StdError + Send + Sync>,
+        body_preview: Box<str>,
+    },
+    InvalidResponseUrl {
+        path: &'static str,
+        value_preview: Box<str>,
+        source: url::ParseError,
+    },
+    InvalidField {
+        path: &'static str,
+        reason: Box<str>,
+    },
+    MissingField {
+        field: &'static str,
+    },
+    HeaderConversion(http::Error),
+    InvalidResponseHeaderValue(InvalidHeaderValue),
+    NoPollingUrlAsyncQuery,
+    UnsupportedResultFormat(Box<str>),
+    InvalidChunkFormat {
+        message: Box<str>,
+        source: Option<Box<dyn StdError + Send + Sync>>,
+    },
+    RowsetParse(RowsetParseError),
+}
+
+#[derive(Debug)]
+pub(crate) enum InternalError {
+    FutureJoin(JoinError),
+}

--- a/src/error/schema.rs
+++ b/src/error/schema.rs
@@ -1,0 +1,234 @@
+use std::fmt;
+
+use crate::result::ColumnIndex;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchemaError {
+    MissingColumn(MissingColumnError),
+    AmbiguousColumn(AmbiguousColumnError),
+    InvalidColumnIndex(InvalidColumnIndexError),
+    DuplicateColumnName(DuplicateColumnNameError),
+    ColumnCountMismatch(ColumnCountMismatchError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingColumnError {
+    name: Box<str>,
+}
+
+impl MissingColumnError {
+    pub fn new(name: impl Into<Box<str>>) -> Self {
+        Self { name: name.into() }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl fmt::Display for MissingColumnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "missing column: {}", self.name)
+    }
+}
+
+impl std::error::Error for MissingColumnError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbiguousColumnError {
+    name: Box<str>,
+    candidates: Box<[ColumnIndex]>,
+}
+
+impl AmbiguousColumnError {
+    pub fn new(name: impl Into<Box<str>>, candidates: impl Into<Box<[ColumnIndex]>>) -> Self {
+        Self {
+            name: name.into(),
+            candidates: candidates.into(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn candidates(&self) -> &[ColumnIndex] {
+        &self.candidates
+    }
+}
+
+impl fmt::Display for AmbiguousColumnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ambiguous column: {}", self.name)
+    }
+}
+
+impl std::error::Error for AmbiguousColumnError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidColumnIndexError {
+    index: ColumnIndex,
+    len: usize,
+}
+
+impl InvalidColumnIndexError {
+    pub fn new(index: ColumnIndex, len: usize) -> Self {
+        Self { index, len }
+    }
+
+    pub fn index(&self) -> ColumnIndex {
+        self.index
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl fmt::Display for InvalidColumnIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid column index {:?} for schema with {} columns",
+            self.index, self.len
+        )
+    }
+}
+
+impl std::error::Error for InvalidColumnIndexError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateColumnNameError {
+    name: Box<str>,
+}
+
+impl DuplicateColumnNameError {
+    pub fn new(name: impl Into<Box<str>>) -> Self {
+        Self { name: name.into() }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl fmt::Display for DuplicateColumnNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "duplicate column name in result: {}", self.name)
+    }
+}
+
+impl std::error::Error for DuplicateColumnNameError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnCountMismatchError {
+    expected: usize,
+    actual: usize,
+}
+
+impl ColumnCountMismatchError {
+    pub fn new(expected: usize, actual: usize) -> Self {
+        Self { expected, actual }
+    }
+
+    pub fn expected(&self) -> usize {
+        self.expected
+    }
+
+    pub fn actual(&self) -> usize {
+        self.actual
+    }
+}
+
+impl fmt::Display for ColumnCountMismatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "column count mismatch (expected {}, actual {})",
+            self.expected, self.actual
+        )
+    }
+}
+
+impl std::error::Error for ColumnCountMismatchError {}
+
+impl fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingColumn(error) => error.fmt(f),
+            Self::AmbiguousColumn(error) => error.fmt(f),
+            Self::InvalidColumnIndex(error) => error.fmt(f),
+            Self::DuplicateColumnName(error) => error.fmt(f),
+            Self::ColumnCountMismatch(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for SchemaError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_error_display_formats_missing_and_ambiguous_variants() {
+        assert_eq!(
+            SchemaError::MissingColumn(MissingColumnError::new("value")).to_string(),
+            "missing column: value"
+        );
+        assert_eq!(
+            SchemaError::AmbiguousColumn(AmbiguousColumnError::new(
+                "value",
+                vec![ColumnIndex::new(0), ColumnIndex::new(1)].into_boxed_slice(),
+            ))
+            .to_string(),
+            "ambiguous column: value"
+        );
+    }
+
+    #[test]
+    fn schema_error_accessors_expose_structured_fields() {
+        let ambiguous = AmbiguousColumnError::new(
+            "value",
+            vec![ColumnIndex::new(0), ColumnIndex::new(1)].into_boxed_slice(),
+        );
+        assert_eq!(ambiguous.name(), "value");
+        assert_eq!(
+            ambiguous.candidates(),
+            &[ColumnIndex::new(0), ColumnIndex::new(1)]
+        );
+
+        let invalid = InvalidColumnIndexError::new(ColumnIndex::new(7), 3);
+        assert_eq!(invalid.index(), ColumnIndex::new(7));
+        assert_eq!(invalid.len(), 3);
+
+        let duplicate = DuplicateColumnNameError::new("id");
+        assert_eq!(duplicate.name(), "id");
+
+        let mismatch = ColumnCountMismatchError::new(4, 2);
+        assert_eq!(mismatch.expected(), 4);
+        assert_eq!(mismatch.actual(), 2);
+    }
+
+    #[test]
+    fn schema_error_display_formats_remaining_variants() {
+        assert_eq!(
+            SchemaError::InvalidColumnIndex(InvalidColumnIndexError::new(ColumnIndex::new(7), 3))
+                .to_string(),
+            "invalid column index ColumnIndex(7) for schema with 3 columns"
+        );
+        assert_eq!(
+            SchemaError::DuplicateColumnName(DuplicateColumnNameError::new("id")).to_string(),
+            "duplicate column name in result: id"
+        );
+        assert_eq!(
+            SchemaError::ColumnCountMismatch(ColumnCountMismatchError::new(4, 2)).to_string(),
+            "column count mismatch (expected 4, actual 2)"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,10 @@ pub use config::{
     SnowflakeClientConfig, SnowflakeEndpointConfig, SnowflakeProxyConfig, SnowflakeQueryConfig,
     SnowflakeSessionConfig, SnowflakeTransportConfig,
 };
-pub use error::{DecodeError, Error, ParseError, Result, SchemaError};
+pub use error::{
+    AmbiguousColumnError, CellDecodeError, ColumnCountMismatchError, DuplicateColumnNameError,
+    Error, ErrorKind, InvalidColumnIndexError, MissingColumnError, Result, SchemaError,
+};
 pub use query::{Binding, BindingType, QueryRequest};
 pub use query_result::{CollectOptions, ResultSet, TypedResultSet};
 pub use result::{
@@ -170,6 +173,11 @@ pub enum SnowflakeAuthMethod {
 }
 
 impl SnowflakeClient {
+    /// Build a client from validated configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Config` when endpoint or transport configuration is invalid.
     pub fn new(config: SnowflakeClientConfig) -> Result<Self> {
         let base_url = config.endpoint().resolve(config.account())?;
         let http = config.transport().build_http_client()?;
@@ -183,6 +191,12 @@ impl SnowflakeClient {
     }
 
     /// Authenticate and create a new Snowflake session.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Config`, `ErrorKind::Auth`, `ErrorKind::Network`,
+    /// `ErrorKind::Timeout`, `ErrorKind::Protocol`, or `ErrorKind::Internal`
+    /// depending on how session establishment fails.
     pub async fn create_session(&self) -> Result<SnowflakeSession> {
         let session_token = login(&self.http, &self.config, &self.base_url).await?;
         Ok(SnowflakeSession {

--- a/src/query_result/collect.rs
+++ b/src/query_result/collect.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 
 use tokio::task::JoinSet;
 
-use crate::{Error, Result, result::ResultTable, runtime::BlockingParseLimiter};
+use crate::{Result, error::InternalError, result::ResultTable, runtime::BlockingParseLimiter};
 
 use super::{
     partition_source::{PartitionSource, remote_fetch_context},
@@ -68,11 +68,10 @@ impl CollectWindow {
 
     pub(crate) async fn join_next(&mut self) -> Option<Result<(usize, ResultTable)>> {
         let join_result = self.tasks.join_next().await?;
-        Some(
-            join_result
-                .map_err(Error::FutureJoin)
-                .and_then(|(ordinal, r)| r.map(|t| (ordinal, t))),
-        )
+        Some(match join_result {
+            Ok((ordinal, result)) => result.map(|table| (ordinal, table)),
+            Err(err) => Err(InternalError::future_join(err).into()),
+        })
     }
 
     pub(crate) fn commit(

--- a/src/query_result/result_set.rs
+++ b/src/query_result/result_set.rs
@@ -98,6 +98,12 @@ impl ResultSet {
     }
 
     /// Fetch the next partition as a `ResultTable`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Timeout`,
+    /// `ErrorKind::Protocol`, or `ErrorKind::Internal` if fetching or
+    /// materializing the next partition fails.
     pub async fn next_table(&mut self) -> Result<Option<ResultTable>> {
         if self.cursor.is_exhausted() {
             return Ok(None);
@@ -146,11 +152,24 @@ impl ResultSet {
     }
 
     /// Consume this result set and merge all remaining partitions into a single `ResultTable`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Timeout`,
+    /// `ErrorKind::Protocol`, or `ErrorKind::Internal` if any remaining
+    /// partition fails to materialize.
     pub async fn collect_table(self) -> Result<ResultTable> {
         let policy = self.default_collect_policy;
         self.collect_with_policy(policy).await
     }
 
+    /// Consume this result set and merge all remaining partitions into a single `ResultTable`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Timeout`,
+    /// `ErrorKind::Protocol`, or `ErrorKind::Internal` if any remaining
+    /// partition fails to materialize.
     pub async fn collect_table_with_options(self, options: CollectOptions) -> Result<ResultTable> {
         let policy = CollectPolicy::new(
             options
@@ -160,11 +179,27 @@ impl ResultSet {
         self.collect_with_policy(policy).await
     }
 
+    /// Consume this result set and decode all rows into [`DynamicRow`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Timeout`,
+    /// `ErrorKind::Protocol`, `ErrorKind::Internal`, or
+    /// `ErrorKind::Decode`; inspect the detail via
+    /// [`crate::Error::as_cell_decode_error`].
     pub async fn collect(self) -> Result<Vec<DynamicRow>> {
         let table = self.collect_table().await?;
         table.dynamic_rows()?.collect()
     }
 
+    /// Consume this result set and decode all rows into [`DynamicRow`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Timeout`,
+    /// `ErrorKind::Protocol`, `ErrorKind::Internal`, or
+    /// `ErrorKind::Decode`; inspect the detail via
+    /// [`crate::Error::as_cell_decode_error`].
     pub async fn collect_with_options(self, options: CollectOptions) -> Result<Vec<DynamicRow>> {
         let table = self.collect_table_with_options(options).await?;
         table.dynamic_rows()?.collect()
@@ -190,34 +225,47 @@ impl ResultSet {
 
         let mut tables = Vec::new();
         let total = snapshot.partitions.len();
-        let mut next_remote_ordinal = cursor.next_ordinal;
+        let inline_ordinal = cursor.next_ordinal;
+        let inline_first = matches!(
+            snapshot.partitions.get(inline_ordinal),
+            Some(PartitionSpec::Inline)
+        );
+        let first_remote_ordinal = inline_ordinal + usize::from(inline_first);
 
-        if next_remote_ordinal < total {
-            if let PartitionSpec::Inline = &snapshot.partitions[next_remote_ordinal] {
-                let inline = inline_rowset
-                    .expect("inline_rowset must be Some when partition spec is Inline");
-                let table = parse_inline_result_table_async(
-                    Arc::clone(&snapshot.schema),
-                    Arc::clone(&snapshot.identity.query_id),
-                    inline.bytes,
-                    inline.row_count_hint,
-                    Some(runtime.blocking_parse_limiter()),
-                )
-                .await?;
-                tables.push(table);
-                next_remote_ordinal += 1;
-            }
-        }
-
-        if next_remote_ordinal < total {
-            let source = Arc::new(source);
-            let blocking_parse_limiter = runtime.blocking_parse_limiter();
+        // Start remote prefetch before awaiting inline parsing so network I/O can
+        // overlap any blocking-parse permit wait on the inline partition.
+        let source = (first_remote_ordinal < total).then(|| Arc::new(source));
+        let blocking_parse_limiter = source.as_ref().map(|_| runtime.blocking_parse_limiter());
+        let mut window = source.as_ref().map(|source| {
+            let blocking_parse_limiter = blocking_parse_limiter
+                .as_ref()
+                .expect("limiter exists when source exists");
             let mut window = CollectWindow::new(
-                next_remote_ordinal,
+                first_remote_ordinal,
                 total,
                 policy.prefetch_concurrency.get(),
             );
-            window.fill(&source, &snapshot, &blocking_parse_limiter);
+            window.fill(source, &snapshot, blocking_parse_limiter);
+            window
+        });
+
+        if inline_first {
+            let inline =
+                inline_rowset.expect("inline_rowset must be Some when partition spec is Inline");
+            let table = parse_inline_result_table_async(
+                Arc::clone(&snapshot.schema),
+                Arc::clone(&snapshot.identity.query_id),
+                inline.bytes,
+                inline.row_count_hint,
+                Some(runtime.blocking_parse_limiter()),
+            )
+            .await?;
+            tables.push(table);
+        }
+
+        if let (Some(source), Some(blocking_parse_limiter), Some(mut window)) =
+            (source, blocking_parse_limiter, window.take())
+        {
             while let Some(result) = window.join_next().await {
                 let (ordinal, table) = result?;
                 window.commit(ordinal, table, &mut tables);
@@ -231,7 +279,7 @@ impl ResultSet {
                 Arc::clone(&snapshot.identity.query_id),
             ));
         }
-        ResultTable::concat_same_schema(tables)
+        Ok(ResultTable::concat_same_schema(tables))
     }
 }
 
@@ -241,7 +289,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        Error, SchemaError,
+        MissingColumnError, SchemaError,
         query_result::{
             TypedResultSet,
             collect::CollectPolicy,
@@ -249,6 +297,7 @@ mod tests {
             snapshot::{PartitionCursor, PartitionSpec, ResultIdentity, ResultSnapshot},
         },
         result::{Column, ColumnType, DynamicRow, FromRow, RowPlanContext, RowRef, Schema},
+        rowset::BLOCKING_PARSE_CELLS,
         runtime::QueryRuntime,
     };
 
@@ -325,7 +374,7 @@ mod tests {
     }
 
     fn fail() -> crate::Result<Vec<Vec<Option<String>>>> {
-        Err(crate::Error::ChunkDownload("simulated failure".into()))
+        Err(crate::error::NetworkError::chunk_download(500, "simulated failure").into())
     }
 
     type FakeRows = Vec<Vec<Option<String>>>;
@@ -376,9 +425,7 @@ mod tests {
         type Plan = ();
 
         fn build_plan(_: RowPlanContext<'_>) -> crate::Result<Self::Plan> {
-            Err(Error::Schema(SchemaError::MissingColumn {
-                name: Box::from("MISSING"),
-            }))
+            Err(SchemaError::MissingColumn(MissingColumnError::new("MISSING")).into())
         }
 
         fn from_row_with_plan(_: RowRef<'_>, _: &Self::Plan) -> crate::Result<Self> {
@@ -524,6 +571,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn collect_table_starts_remote_prefetch_while_inline_parse_waits_for_permit() {
+        let snapshot = snapshot_with_inline(1);
+        let total = snapshot.partitions.len();
+        let source = FakePartitionSource::new(
+            vec![(1, VecDeque::from(vec![FakeResponse::Rows(ok_rows(1))]))]
+                .into_iter()
+                .collect(),
+        );
+        let fetch_count = source.fetch_count();
+        let runtime = QueryRuntime::with_blocking_parse_concurrency(NonZeroUsize::new(1).unwrap());
+        let permit = runtime.blocking_parse_limiter().acquire_owned().await;
+        let rs = ResultSet::new(
+            snapshot,
+            PartitionCursor::new(total),
+            Some(inline_rowset(br#"[["10"]]"#, Some(BLOCKING_PARSE_CELLS))),
+            PartitionSource::Fake(source),
+            runtime,
+            CollectPolicy::new(NonZeroUsize::new(1).unwrap()),
+        );
+
+        let collect = rs.collect_table();
+        tokio::pin!(collect);
+
+        match tokio::time::timeout(Duration::from_millis(20), &mut collect).await {
+            Err(_) => {}
+            Ok(_) => panic!("expected collect_table to wait for the inline blocking-parse permit"),
+        }
+
+        assert_eq!(fetch_count.load(Ordering::SeqCst), 1);
+
+        drop(permit);
+
+        let table = collect.await.unwrap();
+        assert_eq!(table.row_count(), 2);
+    }
+
+    #[tokio::test]
     async fn typed_result_set_collect_builds_plan_once() {
         reset_build_plan_calls();
         let snapshot = dummy_snapshot(1);
@@ -604,8 +688,8 @@ mod tests {
         };
 
         assert!(matches!(
-            err,
-            Error::Schema(SchemaError::MissingColumn { .. })
+            err.as_schema_error(),
+            Some(SchemaError::MissingColumn(_))
         ));
         assert_eq!(fetch_count.load(Ordering::SeqCst), 0);
     }

--- a/src/query_result/typed_result_set.rs
+++ b/src/query_result/typed_result_set.rs
@@ -35,6 +35,13 @@ impl<T: FromRow> TypedResultSet<T> {
         self.inner.is_exhausted()
     }
 
+    /// Fetch the next partition as a typed table.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Timeout`,
+    /// `ErrorKind::Protocol`, or `ErrorKind::Internal` if fetching or
+    /// materializing the next partition fails.
     pub async fn next_table(&mut self) -> Result<Option<TypedResultTable<T>>> {
         self.inner
             .next_table()
@@ -42,22 +49,58 @@ impl<T: FromRow> TypedResultSet<T> {
             .map(|table| table.map(|table| TypedResultTable::new(table, Arc::clone(&self.plan))))
     }
 
+    /// Consume this result set and decode all rows into `T`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`TypedResultSet::collect_table`]. Decoding
+    /// rows then propagates any error returned by [`FromRow::from_row_with_plan`]
+    /// for `T`.
+    ///
+    /// Built-in and derive-based row types typically use
+    /// `ErrorKind::Decode` for per-row conversion failures; inspect the
+    /// detail via [`crate::Error::as_cell_decode_error`].
     pub async fn collect(self) -> Result<Vec<T>> {
         let table = self.collect_table().await?;
         table.rows().collect()
     }
 
+    /// Consume this result set and decode all rows into `T`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`TypedResultSet::collect_table_with_options`].
+    /// Decoding rows then propagates any error returned by
+    /// [`FromRow::from_row_with_plan`] for `T`.
+    ///
+    /// Built-in and derive-based row types typically use
+    /// `ErrorKind::Decode` for per-row conversion failures; inspect the
+    /// detail via [`crate::Error::as_cell_decode_error`].
     pub async fn collect_with_options(self, options: CollectOptions) -> Result<Vec<T>> {
         let table = self.collect_table_with_options(options).await?;
         table.rows().collect()
     }
 
+    /// Consume this result set and collect all remaining partitions into a typed table.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Timeout`,
+    /// `ErrorKind::Protocol`, or `ErrorKind::Internal` if any remaining
+    /// partition fails to materialize.
     pub async fn collect_table(self) -> Result<TypedResultTable<T>> {
         let Self { inner, plan, .. } = self;
         let table = inner.collect_table().await?;
         Ok(TypedResultTable::new(table, plan))
     }
 
+    /// Consume this result set and collect all remaining partitions into a typed table.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Timeout`,
+    /// `ErrorKind::Protocol`, or `ErrorKind::Internal` if any remaining
+    /// partition fails to materialize.
     pub async fn collect_table_with_options(
         self,
         options: CollectOptions,

--- a/src/result/cell.rs
+++ b/src/result/cell.rs
@@ -3,8 +3,9 @@ use std::borrow::Cow;
 use bytes::Bytes;
 
 use crate::{
+    error::RowsetParseError,
     result::schema::{Column, ColumnType},
-    {DecodeError, Error, ParseError, Result},
+    {CellDecodeError, Error, Result},
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -63,11 +64,12 @@ impl StringArenaBuilder {
         let len = end - start;
         if (start as u64).saturating_add(len as u64) > u32::MAX as u64 {
             self.bytes.truncate(start);
-            return Err(Error::Parse(ParseError::SpanOverflow {
+            return Err(RowsetParseError::SpanOverflow {
                 limit: u32::MAX as u64,
                 actual: end as u64,
                 scope: "string arena",
-            }));
+            }
+            .into());
         }
 
         Ok(TextSpan {
@@ -82,14 +84,15 @@ impl StringArenaBuilder {
             .bytes
             .len()
             .checked_add(additional)
-            .ok_or(Error::Parse(ParseError::CapacityOverflow))?;
+            .ok_or(RowsetParseError::CapacityOverflow)?;
 
         if new_len > u32::MAX as usize {
-            return Err(Error::Parse(ParseError::SpanOverflow {
+            return Err(RowsetParseError::SpanOverflow {
                 limit: u32::MAX as u64,
                 actual: new_len as u64,
                 scope: "string arena",
-            }));
+            }
+            .into());
         }
         Ok(())
     }
@@ -173,11 +176,16 @@ impl<'a> CellRef<'a> {
         self.row
     }
 
-    /// Convert NULL into a `DecodeError`. Otherwise return the raw text.
+    /// Convert NULL into a `CellDecodeError`. Otherwise return the raw text.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Decode` when the cell is `NULL`; inspect the
+    /// detail via [`crate::Error::as_cell_decode_error`].
     pub fn required_raw(self, expected: impl Into<Cow<'static, str>>) -> Result<&'a str> {
         match self.raw {
             Some(s) => Ok(s),
-            None => Err(Error::Decode(DecodeError::new(
+            None => Err(CellDecodeError::new(
                 self.row,
                 self.column.index(),
                 self.column.name(),
@@ -185,7 +193,8 @@ impl<'a> CellRef<'a> {
                 self.column.ty().clone(),
                 None,
                 "value is NULL",
-            ))),
+            )
+            .into()),
         }
     }
 
@@ -195,7 +204,7 @@ impl<'a> CellRef<'a> {
         expected: impl Into<Cow<'static, str>>,
         reason: impl Into<Box<str>>,
     ) -> Error {
-        Error::Decode(DecodeError::new(
+        CellDecodeError::new(
             self.row,
             self.column.index(),
             self.column.name(),
@@ -203,6 +212,7 @@ impl<'a> CellRef<'a> {
             self.column.ty().clone(),
             self.raw,
             reason,
-        ))
+        )
+        .into()
     }
 }

--- a/src/result/decode.rs
+++ b/src/result/decode.rs
@@ -9,13 +9,20 @@ use crate::result::{
     row::RowRef,
     schema::{ColumnIndex, ColumnType},
 };
-use crate::{Error, Result, SchemaError};
+use crate::{ColumnCountMismatchError, Error, Result, SchemaError};
 
 const LEGACY_TIMESTAMP_TZ_SHIFT: i128 = 16_384;
 
 /// Trait for decoding a single cell into a Rust value.
 pub trait FromCell: Sized {
     fn expected() -> Cow<'static, str>;
+
+    /// Decode a single cell into `Self`.
+    ///
+    /// # Errors
+    ///
+    /// Implementations may return any [`crate::Error`] appropriate for their
+    /// decode logic.
     fn from_cell(cell: CellRef<'_>) -> Result<Self>;
 }
 
@@ -23,7 +30,20 @@ pub trait FromCell: Sized {
 pub trait FromRow: Sized {
     type Plan: Send + Sync;
 
+    /// Build a reusable decode plan for `Self` from result-set metadata.
+    ///
+    /// # Errors
+    ///
+    /// Implementations may return any [`crate::Error`] appropriate for schema
+    /// validation or planning.
     fn build_plan(ctx: RowPlanContext<'_>) -> Result<Self::Plan>;
+
+    /// Materialize a row using a precomputed plan.
+    ///
+    /// # Errors
+    ///
+    /// Implementations may return any [`crate::Error`] appropriate for row
+    /// conversion.
     fn from_row_with_plan(row: RowRef<'_>, plan: &Self::Plan) -> Result<Self>;
 }
 
@@ -33,10 +53,10 @@ impl FromRow for () {
     fn build_plan(ctx: RowPlanContext<'_>) -> Result<Self::Plan> {
         let schema = ctx.schema();
         if !schema.is_empty() {
-            return Err(Error::Schema(SchemaError::ColumnCountMismatch {
-                expected: 0,
-                actual: schema.len(),
-            }));
+            return Err(
+                SchemaError::ColumnCountMismatch(ColumnCountMismatchError::new(0, schema.len()))
+                    .into(),
+            );
         }
         Ok(())
     }
@@ -634,12 +654,12 @@ macro_rules! impl_tuple_from_row {
             fn build_plan(ctx: RowPlanContext<'_>) -> Result<Self::Plan> {
                 let schema = ctx.schema();
                 if schema.len() != $len {
-                    return Err(Error::Schema(SchemaError::ColumnCountMismatch {
-                        expected: $len,
-                        actual: schema.len(),
-                    }));
+                    return Err(SchemaError::ColumnCountMismatch(
+                        ColumnCountMismatchError::new($len, schema.len()),
+                    )
+                    .into());
                 }
-                Ok([$(ColumnIndex::new($idx)?),*])
+                Ok([$(ColumnIndex::new($idx as u32)),*])
             }
 
             fn from_row_with_plan(row: RowRef<'_>, plan: &Self::Plan) -> Result<Self> {
@@ -904,11 +924,9 @@ mod tests {
             Err(err) => err,
         };
         assert!(matches!(
-            err,
-            Error::Schema(SchemaError::ColumnCountMismatch {
-                expected: 0,
-                actual: 1
-            })
+            err.as_schema_error(),
+            Some(SchemaError::ColumnCountMismatch(error))
+                if error.expected() == 0 && error.actual() == 1
         ));
     }
 
@@ -940,7 +958,7 @@ mod tests {
             .next()
             .unwrap()
             .unwrap_err();
-        assert!(matches!(err, Error::Decode(_)));
+        assert!(err.as_cell_decode_error().is_some());
     }
 
     /// A `TEXT "42"` cell must NOT decode as `i64` even though the parse
@@ -949,7 +967,7 @@ mod tests {
     fn integer_rejects_text_column() {
         let t = one_cell_table(ColumnType::Text { length: None }, "42");
         let e = t.rows::<(i64,)>().unwrap().next().unwrap().unwrap_err();
-        assert!(matches!(e, Error::Decode(_)), "got {e:?}");
+        assert!(e.as_cell_decode_error().is_some(), "got {e:?}");
     }
 
     /// `BOOLEAN "1"` decoded as `i64` must fail; integers require `FIXED`.
@@ -957,7 +975,7 @@ mod tests {
     fn integer_rejects_boolean_column() {
         let t = one_cell_table(ColumnType::Boolean, "1");
         let e = t.rows::<(i64,)>().unwrap().next().unwrap().unwrap_err();
-        assert!(matches!(e, Error::Decode(_)));
+        assert!(e.as_cell_decode_error().is_some());
     }
 
     /// `FIXED(scale=2)` already had a guard; keep it locked down.
@@ -971,7 +989,7 @@ mod tests {
             "12",
         );
         let e = t.rows::<(i64,)>().unwrap().next().unwrap().unwrap_err();
-        assert!(matches!(e, Error::Decode(_)));
+        assert!(e.as_cell_decode_error().is_some());
     }
 
     /// `TEXT "true"` must NOT decode as `bool`.
@@ -979,7 +997,7 @@ mod tests {
     fn bool_rejects_text_column() {
         let t = one_cell_table(ColumnType::Text { length: None }, "true");
         let e = t.rows::<(bool,)>().unwrap().next().unwrap().unwrap_err();
-        assert!(matches!(e, Error::Decode(_)));
+        assert!(e.as_cell_decode_error().is_some());
     }
 
     #[test]
@@ -1053,7 +1071,7 @@ mod tests {
             .next()
             .unwrap()
             .unwrap_err();
-        assert!(matches!(err, Error::Decode(_)));
+        assert!(err.as_cell_decode_error().is_some());
     }
 
     /// The outer rowset parser should unescape once, leaving the inner JSON
@@ -1080,7 +1098,7 @@ mod tests {
     fn binary_rejects_text_column() {
         let t = one_cell_table(ColumnType::Text { length: None }, "48656C6C6F");
         let e = t.rows::<(Vec<u8>,)>().unwrap().next().unwrap().unwrap_err();
-        assert!(matches!(e, Error::Decode(_)));
+        assert!(e.as_cell_decode_error().is_some());
     }
 
     /// `TIMESTAMP_LTZ` must NOT decode as `NaiveDateTime` — semantics differ.
@@ -1093,7 +1111,7 @@ mod tests {
             .next()
             .unwrap()
             .unwrap_err();
-        assert!(matches!(e, Error::Decode(_)));
+        assert!(e.as_cell_decode_error().is_some());
     }
 
     #[test]

--- a/src/result/dynamic.rs
+++ b/src/result/dynamic.rs
@@ -12,7 +12,7 @@ use crate::result::{
     row::RowRef,
     schema::{ColumnIndex, ColumnType, Schema},
 };
-use crate::{Result, SchemaError};
+use crate::{DuplicateColumnNameError, InvalidColumnIndexError, Result, SchemaError};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DecimalValue {
@@ -85,12 +85,9 @@ impl DynamicRow {
 
     /// Borrows a value by resolved column index.
     pub fn at(&self, index: ColumnIndex) -> std::result::Result<&SnowflakeValue, SchemaError> {
-        self.schema
-            .column_at(index)
-            .ok_or_else(|| SchemaError::InvalidColumnIndex {
-                index,
-                len: self.schema.len(),
-            })?;
+        self.schema.column_at(index).ok_or_else(|| {
+            SchemaError::InvalidColumnIndex(InvalidColumnIndexError::new(index, self.schema.len()))
+        })?;
         Ok(&self.values[index.as_usize()])
     }
 
@@ -113,12 +110,9 @@ impl DynamicRow {
         &mut self,
         index: ColumnIndex,
     ) -> std::result::Result<SnowflakeValue, SchemaError> {
-        self.schema
-            .column_at(index)
-            .ok_or_else(|| SchemaError::InvalidColumnIndex {
-                index,
-                len: self.schema.len(),
-            })?;
+        self.schema.column_at(index).ok_or_else(|| {
+            SchemaError::InvalidColumnIndex(InvalidColumnIndexError::new(index, self.schema.len()))
+        })?;
 
         Ok(mem::replace(
             &mut self.values[index.as_usize()],
@@ -140,9 +134,9 @@ impl DynamicRow {
         let mut map = serde_json::Map::new();
         for (col, value) in schema.columns().iter().zip(values.into_vec()) {
             if map.contains_key(col.name()) {
-                return Err(SchemaError::DuplicateColumnName {
-                    name: Box::from(col.name()),
-                });
+                return Err(SchemaError::DuplicateColumnName(
+                    DuplicateColumnNameError::new(col.name()),
+                ));
             }
             map.insert(col.name().to_string(), value.into_json_value());
         }
@@ -339,10 +333,11 @@ mod tests {
     #[test]
     fn dynamic_row_at_rejects_invalid_indices() {
         let row = one_cell_row(ColumnType::Text { length: None }, "value");
-        let index = ColumnIndex::new(1).unwrap();
+        let index = ColumnIndex::new(1);
         assert!(matches!(
             row.at(index),
-            Err(SchemaError::InvalidColumnIndex { index: actual, len: 1 }) if actual == index
+            Err(SchemaError::InvalidColumnIndex(error))
+                if error.index() == index && error.len() == 1
         ));
     }
 
@@ -393,10 +388,11 @@ mod tests {
     #[test]
     fn dynamic_row_take_at_rejects_invalid_indices() {
         let mut row = one_cell_row(ColumnType::Text { length: None }, "value");
-        let index = ColumnIndex::new(1).unwrap();
+        let index = ColumnIndex::new(1);
         assert!(matches!(
             row.take_at(index),
-            Err(SchemaError::InvalidColumnIndex { index: actual, len: 1 }) if actual == index
+            Err(SchemaError::InvalidColumnIndex(error))
+                if error.index() == index && error.len() == 1
         ));
     }
 
@@ -417,7 +413,7 @@ mod tests {
         let mut row = one_cell_row(ColumnType::Text { length: None }, "value");
         assert!(matches!(
             row.take("missing"),
-            Err(SchemaError::MissingColumn { name }) if name.as_ref() == "missing"
+            Err(SchemaError::MissingColumn(error)) if error.name() == "missing"
         ));
     }
 
@@ -512,7 +508,7 @@ mod tests {
 
         assert!(matches!(
             row.into_json_object(),
-            Err(SchemaError::DuplicateColumnName { name }) if name.as_ref() == "id"
+            Err(SchemaError::DuplicateColumnName(error)) if error.name() == "id"
         ));
     }
 

--- a/src/result/result_table.rs
+++ b/src/result/result_table.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use crate::{
-    Error, ParseError, Result, SchemaError,
+    Result,
+    error::RowsetParseError,
     result::{
         DynamicRow, FromRow,
         cell::{Cell, CellBlock, RawSpan, StringArenaBuilder},
@@ -56,10 +57,24 @@ impl ResultTable {
         self.row_count == 0
     }
 
+    /// Create a typed row iterator for this table.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by [`FromRow::build_plan`] for `T` when
+    /// preparing to iterate this table.
+    ///
+    /// Built-in and derive-based row types typically use
+    /// `ErrorKind::Decode` when this table's schema does not match `T`;
+    /// inspect the detail via [`crate::Error::as_schema_error`].
     pub fn rows<T: FromRow>(&self) -> Result<Rows<'_, T>> {
         Rows::new(self)
     }
 
+    /// Create a dynamic row iterator for this table.
+    ///
+    /// This uses the built-in [`DynamicRow`] plan, which currently reuses the
+    /// table schema directly and therefore cannot fail.
     pub fn dynamic_rows(&self) -> Result<Rows<'_, DynamicRow>> {
         self.rows::<DynamicRow>()
     }
@@ -73,13 +88,17 @@ impl ResultTable {
     }
 
     /// Concatenate tables that share the same `Arc<Schema>`. Order is preserved.
-    pub(crate) fn concat_same_schema(tables: Vec<ResultTable>) -> Result<ResultTable> {
-        if tables.is_empty() {
-            return Err(Error::Schema(SchemaError::SchemaMismatch));
-        }
-
+    ///
+    /// Caller must guarantee `tables` is non-empty and all tables share the same
+    /// `Arc<Schema>` (i.e. they originate from the same partitioned query). These
+    /// invariants are enforced via `debug_assert!` rather than runtime errors —
+    /// a violation indicates a connector-internal bug, not a user-recoverable
+    /// condition.
+    pub(crate) fn concat_same_schema(tables: Vec<ResultTable>) -> ResultTable {
         let mut iter = tables.into_iter();
-        let first = iter.next().expect("non-empty");
+        let first = iter
+            .next()
+            .expect("concat_same_schema requires at least one table");
         let schema = Arc::clone(&first.schema);
         let query_id = Arc::clone(&first.query_id);
         let mut blocks = Vec::new();
@@ -87,10 +106,10 @@ impl ResultTable {
         push_storage(&first, &mut blocks, &mut row_count);
 
         for t in iter {
-            if !Arc::ptr_eq(&t.schema, &schema) {
-                return Err(Error::Schema(SchemaError::SchemaMismatch));
-            }
-
+            debug_assert!(
+                Arc::ptr_eq(&t.schema, &schema),
+                "concat_same_schema requires all tables to share the same Arc<Schema>"
+            );
             debug_assert_eq!(
                 t.query_id.as_ref(),
                 query_id.as_ref(),
@@ -105,12 +124,12 @@ impl ResultTable {
             ResultTableStorage::Chunks(blocks.into())
         };
 
-        Ok(ResultTable {
+        ResultTable {
             schema,
             query_id,
             storage,
             row_count,
-        })
+        }
     }
 
     pub(crate) fn empty(schema: Arc<Schema>, query_id: Arc<str>) -> Self {
@@ -164,7 +183,7 @@ impl ResultTableBuilder {
         let cap = match row_count_hint {
             Some(rows) => column_count
                 .checked_mul(rows)
-                .ok_or(Error::Parse(ParseError::CapacityOverflow))?
+                .ok_or(RowsetParseError::CapacityOverflow)?
                 .min(CAPACITY_RESERVE_CELL_LIMIT),
             None => 0,
         };
@@ -210,11 +229,12 @@ impl ResultTableBuilder {
 
     pub(crate) fn finish_row(&mut self) -> Result<()> {
         if self.current_row_cells != self.column_count {
-            return Err(Error::Parse(ParseError::RowLengthMismatch {
+            return Err(RowsetParseError::RowLengthMismatch {
                 row: self.row_count,
                 expected: self.column_count,
                 actual: self.current_row_cells,
-            }));
+            }
+            .into());
         }
 
         self.row_count += 1;
@@ -234,22 +254,24 @@ impl ResultTableBuilder {
             current_row_cells,
         } = self;
         if current_row_cells != 0 {
-            return Err(Error::Parse(ParseError::RowLengthMismatch {
+            return Err(RowsetParseError::RowLengthMismatch {
                 row: row_count,
                 expected: column_count,
                 actual: current_row_cells,
-            }));
+            }
+            .into());
         }
 
         let expected = row_count
             .checked_mul(column_count)
-            .ok_or(Error::Parse(ParseError::CapacityOverflow))?;
+            .ok_or(RowsetParseError::CapacityOverflow)?;
         if expected != cells.len() {
-            return Err(Error::Parse(ParseError::RowLengthMismatch {
+            return Err(RowsetParseError::RowLengthMismatch {
                 row: row_count,
                 expected: column_count,
                 actual: cells.len() % column_count.max(1),
-            }));
+            }
+            .into());
         }
 
         let block = CellBlock {
@@ -289,8 +311,8 @@ mod tests {
         b.push_owned_text("a".into());
         let err = b.finish_row().unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::RowLengthMismatch { .. })
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::RowLengthMismatch { .. })
         ));
     }
 
@@ -313,7 +335,11 @@ mod tests {
     fn builder_rejects_overflowing_capacity_hint() {
         let schema = dummy_schema(2);
         match ResultTableBuilder::new(schema, Arc::from("test"), None, Some(usize::MAX)) {
-            Err(Error::Parse(ParseError::CapacityOverflow)) => {}
+            Err(err)
+                if matches!(
+                    err.as_rowset_parse_error(),
+                    Some(RowsetParseError::CapacityOverflow)
+                ) => {}
             Err(err) => panic!("expected CapacityOverflow, got {err:?}"),
             Ok(_) => panic!("expected CapacityOverflow"),
         }

--- a/src/result/row.rs
+++ b/src/result/row.rs
@@ -1,7 +1,7 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use crate::{
-    Error, Result, SchemaError,
+    Error, InvalidColumnIndexError, Result, SchemaError,
     result::{
         cell::{CellBlock, CellRef},
         decode::{FromCell, FromRow},
@@ -25,12 +25,17 @@ impl<'a> RowRef<'a> {
         self.global_row
     }
 
+    /// Borrow a cell by column index.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Decode` when `index` is out of bounds for
+    /// this row's schema; inspect the detail via [`crate::Error::as_schema_error`].
     pub fn cell(self, index: ColumnIndex) -> Result<CellRef<'a>> {
         let column = self.table.schema().column_at(index).ok_or_else(|| {
-            Error::Schema(SchemaError::InvalidColumnIndex {
-                index,
-                len: self.table.schema().len(),
-            })
+            Error::from(SchemaError::InvalidColumnIndex(
+                InvalidColumnIndexError::new(index, self.table.schema().len()),
+            ))
         })?;
 
         let cell = self.block.cell(self.local_row, index.as_usize());
@@ -58,6 +63,14 @@ impl<'a> RowRef<'a> {
         }
     }
 
+    /// Decode a cell by column index.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Decode` when `index` is out of bounds for
+    /// this row's schema or when [`FromCell::from_cell`] fails for `T`. Use
+    /// [`crate::Error::as_schema_error`] to inspect schema mismatches and
+    /// [`crate::Error::as_cell_decode_error`] for conversion failures.
     pub fn get<T: FromCell>(self, index: ColumnIndex) -> Result<T> {
         T::from_cell(self.cell(index)?)
     }
@@ -185,7 +198,7 @@ mod tests {
                 .collect::<Vec<_>>(),
         )
         .unwrap();
-        let chunked = ResultTable::concat_same_schema(vec![first, second]).unwrap();
+        let chunked = ResultTable::concat_same_schema(vec![first, second]);
 
         for table in [single, chunked] {
             let mut rows = table.rows::<(String,)>().unwrap();

--- a/src/result/schema.rs
+++ b/src/result/schema.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::{Error, ParseError, Result, SchemaError};
+use crate::{
+    AmbiguousColumnError, MissingColumnError, Result, SchemaError, error::RowsetParseError,
+};
 
 /// Index into a result-set column list.
 #[repr(transparent)]
@@ -8,11 +10,8 @@ use crate::{Error, ParseError, Result, SchemaError};
 pub struct ColumnIndex(u32);
 
 impl ColumnIndex {
-    pub fn new(index: usize) -> Result<Self> {
-        if index > u32::MAX as usize {
-            return Err(Error::Parse(ParseError::CapacityOverflow));
-        }
-        Ok(Self(index as u32))
+    pub(crate) const fn new(index: u32) -> Self {
+        Self(index)
     }
 
     pub fn as_usize(self) -> usize {
@@ -219,7 +218,7 @@ pub struct Schema {
 impl Schema {
     pub(crate) fn from_columns(columns: Vec<Column>) -> Result<Self> {
         if columns.len() > u32::MAX as usize {
-            return Err(Error::Parse(ParseError::CapacityOverflow));
+            return Err(RowsetParseError::CapacityOverflow.into());
         }
 
         let indices = ColumnIndexMap::build(&columns);
@@ -258,13 +257,10 @@ fn lookup_result(
 ) -> std::result::Result<ColumnIndex, SchemaError> {
     match entry {
         Some(LookupEntry::Unique(idx)) => Ok(*idx),
-        Some(LookupEntry::Ambiguous(candidates)) => Err(SchemaError::AmbiguousColumn {
-            name: Box::from(name),
-            candidates: candidates.clone(),
-        }),
-        None => Err(SchemaError::MissingColumn {
-            name: Box::from(name),
-        }),
+        Some(LookupEntry::Ambiguous(candidates)) => Err(SchemaError::AmbiguousColumn(
+            AmbiguousColumnError::new(name, candidates.clone()),
+        )),
+        None => Err(SchemaError::MissingColumn(MissingColumnError::new(name))),
     }
 }
 
@@ -299,7 +295,7 @@ mod tests {
         assert_eq!(schema.column("id").unwrap().as_usize(), 1);
         assert!(matches!(
             schema.column("Id"),
-            Err(SchemaError::MissingColumn { name }) if name.as_ref() == "Id"
+            Err(SchemaError::MissingColumn(error)) if error.name() == "Id"
         ));
     }
 
@@ -328,10 +324,11 @@ mod tests {
         .unwrap();
         let err = schema.column("id").unwrap_err();
         match err {
-            SchemaError::AmbiguousColumn { name, candidates } => {
-                assert_eq!(name.as_ref(), "id");
+            SchemaError::AmbiguousColumn(error) => {
+                assert_eq!(error.name(), "id");
                 assert_eq!(
-                    candidates
+                    error
+                        .candidates()
                         .iter()
                         .map(|candidate| candidate.as_usize())
                         .collect::<Vec<_>>(),

--- a/src/rowset/gzip.rs
+++ b/src/rowset/gzip.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use bytes::Bytes;
 use flate2::bufread::GzDecoder;
 
-use crate::{Error, Result};
+use crate::{Result, error::ProtocolError};
 
 pub(crate) fn decode_gzip_chunk(body: Bytes) -> Result<Bytes> {
     if body.is_empty() {
@@ -11,15 +11,34 @@ pub(crate) fn decode_gzip_chunk(body: Bytes) -> Result<Bytes> {
     }
 
     if body.len() < 2 {
-        return Err(Error::ChunkDownload("invalid chunk format".into()));
+        return Err(ProtocolError::chunk_format("invalid chunk format").into());
     }
 
     if body[0] == 0x1f && body[1] == 0x8b {
         let mut decoder = GzDecoder::new(&body[..]);
         let mut decoded = Vec::new();
-        decoder.read_to_end(&mut decoded)?;
+        decoder
+            .read_to_end(&mut decoded)
+            .map_err(ProtocolError::gzip_decode)?;
         Ok(Bytes::from(decoded))
     } else {
         Ok(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as StdError;
+
+    use super::*;
+    use crate::ErrorKind;
+
+    #[test]
+    fn malformed_gzip_is_protocol_error() {
+        let err = decode_gzip_chunk(Bytes::from_static(b"\x1f\x8bgarbage")).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert!(err.to_string().contains("gzip decompression failed"));
+        assert!(StdError::source(&err).is_some());
     }
 }

--- a/src/rowset/parser.rs
+++ b/src/rowset/parser.rs
@@ -16,7 +16,8 @@ use super::{
     workload::execute_parse_work,
 };
 use crate::{
-    Error, ParseError, Result,
+    Error, Result,
+    error::RowsetParseError,
     result::{RawSpan, ResultTable, ResultTableBuilder, Schema},
     runtime::BlockingParseLimiter,
 };
@@ -98,7 +99,9 @@ fn parse_table_with_shape(
 
 fn checked_row_count_hint(row_count: Option<u64>) -> Result<Option<usize>> {
     row_count
-        .map(|rows| usize::try_from(rows).map_err(|_| Error::Parse(ParseError::CapacityOverflow)))
+        .map(|rows| {
+            usize::try_from(rows).map_err(|_| Error::from(RowsetParseError::CapacityOverflow))
+        })
         .transpose()
 }
 
@@ -195,17 +198,19 @@ impl<'a> JsonScanner<'a> {
     }
 
     fn err_unexpected(&self, expected: &'static str) -> Error {
-        Error::Parse(ParseError::UnexpectedToken {
+        RowsetParseError::UnexpectedToken {
             offset: self.offset,
             expected,
-        })
+        }
+        .into()
     }
 
     fn err_string(&self, reason: impl Into<Box<str>>) -> Error {
-        Error::Parse(ParseError::InvalidString {
+        RowsetParseError::InvalidString {
             offset: self.offset,
             reason: reason.into(),
-        })
+        }
+        .into()
     }
 
     /// Parse a row: `[` cell (`,` cell)* `]`.
@@ -282,11 +287,12 @@ impl<'a> JsonScanner<'a> {
                         validate_utf8(slice, content_start)?;
                     }
                     if (content_start as u64).saturating_add(len as u64) > u32::MAX as u64 {
-                        return Err(Error::Parse(ParseError::SpanOverflow {
+                        return Err(RowsetParseError::SpanOverflow {
                             limit: u32::MAX as u64,
                             actual: (content_start + len) as u64,
                             scope: "wire span",
-                        }));
+                        }
+                        .into());
                     }
                     builder.push_raw_text(RawSpan {
                         start: content_start as u32,
@@ -364,32 +370,32 @@ fn utf8_bom_prefix_len(bytes: &[u8]) -> usize {
 fn map_json_string_scan_error(err: JsonStringScanError<Error>) -> Error {
     match err {
         JsonStringScanError::UnterminatedString { offset } => {
-            Error::Parse(ParseError::InvalidString {
+            Error::from(RowsetParseError::InvalidString {
                 offset,
                 reason: Box::from("unterminated string"),
             })
         }
         JsonStringScanError::TrailingBackslash { offset } => {
-            Error::Parse(ParseError::InvalidString {
+            Error::from(RowsetParseError::InvalidString {
                 offset,
                 reason: Box::from("trailing backslash"),
             })
         }
         JsonStringScanError::UnknownEscape { offset, escape } => {
-            Error::Parse(ParseError::InvalidString {
+            Error::from(RowsetParseError::InvalidString {
                 offset,
                 reason: format!("unknown escape: \\{}", escape as char).into_boxed_str(),
             })
         }
         JsonStringScanError::ControlCharacter { offset } => {
-            Error::Parse(ParseError::InvalidString {
+            Error::from(RowsetParseError::InvalidString {
                 offset,
                 reason: Box::from("control character in string"),
             })
         }
         JsonStringScanError::InvalidUnicodeEscape { offset }
         | JsonStringScanError::InvalidUnicodeSurrogatePair { offset } => {
-            Error::Parse(ParseError::InvalidUnicodeEscape { offset })
+            Error::from(RowsetParseError::InvalidUnicodeEscape { offset })
         }
         JsonStringScanError::Visitor(err) => err,
     }
@@ -397,7 +403,7 @@ fn map_json_string_scan_error(err: JsonStringScanError<Error>) -> Error {
 
 fn validate_utf8(bytes: &[u8], start_offset: usize) -> Result<()> {
     std::str::from_utf8(bytes).map_err(|err| {
-        Error::Parse(ParseError::InvalidString {
+        Error::from(RowsetParseError::InvalidString {
             offset: start_offset + err.valid_up_to(),
             reason: Box::from("invalid UTF-8 in string"),
         })
@@ -629,8 +635,8 @@ mod tests {
         let s = schema(1);
         let err = parse_inline_result_table(s, qid(), body).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::UnexpectedToken { expected, .. }) if expected == "end of input"
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::UnexpectedToken { expected, .. }) if *expected == "end of input"
         ));
     }
 
@@ -682,8 +688,8 @@ mod tests {
         let s = schema(1);
         let err = parse_inline_result_table(s, qid(), body).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::InvalidString { .. })
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::InvalidString { .. })
         ));
     }
 
@@ -693,8 +699,8 @@ mod tests {
         let s = schema(1);
         let err = parse_inline_result_table(s, qid(), body).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::InvalidString { .. })
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::InvalidString { .. })
         ));
     }
 
@@ -704,8 +710,8 @@ mod tests {
         let s = schema(1);
         let err = parse_inline_result_table(s, qid(), body).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::InvalidString { .. })
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::InvalidString { .. })
         ));
     }
 
@@ -716,8 +722,8 @@ mod tests {
         let s = schema(2);
         let err = parse_inline_result_table(s, qid(), body).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::RowLengthMismatch { .. })
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::RowLengthMismatch { .. })
         ));
     }
 
@@ -727,8 +733,8 @@ mod tests {
         let s = schema(1);
         let err = parse_inline_result_table(s, qid(), body).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::InvalidString { .. })
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::InvalidString { .. })
         ));
     }
 
@@ -754,8 +760,8 @@ mod tests {
         let s = schema(1);
         let err = parse_inline_result_table(s, qid(), body).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::UnexpectedToken { .. })
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::UnexpectedToken { .. })
         ));
     }
 
@@ -765,8 +771,8 @@ mod tests {
         let s = schema(1);
         let err = parse_remote_chunk_result_table(s, qid(), body).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::UnexpectedToken { .. })
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::UnexpectedToken { .. })
         ));
     }
 
@@ -783,8 +789,8 @@ mod tests {
         let err =
             parse_remote_chunk_result_table(s, qid(), Bytes::from_static(b" \n\t")).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::UnexpectedToken { expected, .. }) if expected == "'['"
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::UnexpectedToken { expected, .. }) if *expected == "'['"
         ));
     }
 
@@ -804,8 +810,8 @@ mod tests {
     {
         let err = parse(Bytes::from(body)).unwrap_err();
         assert!(matches!(
-            err,
-            Error::Parse(ParseError::UnexpectedToken { expected, .. }) if expected == "string or null"
+            err.as_rowset_parse_error(),
+            Some(RowsetParseError::UnexpectedToken { expected, .. }) if *expected == "string or null"
         ));
     }
 
@@ -953,6 +959,6 @@ mod tests {
         })
         .await
         .unwrap_err();
-        assert!(matches!(err, Error::FutureJoin(_)));
+        assert_eq!(err.kind(), crate::ErrorKind::Internal);
     }
 }

--- a/src/rowset/workload.rs
+++ b/src/rowset/workload.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result, runtime::BlockingParseLimiter};
+use crate::{Result, error::InternalError, runtime::BlockingParseLimiter};
 
 // These thresholds intentionally allow modest inline parsing so callers avoid
 // paying `spawn_blocking` overhead for medium-sized rowsets, while still
@@ -93,7 +93,7 @@ where
             work()
         })
         .await
-        .map_err(Error::FutureJoin)?;
+        .map_err(InternalError::future_join)?;
 
         Ok((ParseExecution::SpawnBlocking, result?))
     } else {

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,12 +20,27 @@ pub struct SnowflakeSession {
 
 impl SnowflakeSession {
     /// Submit a statement and return a `ResultSet` for streaming partition access.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::Network`, `ErrorKind::Server`, `ErrorKind::SessionExpired`,
+    /// `ErrorKind::Timeout`, or `ErrorKind::Protocol`.
     pub async fn query<Q: Into<QueryRequest>>(&self, request: Q) -> Result<ResultSet> {
         let executor = StatementExecutor::new(self);
         executor.execute(request.into()).await
     }
 
     /// Submit a statement and return a typed `ResultSet` for streaming partition access.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`SnowflakeSession::query`]. After the
+    /// statement succeeds, this also propagates any error returned by
+    /// [`FromRow::build_plan`] for `T`.
+    ///
+    /// Built-in and derive-based row types typically use
+    /// `ErrorKind::Decode` when the result schema does not match `T`;
+    /// inspect the detail via [`crate::Error::as_schema_error`].
     pub async fn query_as<T, Q>(&self, request: Q) -> Result<TypedResultSet<T>>
     where
         T: FromRow,

--- a/src/statement/client.rs
+++ b/src/statement/client.rs
@@ -5,7 +5,11 @@ use reqwest::{Client, Url};
 use tokio::time::sleep;
 use uuid::Uuid;
 
-use crate::{Error, Result, query::QueryRequest};
+use crate::{
+    Result,
+    error::{ConfigError, NetworkError, ProtocolError, TimeoutError},
+    query::QueryRequest,
+};
 
 use super::response::{
     QUERY_IN_PROGRESS_ASYNC_CODE, QUERY_IN_PROGRESS_CODE, SnowflakeResponse, parse_response,
@@ -32,7 +36,10 @@ impl StatementApiClient {
 
     pub(crate) async fn submit(&self, request: &QueryRequest) -> Result<SnowflakeResponse> {
         let request_id = Uuid::new_v4();
-        let mut url = self.base_url.join("queries/v1/query-request")?;
+        let mut url = self
+            .base_url
+            .join("queries/v1/query-request")
+            .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
         url.query_pairs_mut()
             .append_pair("requestId", &request_id.to_string());
 
@@ -46,13 +53,13 @@ impl StatementApiClient {
             )
             .json(request)
             .send()
-            .await?;
+            .await
+            .map_err(NetworkError::request)?;
 
         let status = response.status();
-        let body = response.bytes().await?;
+        let body = response.bytes().await.map_err(NetworkError::request)?;
         if !status.is_success() {
-            let body_text = String::from_utf8_lossy(&body[..]).into_owned();
-            return Err(Error::Communication(format!("HTTP {status}: {body_text}")));
+            return Err(NetworkError::http_status(status.as_u16(), &body).into());
         }
 
         parse_response(body)
@@ -65,7 +72,7 @@ impl StatementApiClient {
     ) -> Result<SnowflakeResponse> {
         const POLL_INTERVAL: Duration = Duration::from_secs(10);
 
-        let poll_url = self.base_url.join(poll_relative_url)?;
+        let poll_url = resolve_poll_url(&self.base_url, poll_relative_url)?;
         let deadline = Instant::now() + timeout;
 
         loop {
@@ -78,13 +85,13 @@ impl StatementApiClient {
                     format!(r#"Snowflake Token="{}""#, self.session_token),
                 )
                 .send()
-                .await?;
+                .await
+                .map_err(NetworkError::request)?;
 
             let status = resp.status();
-            let body = resp.bytes().await?;
+            let body = resp.bytes().await.map_err(NetworkError::request)?;
             if !status.is_success() {
-                let body_text = String::from_utf8_lossy(&body[..]).into_owned();
-                return Err(Error::Communication(format!("HTTP {status}: {body_text}")));
+                return Err(NetworkError::http_status(status.as_u16(), &body).into());
             }
 
             let response = parse_response(body)?;
@@ -96,9 +103,98 @@ impl StatementApiClient {
 
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                return Err(Error::TimedOut);
+                return Err(TimeoutError::query().into());
             }
             sleep(remaining.min(POLL_INTERVAL)).await;
         }
+    }
+}
+
+fn resolve_poll_url(base_url: &Url, poll_relative_url: &str) -> Result<Url> {
+    const FIELD: &str = "data.getResultUrl";
+
+    if poll_relative_url.trim().is_empty() {
+        return Err(ProtocolError::invalid_field(FIELD, "must not be empty").into());
+    }
+
+    if let Ok(url) = Url::parse(poll_relative_url) {
+        validate_same_origin_absolute_url(base_url, &url, FIELD)?;
+        return Ok(url);
+    }
+
+    let url = base_url
+        .join(poll_relative_url)
+        .map_err(|e| ProtocolError::invalid_response_url(FIELD, poll_relative_url, e))?;
+
+    validate_same_origin_absolute_url(base_url, &url, FIELD)?;
+    Ok(url)
+}
+
+fn validate_same_origin_absolute_url(base_url: &Url, url: &Url, field: &'static str) -> Result<()> {
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(ProtocolError::invalid_field(field, "must not contain credentials").into());
+    }
+
+    let same_origin = url.scheme() == base_url.scheme()
+        && url.host_str() == base_url.host_str()
+        && url.port_or_known_default() == base_url.port_or_known_default();
+
+    if !same_origin {
+        return Err(ProtocolError::invalid_field(
+            field,
+            "must be relative or same-origin absolute URL",
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ErrorKind;
+
+    #[test]
+    fn resolve_poll_url_accepts_relative_and_same_origin_absolute_urls() {
+        let base_url = Url::parse("https://example.com/").unwrap();
+
+        let relative =
+            resolve_poll_url(&base_url, "/queries/v1/query-request?requestId=abc").unwrap();
+        assert_eq!(
+            relative.as_str(),
+            "https://example.com/queries/v1/query-request?requestId=abc"
+        );
+
+        let absolute = resolve_poll_url(
+            &base_url,
+            "https://example.com/queries/v1/query-request?requestId=def",
+        )
+        .unwrap();
+        assert_eq!(
+            absolute.as_str(),
+            "https://example.com/queries/v1/query-request?requestId=def"
+        );
+    }
+
+    #[test]
+    fn resolve_poll_url_rejects_cross_origin_and_credentialed_absolute_urls() {
+        let base_url = Url::parse("https://example.com/").unwrap();
+
+        let err = resolve_poll_url(&base_url, "https://attacker.example/query")
+            .expect_err("cross-origin poll URL must fail");
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "invalid Snowflake response field data.getResultUrl: must be relative or same-origin absolute URL"
+        );
+
+        let err = resolve_poll_url(&base_url, "https://user:pass@example.com/query")
+            .expect_err("credentialed poll URL must fail");
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "invalid Snowflake response field data.getResultUrl: must not contain credentials"
+        );
     }
 }

--- a/src/statement/executor.rs
+++ b/src/statement/executor.rs
@@ -1,9 +1,8 @@
 use std::{num::NonZeroUsize, time::Duration};
 
-use serde::de::Error as _;
-
 use crate::{
     chunk::ChunkDownloader,
+    error::{ProtocolError, ServerError},
     query::QueryRequest,
     query_result::{
         CollectPolicy, InlineRowset, ResultSet,
@@ -57,10 +56,7 @@ impl StatementExecutor {
             || response_code == Some(QUERY_IN_PROGRESS_CODE)
         {
             let Some(data) = response.data else {
-                return Err(Error::Json(
-                    serde_json::Error::custom("missing data field in async query response"),
-                    "".to_string(),
-                ));
+                return Err(ProtocolError::missing_field("data").into());
             };
 
             match data.get_result_url {
@@ -71,29 +67,27 @@ impl StatementExecutor {
                         .await?;
                 }
                 None => {
-                    return Err(Error::NoPollingUrlAsyncQuery);
+                    return Err(ProtocolError::no_polling_url().into());
                 }
             }
         }
 
         if let Some(SESSION_EXPIRED) = response.code.as_deref() {
-            return Err(Error::SessionExpired);
+            return Err(Error::session_expired(response.code, response.message));
         }
 
         if !response.success {
-            return Err(Error::Communication(response.message.unwrap_or_default()));
+            let query_id = response.data.as_ref().map(|data| data.query_id.clone());
+            return Err(ServerError::new(response.code, response.message, query_id).into());
         }
 
         let Some(data) = response.data else {
-            return Err(Error::Json(
-                serde_json::Error::custom("missing data field in query response"),
-                "".to_string(),
-            ));
+            return Err(ProtocolError::missing_field("data").into());
         };
 
         if let Some(ref format) = data.query_result_format {
             if format != "json" {
-                return Err(Error::UnsupportedFormat(format.clone()));
+                return Err(ProtocolError::unsupported_result_format(format.clone()).into());
             }
         }
 
@@ -126,7 +120,13 @@ impl StatementExecutor {
 
 #[cfg(test)]
 mod tests {
-    use std::{num::NonZeroUsize, time::Duration};
+    use std::{
+        io::{Read, Write},
+        net::TcpListener as StdTcpListener,
+        num::NonZeroUsize,
+        thread,
+        time::Duration,
+    };
 
     use bytes::Bytes;
     use reqwest::{Client, Url};
@@ -135,7 +135,6 @@ mod tests {
     use super::super::client::StatementApiClient;
     use super::*;
     use crate::{
-        Error,
         rowset::BLOCKING_PARSE_CELLS,
         runtime::QueryRuntime,
         statement::response::{RawQueryResponse, RawQueryResponseChunk, RawQueryResponseRowType},
@@ -152,6 +151,26 @@ mod tests {
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime: QueryRuntime::new(),
         }
+    }
+
+    fn spawn_single_response_server(body: &'static str) -> Url {
+        let listener = StdTcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 4096];
+            let _ = stream.read(&mut buf);
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        Url::parse(&format!("http://{addr}/")).unwrap()
     }
 
     fn chunk_only_response(row_types: Option<Vec<RawQueryResponseRowType>>) -> RawQueryResponse {
@@ -223,6 +242,113 @@ mod tests {
                 .runtime
                 .blocking_parse_limiter()
                 .ptr_eq(&runtime.blocking_parse_limiter())
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_async_response_with_invalid_polling_url_is_protocol_error() {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_single_response_server(
+                r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"http://[::1"}}"#,
+            ),
+            session_token: "test-token".to_string(),
+            query: crate::SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        let err = StatementExecutor::new(&session)
+            .execute(crate::query::QueryRequest::from("select 1"))
+            .await;
+        let err = match err {
+            Ok(_) => panic!("expected invalid getResultUrl to fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        assert!(err.to_string().contains("data.getResultUrl"));
+    }
+
+    #[tokio::test]
+    async fn execute_async_response_with_cross_origin_polling_url_is_protocol_error() {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_single_response_server(
+                r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"https://attacker.example/query"}}"#,
+            ),
+            session_token: "test-token".to_string(),
+            query: crate::SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        let err = StatementExecutor::new(&session)
+            .execute(crate::query::QueryRequest::from("select 1"))
+            .await;
+        let err = match err {
+            Ok(_) => panic!("expected cross-origin getResultUrl to fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "invalid Snowflake response field data.getResultUrl: must be relative or same-origin absolute URL"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_async_response_with_empty_polling_url_is_protocol_error() {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_single_response_server(
+                r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"   "}}"#,
+            ),
+            session_token: "test-token".to_string(),
+            query: crate::SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        let err = StatementExecutor::new(&session)
+            .execute(crate::query::QueryRequest::from("select 1"))
+            .await;
+        let err = match err {
+            Ok(_) => panic!("expected empty getResultUrl to fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "invalid Snowflake response field data.getResultUrl: must not be empty"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_session_expired_preserves_snowflake_fields() {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_single_response_server(
+                r#"{"code":"390112","message":"Your session has expired. Please login again.","success":false,"data":null}"#,
+            ),
+            session_token: "test-token".to_string(),
+            query: crate::SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        let err = match StatementExecutor::new(&session)
+            .execute(crate::query::QueryRequest::from("select 1"))
+            .await
+        {
+            Ok(_) => panic!("session expired response must fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), crate::ErrorKind::SessionExpired);
+        assert!(err.is_session_expired());
+        assert_eq!(err.snowflake_code(), Some("390112"));
+        assert_eq!(
+            err.snowflake_message(),
+            Some("Your session has expired. Please login again.")
         );
     }
 
@@ -362,14 +488,22 @@ mod tests {
 
     #[test]
     fn chunk_only_results_require_rowtype_metadata_when_missing_or_empty() {
-        for (label, row_types) in [
-            ("missing", None),
-            ("empty", Some(Vec::<RawQueryResponseRowType>::new())),
+        for (label, row_types, expected) in [
+            (
+                "missing",
+                None,
+                "missing required field in Snowflake response: data.rowtype",
+            ),
+            (
+                "empty",
+                Some(Vec::<RawQueryResponseRowType>::new()),
+                "invalid Snowflake response field data.rowtype: must not be empty when result data is present",
+            ),
         ] {
             match executor().build_result_set(chunk_only_response(row_types)) {
-                Err(Error::UnsupportedFormat(message))
-                    if message == "response has result data but no rowtype metadata" => {}
-                Err(other) => panic!("expected UnsupportedFormat, got {other:?}"),
+                Err(err)
+                    if err.kind() == crate::ErrorKind::Protocol && err.to_string() == expected => {}
+                Err(other) => panic!("expected rowtype metadata error, got {other:?}"),
                 Ok(_) => {
                     panic!("expected chunk-only response with {label} rowtype metadata to fail")
                 }

--- a/src/statement/manifest.rs
+++ b/src/statement/manifest.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 
 use crate::{
     Error, Result,
+    error::ProtocolError,
     query_result::snapshot::{
         DownloadLocator, PartitionSpec, ResolvedLease, ResultIdentity, ResultSnapshot,
     },
@@ -52,14 +53,18 @@ impl TryFrom<RawQueryResponse> for ResultManifest {
             returned.or(total).and_then(|v| u64::try_from(v).ok())
         };
 
-        if (has_inline || !chunks.is_empty())
-            && row_types
-                .as_ref()
-                .is_none_or(|row_types| row_types.is_empty())
-        {
-            return Err(Error::UnsupportedFormat(
-                "response has result data but no rowtype metadata".to_string(),
-            ));
+        if has_inline || !chunks.is_empty() {
+            match row_types.as_ref() {
+                None => return Err(ProtocolError::missing_field("data.rowtype").into()),
+                Some(row_types) if row_types.is_empty() => {
+                    return Err(ProtocolError::invalid_field(
+                        "data.rowtype",
+                        "must not be empty when result data is present",
+                    )
+                    .into());
+                }
+                Some(_) => {}
+            }
         }
 
         let columns = row_types
@@ -120,5 +125,112 @@ impl TryFrom<RawQueryResponse> for ResultManifest {
             lease: ResolvedLease { locators },
             snapshot,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::statement::response::{RawQueryResponseChunk, RawQueryResponseRowType};
+
+    fn text_row_type(name: &str) -> RawQueryResponseRowType {
+        RawQueryResponseRowType {
+            database: String::new(),
+            name: name.to_string(),
+            nullable: false,
+            scale: None,
+            byte_length: Some(16),
+            length: Some(16),
+            schema: String::new(),
+            table: String::new(),
+            precision: None,
+            data_type: "text".to_string(),
+        }
+    }
+
+    #[test]
+    fn manifest_requires_rowtype_when_inline_data_is_present() {
+        let response = RawQueryResponse {
+            parameters: None,
+            query_id: "query-id".to_string(),
+            get_result_url: None,
+            returned: Some(1),
+            total: None,
+            row_set_bytes: Some(Bytes::from_static(br#"[["x"]]"#)),
+            row_types: None,
+            chunk_headers: None,
+            qrmk: None,
+            chunks: None,
+            query_result_format: Some("json".to_string()),
+        };
+
+        let err = match ResultManifest::try_from(response) {
+            Ok(_) => panic!("missing rowtype metadata must fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "missing required field in Snowflake response: data.rowtype"
+        );
+    }
+
+    #[test]
+    fn manifest_rejects_empty_rowtype_when_result_data_is_present() {
+        let response = RawQueryResponse {
+            parameters: None,
+            query_id: "query-id".to_string(),
+            get_result_url: None,
+            returned: None,
+            total: None,
+            row_set_bytes: None,
+            row_types: Some(Vec::new()),
+            chunk_headers: None,
+            qrmk: None,
+            chunks: Some(vec![RawQueryResponseChunk {
+                url: "https://example.com/chunk/0".to_string(),
+                row_count: 1,
+                uncompressed_size: 16,
+                compressed_size: 8,
+            }]),
+            query_result_format: Some("json".to_string()),
+        };
+
+        let err = match ResultManifest::try_from(response) {
+            Ok(_) => panic!("empty rowtype metadata must fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "invalid Snowflake response field data.rowtype: must not be empty when result data is present"
+        );
+    }
+
+    #[test]
+    fn manifest_accepts_non_empty_rowtype_when_result_data_is_present() {
+        let response = RawQueryResponse {
+            parameters: None,
+            query_id: "query-id".to_string(),
+            get_result_url: None,
+            returned: Some(1),
+            total: None,
+            row_set_bytes: Some(Bytes::from_static(br#"[["x"]]"#)),
+            row_types: Some(vec![text_row_type("X")]),
+            chunk_headers: None,
+            qrmk: None,
+            chunks: None,
+            query_result_format: Some("json".to_string()),
+        };
+
+        let manifest = ResultManifest::try_from(response).unwrap();
+        assert_eq!(manifest.snapshot.schema.len(), 1);
+        assert_eq!(manifest.snapshot.partitions.len(), 1);
+        assert!(matches!(
+            manifest.snapshot.partitions.first(),
+            Some(PartitionSpec::Inline)
+        ));
     }
 }

--- a/src/statement/response.rs
+++ b/src/statement/response.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, io, sync::Arc};
 
 use bytes::Bytes;
-use http::HeaderMap;
+use http::{HeaderMap, HeaderValue};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 
-use crate::{Error, Result};
+use crate::{Error, Result, error::ProtocolError};
 
 pub(crate) const SESSION_EXPIRED: &str = "390112";
 pub(crate) const QUERY_IN_PROGRESS_CODE: &str = "333333";
@@ -61,7 +61,7 @@ struct BorrowedSnowflakeResponse<'a> {
 #[serde(rename_all = "camelCase")]
 struct BorrowedRawQueryResponse<'a> {
     parameters: Option<Vec<RawQueryResponseParameter>>,
-    query_id: String,
+    query_id: Option<String>,
     get_result_url: Option<String>,
     returned: Option<i64>,
     total: Option<i64>,
@@ -83,7 +83,7 @@ struct BorrowedRawQueryResponse<'a> {
 pub(crate) fn parse_response(body: Bytes) -> Result<SnowflakeResponse> {
     let borrowed: BorrowedSnowflakeResponse<'_> =
         serde_json::from_slice(strip_utf8_bom(body.as_ref()))
-            .map_err(|e| Error::Json(e, String::from_utf8_lossy(&body[..]).into_owned()))?;
+            .map_err(|e| ProtocolError::json_parse(e, &body))?;
 
     let data = borrowed
         .data
@@ -94,7 +94,9 @@ pub(crate) fn parse_response(body: Bytes) -> Result<SnowflakeResponse> {
                 .transpose()?;
             Ok::<RawQueryResponse, Error>(RawQueryResponse {
                 parameters: d.parameters,
-                query_id: d.query_id,
+                query_id: d
+                    .query_id
+                    .ok_or_else(|| ProtocolError::missing_field("data.queryId"))?,
                 get_result_url: d.get_result_url,
                 returned: d.returned,
                 total: d.total,
@@ -140,10 +142,11 @@ fn row_set_bytes_from_raw_value(body: &Bytes, raw: &RawValue) -> Result<Bytes> {
 }
 
 fn json_scan_error(body: &Bytes, message: impl Into<String>) -> Error {
-    Error::Json(
+    ProtocolError::json_parse(
         serde_json::Error::io(io::Error::new(io::ErrorKind::InvalidData, message.into())),
-        String::from_utf8_lossy(&body[..]).into_owned(),
+        body,
     )
+    .into()
 }
 
 fn strip_utf8_bom(bytes: &[u8]) -> &[u8] {
@@ -199,11 +202,15 @@ pub(crate) fn resolve_download_headers(
     // returns `chunkHeaders: {}` that empty map is used as-is, without
     // falling back to qrmk-derived SSE-C headers.
     let headers = match (chunk_headers, qrmk) {
-        (Some(ch), _) => HeaderMap::try_from(ch)?,
+        (Some(ch), _) => HeaderMap::try_from(ch).map_err(ProtocolError::header_conversion)?,
         (None, Some(qrmk)) => {
             let mut h = HeaderMap::with_capacity(2);
-            h.append(HEADER_SSE_C_ALGORITHM, AES256.parse()?);
-            h.append(HEADER_SSE_C_KEY, qrmk.parse()?);
+            h.append(HEADER_SSE_C_ALGORITHM, HeaderValue::from_static(AES256));
+            h.append(
+                HEADER_SSE_C_KEY,
+                qrmk.parse()
+                    .map_err(ProtocolError::invalid_response_header_value)?,
+            );
             h
         }
         _ => HeaderMap::new(),
@@ -286,7 +293,10 @@ mod tests {
         let body = Bytes::from(
             r#"{"message":"\uD83D","data":{"queryId":"q1","rowset":[["ok"]],"rowtype":[],"queryResultFormat":"json"},"success":true}"#,
         );
-        assert!(matches!(parse_response(body), Err(Error::Json(..))));
+        assert!(matches!(
+            parse_response(body),
+            Err(err) if err.kind() == crate::ErrorKind::Protocol
+        ));
     }
 
     #[test]
@@ -296,6 +306,18 @@ mod tests {
         );
         let resp = parse_response(body).unwrap();
         assert!(resp.data.expect("data").row_set_bytes.is_none());
+    }
+
+    #[test]
+    fn parse_response_missing_query_id_is_protocol_error() {
+        let body = Bytes::from(r#"{"data":{"rowset":null},"success":true}"#);
+
+        let err = parse_response(body).unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "missing required field in Snowflake response: data.queryId"
+        );
     }
 
     #[test]
@@ -346,5 +368,20 @@ mod tests {
             headers.get(HEADER_SSE_C_KEY).is_none(),
             "qrmk headers must not be present when chunkHeaders is provided"
         );
+    }
+
+    #[test]
+    fn resolve_headers_invalid_chunk_headers_are_protocol_errors() {
+        let mut map = HashMap::new();
+        map.insert("x-custom".to_string(), "bad\nvalue".to_string());
+
+        let err = resolve_download_headers(&None, &Some(map)).unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+    }
+
+    #[test]
+    fn resolve_headers_invalid_qrmk_is_protocol_error() {
+        let err = resolve_download_headers(&Some("bad\nvalue".into()), &None).unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
     }
 }

--- a/tests/cases/common.rs
+++ b/tests/cases/common.rs
@@ -35,10 +35,10 @@ fn connect_with_configs(
     if let Some(host) = host {
         let scheme = protocol.unwrap_or_else(|| "https".to_string());
         let mut url = Url::parse(&format!("{scheme}://{host}"))
-            .map_err(|e| snowflake_connector_rs::Error::Url(e.to_string()))?;
+            .map_err(|e| snowflake_connector_rs::Error::other(e.to_string()))?;
         if let Some(port) = port {
             url.set_port(Some(port))
-                .map_err(|_| snowflake_connector_rs::Error::Url("invalid base url port".into()))?;
+                .map_err(|_| snowflake_connector_rs::Error::other("invalid base url port"))?;
         }
         client_config = client_config.with_endpoint(SnowflakeEndpointConfig::custom_base_url(url));
     }

--- a/tests/cases/test_bind_parameters.rs
+++ b/tests/cases/test_bind_parameters.rs
@@ -302,7 +302,7 @@ async fn test_bind_parameters_timestamp_tz_round_trips_control_and_extreme_offse
         let rendered = render_bound_timestamp_tz(&session, offset)
             .await
             .map_err(|err| {
-                snowflake_connector_rs::Error::Communication(format!(
+                snowflake_connector_rs::Error::other(format!(
                     "{label} bind unexpectedly failed: {err}"
                 ))
             })?;

--- a/tests/cases/test_decode.rs
+++ b/tests/cases/test_decode.rs
@@ -136,11 +136,11 @@ async fn test_dynamic_row_get_resolves_escaped_identifiers() -> Result<()> {
 
     assert!(matches!(
         row.get("MIXEDCASE"),
-        Err(SchemaError::MissingColumn { .. })
+        Err(SchemaError::MissingColumn(_))
     ));
     assert!(matches!(
         row.get("MY COLUMN"),
-        Err(SchemaError::MissingColumn { .. })
+        Err(SchemaError::MissingColumn(_))
     ));
 
     Ok(())

--- a/tests/cases/test_derive.rs
+++ b/tests/cases/test_derive.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDateTime;
 
-use snowflake_connector_rs::{DecimalValue, Error, FromRow, Result, SchemaError};
+use snowflake_connector_rs::{DecimalValue, FromRow, Result, SchemaError};
 
 use super::common;
 
@@ -180,8 +180,8 @@ async fn derive_required_fields_surface_schema_and_decode_errors() -> Result<()>
         .err()
         .expect("missing named column should fail during plan building");
 
-    match err {
-        Error::Schema(SchemaError::MissingColumn { name }) => assert_eq!(name.as_ref(), "BIO"),
+    match err.as_schema_error() {
+        Some(SchemaError::MissingColumn(error)) => assert_eq!(error.name(), "BIO"),
         other => panic!("expected MissingColumn, got: {other:?}"),
     }
 
@@ -191,8 +191,8 @@ async fn derive_required_fields_surface_schema_and_decode_errors() -> Result<()>
         .err()
         .expect("default lookup should not match lowercase quoted labels");
 
-    match err {
-        Error::Schema(SchemaError::MissingColumn { name }) => assert_eq!(name.as_ref(), "VALUE"),
+    match err.as_schema_error() {
+        Some(SchemaError::MissingColumn(error)) => assert_eq!(error.name(), "VALUE"),
         other => panic!("expected MissingColumn, got: {other:?}"),
     }
 
@@ -202,10 +202,10 @@ async fn derive_required_fields_surface_schema_and_decode_errors() -> Result<()>
         .err()
         .expect("short positional row should fail during plan building");
 
-    match err {
-        Error::Schema(SchemaError::ColumnCountMismatch { expected, actual }) => {
-            assert_eq!(expected, 2);
-            assert_eq!(actual, 1);
+    match err.as_schema_error() {
+        Some(SchemaError::ColumnCountMismatch(error)) => {
+            assert_eq!(error.expected(), 2);
+            assert_eq!(error.actual(), 1);
         }
         other => panic!("expected ColumnCountMismatch, got: {other:?}"),
     }
@@ -217,8 +217,8 @@ async fn derive_required_fields_surface_schema_and_decode_errors() -> Result<()>
         .await
         .expect_err("non-Option NULL should surface the decode error");
 
-    match err {
-        Error::Decode(err) => {
+    match err.as_cell_decode_error() {
+        Some(err) => {
             assert_eq!(err.column_name(), "NOTE");
             assert_eq!(err.reason(), "value is NULL");
         }
@@ -231,10 +231,10 @@ async fn derive_required_fields_surface_schema_and_decode_errors() -> Result<()>
         .err()
         .expect("duplicate raw labels should fail during plan building");
 
-    match err {
-        Error::Schema(SchemaError::AmbiguousColumn { .. }) => {}
-        other => panic!("expected AmbiguousColumn, got: {other:?}"),
-    }
+    assert!(matches!(
+        err.as_schema_error(),
+        Some(SchemaError::AmbiguousColumn(_))
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
## Overview

Redesign the crate's public error API around `ErrorKind`.
The goal is to remove external crate types such as `reqwest::Error` from the public surface, so users only need to consider `snowflake-connector-rs` types for semver compatibility.

## Design

- `Error` is now an opaque struct instead of a public enum.
- Users classify errors via `err.kind()` and `ErrorKind`, rather than matching on internal representations.
- Common operational checks such as timeout and session expiration can be obtained directly through helpers like `is_timeout()`, `is_session_expired()`, and `snowflake_code()`.
- Schema mismatches and cell decode failures can be extracted as `SchemaError` / `CellDecodeError`, making them easier to handle in user code.

## Migration example

```rust
match err.kind() {
    ErrorKind::Timeout => { /* retry */ }
    ErrorKind::SessionExpired => { /* re-auth */ }
    ErrorKind::Schema => { /* inspect err.as_schema_error() */ }
    _ => { /* fallback */ }
}
```
