### PR TITLE
feat(error): propagate query_id from query-scope failures via typed internal errors

### DIFF
--- a/src/auth/external_browser.rs
+++ b/src/auth/external_browser.rs
@@ -15,7 +15,9 @@ mod payload;
 use crate::{
     Result,
     auth::client::AUTH_REQUEST_TIMEOUT,
-    error::{AuthError, ConfigError, NetworkError, ProtocolError, TimeoutError},
+    error::{
+        AuthError, ConfigError, NetworkError, ProtocolError, TimeoutError, classify_request_error,
+    },
 };
 
 use launcher::{BrowserLauncher, LaunchOutcome, SystemCommandRunner};
@@ -158,9 +160,9 @@ async fn request_external_browser_challenge(
         .json(&body)
         .send()
         .await
-        .map_err(NetworkError::request)?;
+        .map_err(classify_request_error)?;
     let status = resp.status();
-    let text = resp.text().await.map_err(NetworkError::request)?;
+    let text = resp.text().await.map_err(classify_request_error)?;
     if !status.is_success() {
         return Err(NetworkError::http_status(status.as_u16(), text.as_bytes()).into());
     }

--- a/src/auth/login.rs
+++ b/src/auth/login.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     Result, SnowflakeAuthMethod, SnowflakeClientConfig,
-    error::{AuthError, ConfigError, NetworkError, ProtocolError},
+    error::{AuthError, ConfigError, NetworkError, ProtocolError, classify_request_error},
 };
 
 use super::client::AUTH_REQUEST_TIMEOUT;
@@ -118,10 +118,10 @@ pub(crate) async fn login(
         );
     }
 
-    let resp = request.send().await.map_err(NetworkError::request)?;
+    let resp = request.send().await.map_err(classify_request_error)?;
 
     let status = resp.status();
-    let body = resp.text().await.map_err(NetworkError::request)?;
+    let body = resp.text().await.map_err(classify_request_error)?;
     if !status.is_success() {
         return Err(NetworkError::http_status(status.as_u16(), body.as_bytes()).into());
     }

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 
 pub use crate::result::test_data::{make_result_table_from_rows, make_schema};
-pub use crate::rowset::parser::inline_rows_to_result_table;
 
 #[derive(Debug, Clone)]
 pub struct StatementEnvelopeParts {
@@ -48,7 +47,15 @@ pub fn parse_inline_result_table(
 }
 
 pub fn decode_gzip_chunk(body: Bytes) -> Result<Bytes> {
-    rowset::decode_gzip_chunk(body)
+    rowset::decode_gzip_chunk(body).map_err(crate::Error::from)
+}
+
+pub fn inline_rows_to_result_table(
+    schema: Arc<Schema>,
+    query_id: Arc<str>,
+    rows: Vec<Vec<Option<String>>>,
+) -> Result<ResultTable> {
+    parser::inline_rows_to_result_table_inner(schema, query_id, rows).map_err(crate::Error::from)
 }
 
 pub fn parse_remote_chunk_result_table(
@@ -87,5 +94,7 @@ pub async fn parse_remote_chunk_result_table_async_with_workload(
             Some(uncompressed_bytes.unwrap_or(body.len()))
         },
     };
-    parser::parse_remote_chunk_result_table_async(schema, query_id, body, workload, None).await
+    parser::parse_remote_chunk_result_table_async(schema, query_id, body, workload, None)
+        .await
+        .map_err(crate::Error::from)
 }

--- a/src/chunk/downloader.rs
+++ b/src/chunk/downloader.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io, sync::Arc, time::Duration};
+use std::{fmt, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use http::HeaderMap;
@@ -6,8 +6,7 @@ use reqwest::StatusCode;
 use tokio::time::sleep;
 
 use crate::{
-    Error, Result,
-    error::NetworkError,
+    error::{NetworkError, QueryScopedError, QueryScopedResult, TimeoutError},
     query_result::partition_source::FetchContext,
     result::{ResultTable, Schema},
     rowset::{ParseWorkload, parser::parse_remote_chunk_result_table_async},
@@ -19,27 +18,15 @@ const MAX_RETRY_DELAY: Duration = Duration::from_secs(16);
 
 /// Internal download error used for retry classification.
 enum DownloadFailure {
-    Retryable(Error),
-    Fatal(Error),
+    Retryable(QueryScopedError),
+    Fatal(QueryScopedError),
 }
 
 impl DownloadFailure {
-    fn into_inner(self) -> Error {
+    fn into_inner(self) -> QueryScopedError {
         match self {
             Self::Retryable(e) | Self::Fatal(e) => e,
         }
-    }
-}
-
-impl From<reqwest::Error> for DownloadFailure {
-    fn from(e: reqwest::Error) -> Self {
-        Self::Retryable(NetworkError::request(e))
-    }
-}
-
-impl From<io::Error> for DownloadFailure {
-    fn from(e: io::Error) -> Self {
-        Self::Retryable(NetworkError::io(e).into())
     }
 }
 
@@ -60,7 +47,7 @@ impl ChunkDownloader {
         headers: &HeaderMap,
         schema: Arc<Schema>,
         ctx: FetchContext,
-    ) -> Result<ResultTable> {
+    ) -> QueryScopedResult<ResultTable> {
         let mut retries = 0;
         loop {
             match self
@@ -84,13 +71,47 @@ impl ChunkDownloader {
         schema: Arc<Schema>,
         ctx: FetchContext,
     ) -> std::result::Result<ResultTable, DownloadFailure> {
-        let response = self.client.get(url).headers(headers).send().await?;
+        let response = match self.client.get(url).headers(headers).send().await {
+            Ok(response) => response,
+            Err(error) => {
+                if error.is_timeout() {
+                    return Err(DownloadFailure::Retryable(QueryScopedError::new(
+                        ctx.query_id,
+                        TimeoutError::request(error),
+                    )));
+                }
+                return Err(DownloadFailure::Retryable(QueryScopedError::new(
+                    ctx.query_id,
+                    NetworkError::Http(error),
+                )));
+            }
+        };
+
         let status = response.status();
         if !status.is_success() {
-            return Err(classify_failed_status(status, response.bytes().await));
+            return Err(classify_failed_status(
+                status,
+                response.bytes().await,
+                ctx.query_id,
+            ));
         }
 
-        let body = response.bytes().await?;
+        let body = match response.bytes().await {
+            Ok(body) => body,
+            Err(error) => {
+                if error.is_timeout() {
+                    return Err(DownloadFailure::Retryable(QueryScopedError::new(
+                        ctx.query_id,
+                        TimeoutError::request(error),
+                    )));
+                }
+                return Err(DownloadFailure::Retryable(QueryScopedError::new(
+                    ctx.query_id,
+                    NetworkError::Http(error),
+                )));
+            }
+        };
+
         let gzip_encoded = body.len() >= 2 && body[0] == 0x1f && body[1] == 0x8b;
         let workload = ParseWorkload::remote_chunk(
             body.len(),
@@ -103,7 +124,7 @@ impl ChunkDownloader {
 
         parse_remote_chunk_result_table_async(
             schema,
-            ctx.query_id,
+            Arc::clone(&ctx.query_id),
             body,
             workload,
             ctx.blocking_parse_limiter,
@@ -116,17 +137,23 @@ impl ChunkDownloader {
 fn classify_failed_status<E>(
     status: StatusCode,
     body: std::result::Result<Bytes, E>,
+    query_id: Arc<str>,
 ) -> DownloadFailure
 where
     E: fmt::Display,
 {
-    let error: Error = match body {
-        Ok(body) => NetworkError::chunk_download(status.as_u16(), body).into(),
-        Err(err) => NetworkError::chunk_download(
-            status.as_u16(),
-            format!("<failed to read response body: {err}>"),
-        )
-        .into(),
+    let error = match body {
+        Ok(body) => QueryScopedError::new(
+            query_id,
+            NetworkError::chunk_download(status.as_u16(), body),
+        ),
+        Err(err) => QueryScopedError::new(
+            query_id,
+            NetworkError::chunk_download(
+                status.as_u16(),
+                format!("<failed to read response body: {err}>"),
+            ),
+        ),
     };
 
     if is_retryable_status(status) {
@@ -149,8 +176,14 @@ fn retry_delay(retries: usize) -> Duration {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::ErrorKind;
+
+    fn qid() -> Arc<str> {
+        Arc::from("query-id")
+    }
 
     #[test]
     fn retryable_status_codes() {
@@ -180,8 +213,9 @@ mod tests {
 
     #[test]
     fn body_read_failure_keeps_non_retryable_status_fatal() {
-        match classify_failed_status(StatusCode::FORBIDDEN, Err("body read failed")) {
+        match classify_failed_status(StatusCode::FORBIDDEN, Err("body read failed"), qid()) {
             DownloadFailure::Fatal(error) => {
+                let error: crate::Error = error.into();
                 assert_eq!(error.kind(), ErrorKind::Network);
                 assert_eq!(
                     error.to_string(),
@@ -189,15 +223,16 @@ mod tests {
                 );
             }
             DownloadFailure::Retryable(error) => {
-                panic!("expected fatal classification, got retryable: {error}")
+                panic!("expected fatal classification, got retryable: {error:?}")
             }
         }
     }
 
     #[test]
     fn body_read_failure_keeps_retryable_status_retryable() {
-        match classify_failed_status(StatusCode::BAD_GATEWAY, Err("body read failed")) {
+        match classify_failed_status(StatusCode::BAD_GATEWAY, Err("body read failed"), qid()) {
             DownloadFailure::Retryable(error) => {
+                let error: crate::Error = error.into();
                 assert_eq!(error.kind(), ErrorKind::Network);
                 assert_eq!(
                     error.to_string(),
@@ -205,7 +240,7 @@ mod tests {
                 );
             }
             DownloadFailure::Fatal(error) => {
-                panic!("expected retryable classification, got fatal: {error}")
+                panic!("expected retryable classification, got fatal: {error:?}")
             }
         }
     }
@@ -215,14 +250,16 @@ mod tests {
         match classify_failed_status(
             StatusCode::FORBIDDEN,
             Ok::<Bytes, &str>(Bytes::from_static(b"\xfffoo")),
+            qid(),
         ) {
             DownloadFailure::Fatal(error) => {
+                let error: crate::Error = error.into();
                 assert_eq!(error.kind(), ErrorKind::Network);
                 assert!(error.to_string().contains("foo"));
                 assert!(!error.to_string().contains("<failed to read response body"));
             }
             DownloadFailure::Retryable(error) => {
-                panic!("expected fatal classification, got retryable: {error}")
+                panic!("expected fatal classification, got retryable: {error:?}")
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,18 @@
 mod decode;
 mod display;
 mod parse;
+mod query_scoped;
 mod repr;
 mod schema;
 
-use std::{error::Error as StdError, fmt};
+use std::{error::Error as StdError, fmt, sync::Arc};
 
 use reqwest::header::InvalidHeaderValue;
 use tokio::task::JoinError;
 
 pub use decode::CellDecodeError;
 pub(crate) use parse::RowsetParseError;
+pub(crate) use query_scoped::{QueryScopedError, QueryScopedRepr, QueryScopedResult};
 use repr::Repr;
 pub(crate) use repr::{
     AuthError, ConfigError, InternalError, NetworkError, ProtocolError, ServerError,
@@ -105,12 +107,12 @@ impl Error {
         match &*self.repr {
             Repr::Config(_) => ErrorKind::Config,
             Repr::Auth(_) => ErrorKind::Auth,
-            Repr::Network(_) => ErrorKind::Network,
+            Repr::Network { .. } => ErrorKind::Network,
             Repr::Server(_) => ErrorKind::Server,
             Repr::SessionExpired(_) => ErrorKind::SessionExpired,
-            Repr::Timeout(_) => ErrorKind::Timeout,
-            Repr::Protocol(_) => ErrorKind::Protocol,
-            Repr::Internal(_) => ErrorKind::Internal,
+            Repr::Timeout { .. } => ErrorKind::Timeout,
+            Repr::Protocol { .. } => ErrorKind::Protocol,
+            Repr::Internal { .. } => ErrorKind::Internal,
             Repr::Other(_) => ErrorKind::Other,
             Repr::Schema(_) | Repr::CellDecode(_) => ErrorKind::Decode,
         }
@@ -135,10 +137,24 @@ impl Error {
         }
     }
 
-    /// Returns the related Snowflake query ID when one is available.
+    /// Returns the related Snowflake query ID when the connector could extract
+    /// one from the failure path.
+    ///
+    /// `None` does not mean "Snowflake did not assign a query ID". The
+    /// accessor may return `None` when, for example, response parsing failed
+    /// before the query ID could be extracted, or when another access path
+    /// (a live `ResultSet` / `ResultTable` receiver) was available to the caller.
+    ///
+    /// If an API that reliably exposes the query ID is available (e.g.
+    /// `ResultSet::query_id`), prefer that. Use this accessor as a best-effort fallback.
     pub fn query_id(&self) -> Option<&str> {
         match &*self.repr {
+            Repr::Network { query_id, .. }
+            | Repr::Timeout { query_id, .. }
+            | Repr::Protocol { query_id, .. }
+            | Repr::Internal { query_id, .. } => query_id.as_deref(),
             Repr::Server(ServerError { query_id, .. }) => query_id.as_deref(),
+            Repr::SessionExpired(SessionExpiredError { query_id, .. }) => query_id.as_deref(),
             _ => None,
         }
     }
@@ -148,7 +164,7 @@ impl Error {
     }
 
     pub fn is_timeout(&self) -> bool {
-        matches!(&*self.repr, Repr::Timeout(_))
+        matches!(&*self.repr, Repr::Timeout { .. })
     }
 
     pub fn is_server_error(&self) -> bool {
@@ -172,17 +188,24 @@ impl Error {
     #[cfg(test)]
     pub(crate) fn as_rowset_parse_error(&self) -> Option<&RowsetParseError> {
         match &*self.repr {
-            Repr::Protocol(ProtocolError::RowsetParse(error)) => Some(error),
+            Repr::Protocol {
+                error: ProtocolError::RowsetParse(error),
+                ..
+            } => Some(error),
             _ => None,
         }
     }
 
-    pub(crate) fn session_expired(code: Option<String>, message: Option<String>) -> Self {
-        SessionExpiredError::new(code, message).into()
-    }
-
     pub fn other(message: impl Into<String>) -> Self {
         Self::new(Repr::Other(message.into().into_boxed_str()))
+    }
+}
+
+pub(crate) fn classify_request_error(source: reqwest::Error) -> Error {
+    if source.is_timeout() {
+        TimeoutError::request(source).into()
+    } else {
+        NetworkError::request(source).into()
     }
 }
 
@@ -200,7 +223,10 @@ impl From<AuthError> for Error {
 
 impl From<NetworkError> for Error {
     fn from(error: NetworkError) -> Self {
-        Self::new(Repr::Network(error))
+        Self::new(Repr::Network {
+            error,
+            query_id: None,
+        })
     }
 }
 
@@ -218,19 +244,28 @@ impl From<SessionExpiredError> for Error {
 
 impl From<TimeoutError> for Error {
     fn from(error: TimeoutError) -> Self {
-        Self::new(Repr::Timeout(error))
+        Self::new(Repr::Timeout {
+            error,
+            query_id: None,
+        })
     }
 }
 
 impl From<ProtocolError> for Error {
     fn from(error: ProtocolError) -> Self {
-        Self::new(Repr::Protocol(error))
+        Self::new(Repr::Protocol {
+            error,
+            query_id: None,
+        })
     }
 }
 
 impl From<InternalError> for Error {
     fn from(error: InternalError) -> Self {
-        Self::new(Repr::Internal(error))
+        Self::new(Repr::Internal {
+            error,
+            query_id: None,
+        })
     }
 }
 
@@ -302,16 +337,12 @@ impl AuthError {
 }
 
 impl NetworkError {
-    pub(crate) fn request(source: reqwest::Error) -> Error {
-        if source.is_timeout() {
-            TimeoutError::request(source).into()
-        } else {
-            Self::Http(source).into()
-        }
-    }
-
-    pub(crate) fn io(source: std::io::Error) -> Self {
-        Self::Io(source)
+    pub(crate) fn request(source: reqwest::Error) -> Self {
+        debug_assert!(
+            !source.is_timeout(),
+            "timeouts should be converted to TimeoutError before NetworkError",
+        );
+        Self::Http(source)
     }
 
     pub(crate) fn http_status(status: u16, body: impl AsRef<[u8]>) -> Self {
@@ -333,27 +364,36 @@ impl ServerError {
     pub(crate) fn new(
         code: Option<String>,
         message: Option<String>,
-        query_id: Option<String>,
+        query_id: Option<Arc<str>>,
     ) -> Self {
         Self {
             code: code.map(String::into_boxed_str),
             message: message.map(String::into_boxed_str),
-            query_id: query_id.map(String::into_boxed_str),
+            query_id,
         }
     }
 }
 
 impl SessionExpiredError {
-    pub(crate) fn new(code: Option<String>, message: Option<String>) -> Self {
+    pub(crate) fn new(
+        code: Option<String>,
+        message: Option<String>,
+        query_id: Option<Arc<str>>,
+    ) -> Self {
         Self {
             code: code.map(String::into_boxed_str),
             message: message.map(String::into_boxed_str),
+            query_id,
         }
     }
 }
 
 impl TimeoutError {
     pub(crate) fn request(source: reqwest::Error) -> Self {
+        debug_assert!(
+            source.is_timeout(),
+            "only timeout errors should be converted to TimeoutError::Request"
+        );
         Self::Request(source)
     }
 
@@ -494,7 +534,7 @@ mod tests {
         let err: Error = ServerError::new(
             Some("12345".to_string()),
             Some("statement failed".to_string()),
-            Some("query-id".to_string()),
+            Some(Arc::from("query-id")),
         )
         .into();
 
@@ -522,10 +562,12 @@ mod tests {
 
     #[test]
     fn session_expired_preserves_snowflake_fields() {
-        let err = Error::session_expired(
+        let err: Error = SessionExpiredError::new(
             Some("390112".to_string()),
             Some("Your session has expired. Please login again.".to_string()),
-        );
+            None,
+        )
+        .into();
 
         assert_eq!(err.kind(), ErrorKind::SessionExpired);
         assert!(err.is_session_expired());
@@ -534,7 +576,46 @@ mod tests {
             err.snowflake_message(),
             Some("Your session has expired. Please login again.")
         );
+        assert_eq!(err.query_id(), None);
         assert_eq!(err.to_string(), "session expired");
+    }
+
+    #[test]
+    fn query_scoped_error_decorates_contextual_variants() {
+        let err = Error::from(QueryScopedError::new(
+            std::sync::Arc::from("query-id"),
+            NetworkError::chunk_download(500, "boom"),
+        ));
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert_eq!(err.query_id(), Some("query-id"));
+    }
+
+    #[test]
+    fn query_scoped_error_keeps_intrinsic_server_query_id() {
+        let err = Error::from(QueryScopedError::new(
+            std::sync::Arc::from("outer-query-id"),
+            ServerError::new(
+                Some("390001".to_string()),
+                Some("server boom".to_string()),
+                Some(Arc::from("intrinsic-query-id")),
+            ),
+        ));
+
+        assert_eq!(err.kind(), ErrorKind::Server);
+        assert_eq!(err.query_id(), Some("intrinsic-query-id"));
+    }
+
+    #[test]
+    fn session_expired_query_id_is_exposed_when_present() {
+        let err: Error = SessionExpiredError::new(
+            Some("390112".to_string()),
+            Some("Your session has expired. Please login again.".to_string()),
+            Some(Arc::from("query-id")),
+        )
+        .into();
+
+        assert_eq!(err.kind(), ErrorKind::SessionExpired);
+        assert_eq!(err.query_id(), Some("query-id"));
     }
 
     #[test]
@@ -645,18 +726,6 @@ mod tests {
     }
 
     #[test]
-    fn wrapped_errors_choose_source_over_display_duplication() {
-        let io_err = std::io::Error::other("boom");
-        let err: Error = NetworkError::io(io_err).into();
-
-        assert_eq!(err.to_string(), "io error");
-        assert_eq!(
-            StdError::source(&err).map(std::string::ToString::to_string),
-            Some("boom".to_string())
-        );
-    }
-
-    #[test]
     fn schema_decode_and_parse_errors_do_not_repeat_as_sources() {
         let schema_error: Error = SchemaError::MissingColumn(MissingColumnError::new("col")).into();
         assert!(StdError::source(&schema_error).is_none());
@@ -708,17 +777,6 @@ mod tests {
         assert!(err.as_rowset_parse_error().is_some());
     }
 
-    #[test]
-    fn debug_output_is_normalized() {
-        let err: Error = NetworkError::io(std::io::Error::other("boom")).into();
-        let rendered = format!("{err:?}");
-
-        assert!(rendered.contains("Error { kind: Network"));
-        assert!(rendered.contains("message: \"io error\""));
-        assert!(rendered.contains("source: Some(\"boom\")"));
-        assert!(!rendered.contains("repr"));
-    }
-
     #[tokio::test]
     async fn future_join_uses_internal_kind() {
         let handle = tokio::spawn(std::future::pending::<()>());
@@ -729,7 +787,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn network_request_timeout_uses_timeout_kind() {
+    async fn classify_request_error_uses_timeout_kind() {
         let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
@@ -749,7 +807,7 @@ mod tests {
 
         assert!(err.is_timeout());
 
-        let err = NetworkError::request(err);
+        let err = classify_request_error(err);
         assert_eq!(err.kind(), ErrorKind::Timeout);
         assert!(err.is_timeout());
         assert!(StdError::source(&err).is_some());

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -26,12 +26,20 @@ impl fmt::Display for Error {
             Repr::Auth(AuthError::ExternalBrowser { message, .. }) => {
                 write!(f, "external browser authentication error: {message}")
             }
-            Repr::Network(NetworkError::Http(_source)) => f.write_str("network error"),
-            Repr::Network(NetworkError::Io(_source)) => f.write_str("io error"),
-            Repr::Network(NetworkError::HttpStatus { status, body }) => {
+            Repr::Network {
+                error: NetworkError::Http(_source),
+                ..
+            } => f.write_str("network error"),
+            Repr::Network {
+                error: NetworkError::HttpStatus { status, body },
+                ..
+            } => {
                 write!(f, "HTTP {status}: {body}")
             }
-            Repr::Network(NetworkError::ChunkDownload { status, body }) => {
+            Repr::Network {
+                error: NetworkError::ChunkDownload { status, body },
+                ..
+            } => {
                 write!(f, "chunk download failed with HTTP {status}: {body}")
             }
             Repr::Server(ServerError {
@@ -53,58 +61,97 @@ impl fmt::Display for Error {
                 Ok(())
             }
             Repr::SessionExpired(_) => f.write_str("session expired"),
-            Repr::Timeout(TimeoutError::Request(_)) => f.write_str("network request timed out"),
-            Repr::Timeout(TimeoutError::Query) => {
-                f.write_str("timed out waiting for query results")
-            }
+            Repr::Timeout {
+                error: TimeoutError::Request(_),
+                ..
+            } => f.write_str("network request timed out"),
+            Repr::Timeout {
+                error: TimeoutError::Query,
+                ..
+            } => f.write_str("timed out waiting for query results"),
             #[cfg(feature = "external-browser-sso")]
-            Repr::Timeout(TimeoutError::BrowserCallback) => {
-                f.write_str("timed out waiting for external browser callback")
-            }
-            Repr::Protocol(ProtocolError::JsonParse {
-                source: _source,
-                body_preview,
-            }) => write!(f, "JSON parse error; body preview: {body_preview:?}"),
-            Repr::Protocol(ProtocolError::InvalidResponseUrl {
-                path,
-                value_preview,
-                source: _source,
-            }) => write!(
+            Repr::Timeout {
+                error: TimeoutError::BrowserCallback,
+                ..
+            } => f.write_str("timed out waiting for external browser callback"),
+            Repr::Protocol {
+                error:
+                    ProtocolError::JsonParse {
+                        source: _source,
+                        body_preview,
+                    },
+                ..
+            } => write!(f, "JSON parse error; body preview: {body_preview:?}"),
+            Repr::Protocol {
+                error:
+                    ProtocolError::InvalidResponseUrl {
+                        path,
+                        value_preview,
+                        source: _source,
+                    },
+                ..
+            } => write!(
                 f,
                 "invalid URL in Snowflake response field {path}; value: {value_preview}"
             ),
-            Repr::Protocol(ProtocolError::InvalidField { path, reason }) => {
+            Repr::Protocol {
+                error: ProtocolError::InvalidField { path, reason },
+                ..
+            } => {
                 write!(f, "invalid Snowflake response field {path}: {reason}")
             }
-            Repr::Protocol(ProtocolError::MissingField { field }) => {
+            Repr::Protocol {
+                error: ProtocolError::MissingField { field },
+                ..
+            } => {
                 write!(f, "missing required field in Snowflake response: {field}")
             }
-            Repr::Protocol(ProtocolError::HeaderConversion(_source)) => {
-                f.write_str("header conversion error")
-            }
-            Repr::Protocol(ProtocolError::InvalidResponseHeaderValue(_source)) => {
-                f.write_str("invalid header value in Snowflake response")
-            }
-            Repr::Protocol(ProtocolError::NoPollingUrlAsyncQuery) => {
-                f.write_str("async response doesn't contain a URL to poll for results")
-            }
-            Repr::Protocol(ProtocolError::UnsupportedResultFormat(message)) => {
+            Repr::Protocol {
+                error: ProtocolError::HeaderConversion(_source),
+                ..
+            } => f.write_str("header conversion error"),
+            Repr::Protocol {
+                error: ProtocolError::InvalidResponseHeaderValue(_source),
+                ..
+            } => f.write_str("invalid header value in Snowflake response"),
+            Repr::Protocol {
+                error: ProtocolError::NoPollingUrlAsyncQuery,
+                ..
+            } => f.write_str("async response doesn't contain a URL to poll for results"),
+            Repr::Protocol {
+                error: ProtocolError::UnsupportedResultFormat(message),
+                ..
+            } => {
                 write!(f, "unsupported result format: {message}")
             }
-            Repr::Protocol(ProtocolError::InvalidChunkFormat {
-                message,
-                source: Some(_source),
-            }) => {
+            Repr::Protocol {
+                error:
+                    ProtocolError::InvalidChunkFormat {
+                        message,
+                        source: Some(_source),
+                    },
+                ..
+            } => {
                 write!(f, "chunk download error: {message}")
             }
-            Repr::Protocol(ProtocolError::InvalidChunkFormat {
-                message,
-                source: None,
-            }) => {
+            Repr::Protocol {
+                error:
+                    ProtocolError::InvalidChunkFormat {
+                        message,
+                        source: None,
+                    },
+                ..
+            } => {
                 write!(f, "chunk download error: {message}")
             }
-            Repr::Protocol(ProtocolError::RowsetParse(error)) => fmt::Display::fmt(error, f),
-            Repr::Internal(InternalError::FutureJoin(_source)) => f.write_str("future join error"),
+            Repr::Protocol {
+                error: ProtocolError::RowsetParse(error),
+                ..
+            } => fmt::Display::fmt(error, f),
+            Repr::Internal {
+                error: InternalError::FutureJoin(_source),
+                ..
+            } => f.write_str("future join error"),
             Repr::Other(message) => write!(f, "snowflake connector error: {message}"),
             Repr::Schema(error) => fmt::Display::fmt(error, f),
             Repr::CellDecode(error) => fmt::Display::fmt(error, f),
@@ -124,19 +171,46 @@ impl StdError for Error {
                 source: Some(source),
                 ..
             }) => Some(source.as_ref()),
-            Repr::Timeout(TimeoutError::Request(source)) => Some(source),
-            Repr::Network(NetworkError::Http(source)) => Some(source),
-            Repr::Network(NetworkError::Io(source)) => Some(source),
-            Repr::Protocol(ProtocolError::JsonParse { source, .. }) => Some(source.as_ref()),
-            Repr::Protocol(ProtocolError::InvalidResponseUrl { source, .. }) => Some(source),
-            Repr::Protocol(ProtocolError::HeaderConversion(source)) => Some(source),
-            Repr::Protocol(ProtocolError::InvalidResponseHeaderValue(source)) => Some(source),
-            Repr::Protocol(ProtocolError::InvalidChunkFormat {
-                source: Some(source),
+            Repr::Timeout {
+                error: TimeoutError::Request(source),
                 ..
-            }) => Some(source.as_ref()),
-            Repr::Internal(InternalError::FutureJoin(source)) => Some(source),
-            Repr::Protocol(ProtocolError::RowsetParse(_)) => None,
+            } => Some(source),
+            Repr::Network {
+                error: NetworkError::Http(source),
+                ..
+            } => Some(source),
+            Repr::Protocol {
+                error: ProtocolError::JsonParse { source, .. },
+                ..
+            } => Some(source.as_ref()),
+            Repr::Protocol {
+                error: ProtocolError::InvalidResponseUrl { source, .. },
+                ..
+            } => Some(source),
+            Repr::Protocol {
+                error: ProtocolError::HeaderConversion(source),
+                ..
+            } => Some(source),
+            Repr::Protocol {
+                error: ProtocolError::InvalidResponseHeaderValue(source),
+                ..
+            } => Some(source),
+            Repr::Protocol {
+                error:
+                    ProtocolError::InvalidChunkFormat {
+                        source: Some(source),
+                        ..
+                    },
+                ..
+            } => Some(source.as_ref()),
+            Repr::Internal {
+                error: InternalError::FutureJoin(source),
+                ..
+            } => Some(source),
+            Repr::Protocol {
+                error: ProtocolError::RowsetParse(_),
+                ..
+            } => None,
             Repr::Schema(_) => None,
             Repr::CellDecode(_) => None,
             _ => None,

--- a/src/error/query_scoped.rs
+++ b/src/error/query_scoped.rs
@@ -1,0 +1,116 @@
+use std::sync::Arc;
+
+use super::{
+    Error, InternalError, NetworkError, ProtocolError, RowsetParseError, ServerError,
+    SessionExpiredError, TimeoutError, repr::Repr,
+};
+
+#[derive(Debug)]
+pub(crate) struct QueryScopedError {
+    query_id: Arc<str>,
+    inner: QueryScopedRepr,
+}
+
+#[derive(Debug)]
+pub(crate) enum QueryScopedRepr {
+    Network(NetworkError),
+    Timeout(TimeoutError),
+    Protocol(ProtocolError),
+    Internal(InternalError),
+    Server(ServerError),
+    SessionExpired(SessionExpiredError),
+}
+
+pub(crate) type QueryScopedResult<T> = std::result::Result<T, QueryScopedError>;
+
+impl QueryScopedError {
+    pub(crate) fn new(query_id: Arc<str>, inner: impl Into<QueryScopedRepr>) -> Self {
+        Self {
+            query_id,
+            inner: inner.into(),
+        }
+    }
+
+    fn into_parts(self) -> (Arc<str>, QueryScopedRepr) {
+        (self.query_id, self.inner)
+    }
+}
+
+impl From<QueryScopedError> for Error {
+    fn from(error: QueryScopedError) -> Self {
+        let (query_id, inner) = error.into_parts();
+        let repr = match inner {
+            QueryScopedRepr::Network(error) => Repr::Network {
+                error,
+                query_id: Some(query_id),
+            },
+            QueryScopedRepr::Timeout(error) => Repr::Timeout {
+                error,
+                query_id: Some(query_id),
+            },
+            QueryScopedRepr::Protocol(error) => Repr::Protocol {
+                error,
+                query_id: Some(query_id),
+            },
+            QueryScopedRepr::Internal(error) => Repr::Internal {
+                error,
+                query_id: Some(query_id),
+            },
+            QueryScopedRepr::Server(mut error) => {
+                if error.query_id.is_none() {
+                    error.query_id = Some(query_id);
+                }
+                Repr::Server(error)
+            }
+            QueryScopedRepr::SessionExpired(mut error) => {
+                if error.query_id.is_none() {
+                    error.query_id = Some(query_id);
+                }
+                Repr::SessionExpired(error)
+            }
+        };
+        Error::new(repr)
+    }
+}
+
+impl From<NetworkError> for QueryScopedRepr {
+    fn from(error: NetworkError) -> Self {
+        Self::Network(error)
+    }
+}
+
+impl From<TimeoutError> for QueryScopedRepr {
+    fn from(error: TimeoutError) -> Self {
+        Self::Timeout(error)
+    }
+}
+
+impl From<ProtocolError> for QueryScopedRepr {
+    fn from(error: ProtocolError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+impl From<InternalError> for QueryScopedRepr {
+    fn from(error: InternalError) -> Self {
+        Self::Internal(error)
+    }
+}
+
+impl From<ServerError> for QueryScopedRepr {
+    fn from(error: ServerError) -> Self {
+        Self::Server(error)
+    }
+}
+
+impl From<SessionExpiredError> for QueryScopedRepr {
+    fn from(error: SessionExpiredError) -> Self {
+        Self::SessionExpired(error)
+    }
+}
+
+impl From<RowsetParseError> for QueryScopedRepr {
+    fn from(error: RowsetParseError) -> Self {
+        Self::Protocol(ProtocolError::RowsetParse(error))
+    }
+}

--- a/src/error/repr.rs
+++ b/src/error/repr.rs
@@ -1,4 +1,4 @@
-use std::error::Error as StdError;
+use std::{error::Error as StdError, sync::Arc};
 
 use reqwest::header::InvalidHeaderValue;
 use tokio::task::JoinError;
@@ -9,12 +9,24 @@ use super::{CellDecodeError, RowsetParseError, SchemaError};
 pub(crate) enum Repr {
     Config(ConfigError),
     Auth(AuthError),
-    Network(NetworkError),
+    Network {
+        error: NetworkError,
+        query_id: Option<Arc<str>>,
+    },
     Server(ServerError),
     SessionExpired(SessionExpiredError),
-    Timeout(TimeoutError),
-    Protocol(ProtocolError),
-    Internal(InternalError),
+    Timeout {
+        error: TimeoutError,
+        query_id: Option<Arc<str>>,
+    },
+    Protocol {
+        error: ProtocolError,
+        query_id: Option<Arc<str>>,
+    },
+    Internal {
+        error: InternalError,
+        query_id: Option<Arc<str>>,
+    },
     Other(Box<str>),
     Schema(SchemaError),
     CellDecode(CellDecodeError),
@@ -44,7 +56,6 @@ pub(crate) enum AuthError {
 #[derive(Debug)]
 pub(crate) enum NetworkError {
     Http(reqwest::Error),
-    Io(std::io::Error),
     HttpStatus { status: u16, body: Box<str> },
     ChunkDownload { status: u16, body: Box<str> },
 }
@@ -53,13 +64,14 @@ pub(crate) enum NetworkError {
 pub(crate) struct ServerError {
     pub(crate) code: Option<Box<str>>,
     pub(crate) message: Option<Box<str>>,
-    pub(crate) query_id: Option<Box<str>>,
+    pub(crate) query_id: Option<Arc<str>>,
 }
 
 #[derive(Debug)]
 pub(crate) struct SessionExpiredError {
     pub(crate) code: Option<Box<str>>,
     pub(crate) message: Option<Box<str>>,
+    pub(crate) query_id: Option<Arc<str>>,
 }
 
 #[derive(Debug)]

--- a/src/query_result/collect.rs
+++ b/src/query_result/collect.rs
@@ -2,7 +2,11 @@ use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 
 use tokio::task::JoinSet;
 
-use crate::{Result, error::InternalError, result::ResultTable, runtime::BlockingParseLimiter};
+use crate::{
+    error::{InternalError, QueryScopedError, QueryScopedResult},
+    result::ResultTable,
+    runtime::BlockingParseLimiter,
+};
 
 use super::{
     partition_source::{PartitionSource, remote_fetch_context},
@@ -23,17 +27,24 @@ impl CollectPolicy {
 }
 
 pub(crate) struct CollectWindow {
+    query_id: Arc<str>,
     next_spawn_ordinal: usize,
     next_commit_ordinal: usize,
     total: usize,
     max_in_flight: usize,
-    tasks: JoinSet<(usize, Result<ResultTable>)>,
+    tasks: JoinSet<(usize, QueryScopedResult<ResultTable>)>,
     buffered: BTreeMap<usize, ResultTable>,
 }
 
 impl CollectWindow {
-    pub(crate) fn new(start_ordinal: usize, total: usize, max_in_flight: usize) -> Self {
+    pub(crate) fn new(
+        query_id: Arc<str>,
+        start_ordinal: usize,
+        total: usize,
+        max_in_flight: usize,
+    ) -> Self {
         Self {
+            query_id,
             next_spawn_ordinal: start_ordinal,
             next_commit_ordinal: start_ordinal,
             total,
@@ -66,11 +77,14 @@ impl CollectWindow {
         }
     }
 
-    pub(crate) async fn join_next(&mut self) -> Option<Result<(usize, ResultTable)>> {
+    pub(crate) async fn join_next(&mut self) -> Option<QueryScopedResult<(usize, ResultTable)>> {
         let join_result = self.tasks.join_next().await?;
         Some(match join_result {
             Ok((ordinal, result)) => result.map(|table| (ordinal, table)),
-            Err(err) => Err(InternalError::future_join(err).into()),
+            Err(err) => Err(QueryScopedError::new(
+                Arc::clone(&self.query_id),
+                InternalError::future_join(err),
+            )),
         })
     }
 

--- a/src/query_result/partition_source.rs
+++ b/src/query_result/partition_source.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
-    Result,
     chunk::ChunkDownloader,
+    error::QueryScopedResult,
     result::{ResultTable, Schema},
     runtime::BlockingParseLimiter,
 };
@@ -30,7 +30,7 @@ impl PartitionSource {
         &self,
         ctx: FetchContext,
         schema: Arc<Schema>,
-    ) -> Result<ResultTable> {
+    ) -> QueryScopedResult<ResultTable> {
         match self {
             Self::Static(s) => s.fetch(ctx, schema).await,
             #[cfg(test)]
@@ -49,7 +49,11 @@ impl StaticPartitionSource {
         Self { lease, downloader }
     }
 
-    async fn fetch(&self, ctx: FetchContext, schema: Arc<Schema>) -> Result<ResultTable> {
+    async fn fetch(
+        &self,
+        ctx: FetchContext,
+        schema: Arc<Schema>,
+    ) -> QueryScopedResult<ResultTable> {
         let locator = self
             .lease
             .locators
@@ -100,7 +104,10 @@ pub(crate) mod tests {
     use tokio::time::sleep;
 
     use super::*;
-    use crate::rowset::parser::inline_rows_to_result_table;
+    use crate::{
+        error::{QueryScopedError, QueryScopedRepr},
+        rowset::parser::inline_rows_to_result_table_inner,
+    };
 
     #[derive(Default)]
     pub(crate) struct BlockingFetchProbe {
@@ -135,16 +142,16 @@ pub(crate) mod tests {
     }
 
     pub(crate) enum FakeResponse {
-        Rows(Result<Vec<Vec<Option<String>>>>),
+        Rows(std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr>),
         BlockingRows {
-            rows: Result<Vec<Vec<Option<String>>>>,
+            rows: std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr>,
             probe: Arc<BlockingFetchProbe>,
             delay: Duration,
         },
     }
 
-    impl From<Result<Vec<Vec<Option<String>>>>> for FakeResponse {
-        fn from(rows: Result<Vec<Vec<Option<String>>>>) -> Self {
+    impl From<std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr>> for FakeResponse {
+        fn from(rows: std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr>) -> Self {
             Self::Rows(rows)
         }
     }
@@ -175,7 +182,7 @@ pub(crate) mod tests {
             &self,
             ctx: FetchContext,
             schema: Arc<Schema>,
-        ) -> Result<ResultTable> {
+        ) -> QueryScopedResult<ResultTable> {
             self.fetch_count.fetch_add(1, Ordering::SeqCst);
 
             let response = {
@@ -192,7 +199,9 @@ pub(crate) mod tests {
             };
 
             let raw = match response {
-                FakeResponse::Rows(rows) => rows?,
+                FakeResponse::Rows(rows) => {
+                    rows.map_err(|error| QueryScopedError::new(Arc::clone(&ctx.query_id), error))?
+                }
                 FakeResponse::BlockingRows { rows, probe, delay } => {
                     let _permit = match ctx.blocking_parse_limiter {
                         Some(limiter) => Some(limiter.acquire_owned().await),
@@ -201,11 +210,12 @@ pub(crate) mod tests {
                     probe.enter();
                     sleep(delay).await;
                     probe.exit();
-                    rows?
+                    rows.map_err(|error| QueryScopedError::new(Arc::clone(&ctx.query_id), error))?
                 }
             };
 
-            inline_rows_to_result_table(schema, ctx.query_id, raw)
+            inline_rows_to_result_table_inner(schema, Arc::clone(&ctx.query_id), raw)
+                .map_err(|error| QueryScopedError::new(Arc::clone(&ctx.query_id), error))
         }
     }
 }

--- a/src/query_result/result_set.rs
+++ b/src/query_result/result_set.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 
 use crate::{
     Result,
+    error::QueryScopedResult,
     result::{DynamicRow, ResultTable, Schema},
     rowset::parser::parse_inline_result_table_async,
     runtime::QueryRuntime,
@@ -105,6 +106,10 @@ impl ResultSet {
     /// `ErrorKind::Protocol`, or `ErrorKind::Internal` if fetching or
     /// materializing the next partition fails.
     pub async fn next_table(&mut self) -> Result<Option<ResultTable>> {
+        self.next_table_inner().await.map_err(crate::Error::from)
+    }
+
+    async fn next_table_inner(&mut self) -> QueryScopedResult<Option<ResultTable>> {
         if self.cursor.is_exhausted() {
             return Ok(None);
         }
@@ -160,7 +165,9 @@ impl ResultSet {
     /// partition fails to materialize.
     pub async fn collect_table(self) -> Result<ResultTable> {
         let policy = self.default_collect_policy;
-        self.collect_with_policy(policy).await
+        self.collect_with_policy(policy)
+            .await
+            .map_err(crate::Error::from)
     }
 
     /// Consume this result set and merge all remaining partitions into a single `ResultTable`.
@@ -176,7 +183,9 @@ impl ResultSet {
                 .prefetch_concurrency
                 .unwrap_or(self.default_collect_policy.prefetch_concurrency),
         );
-        self.collect_with_policy(policy).await
+        self.collect_with_policy(policy)
+            .await
+            .map_err(crate::Error::from)
     }
 
     /// Consume this result set and decode all rows into [`DynamicRow`].
@@ -205,7 +214,7 @@ impl ResultSet {
         table.dynamic_rows()?.collect()
     }
 
-    async fn collect_with_policy(self, policy: CollectPolicy) -> Result<ResultTable> {
+    async fn collect_with_policy(self, policy: CollectPolicy) -> QueryScopedResult<ResultTable> {
         let Self {
             snapshot,
             cursor,
@@ -241,6 +250,7 @@ impl ResultSet {
                 .as_ref()
                 .expect("limiter exists when source exists");
             let mut window = CollectWindow::new(
+                Arc::clone(&snapshot.identity.query_id),
                 first_remote_ordinal,
                 total,
                 policy.prefetch_concurrency.get(),
@@ -289,14 +299,17 @@ mod tests {
 
     use super::*;
     use crate::{
-        MissingColumnError, SchemaError,
+        CellDecodeError, ErrorKind, MissingColumnError, SchemaError,
+        error::QueryScopedRepr,
         query_result::{
             TypedResultSet,
             collect::CollectPolicy,
             partition_source::tests::{BlockingFetchProbe, FakePartitionSource, FakeResponse},
             snapshot::{PartitionCursor, PartitionSpec, ResultIdentity, ResultSnapshot},
         },
-        result::{Column, ColumnType, DynamicRow, FromRow, RowPlanContext, RowRef, Schema},
+        result::{
+            Column, ColumnIndex, ColumnType, DynamicRow, FromRow, RowPlanContext, RowRef, Schema,
+        },
         rowset::BLOCKING_PARSE_CELLS,
         runtime::QueryRuntime,
     };
@@ -369,17 +382,34 @@ mod tests {
         })
     }
 
-    fn ok_rows(n: usize) -> crate::Result<Vec<Vec<Option<String>>>> {
+    fn ok_rows(n: usize) -> std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr> {
         Ok((0..n).map(|i| vec![Some(i.to_string())]).collect())
     }
 
-    fn fail() -> crate::Result<Vec<Vec<Option<String>>>> {
+    fn fail() -> std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr> {
         Err(crate::error::NetworkError::chunk_download(500, "simulated failure").into())
+    }
+
+    fn fail_timeout() -> std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr> {
+        Err(crate::error::TimeoutError::query().into())
+    }
+
+    fn fail_protocol() -> std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr> {
+        Err(crate::error::ProtocolError::missing_field("data").into())
+    }
+
+    async fn fail_internal() -> std::result::Result<Vec<Vec<Option<String>>>, QueryScopedRepr> {
+        let handle = tokio::spawn(std::future::pending::<()>());
+        handle.abort();
+
+        Err(crate::error::InternalError::future_join(handle.await.unwrap_err()).into())
     }
 
     type FakeRows = Vec<Vec<Option<String>>>;
 
-    fn fake_source(responses: Vec<(usize, Vec<crate::Result<FakeRows>>)>) -> PartitionSource {
+    fn fake_source(
+        responses: Vec<(usize, Vec<std::result::Result<FakeRows, QueryScopedRepr>>)>,
+    ) -> PartitionSource {
         let map = responses
             .into_iter()
             .map(|(ord, results)| {
@@ -449,12 +479,42 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct DecodeErrorRow;
+
+    impl FromRow for DecodeErrorRow {
+        type Plan = ();
+
+        fn build_plan(_: RowPlanContext<'_>) -> crate::Result<Self::Plan> {
+            Ok(())
+        }
+
+        fn from_row_with_plan(_: RowRef<'_>, _: &Self::Plan) -> crate::Result<Self> {
+            Err(CellDecodeError::new(
+                0,
+                ColumnIndex::new(0),
+                "X",
+                "text",
+                ColumnType::Fixed {
+                    precision: None,
+                    scale: Some(0),
+                },
+                Some("bad"),
+                "simulated decode failure",
+            )
+            .into())
+        }
+    }
+
     #[tokio::test]
     async fn next_table_failure_does_not_advance_cursor() {
         let snapshot = dummy_snapshot(2);
         let source = fake_source(vec![(0, vec![fail(), ok_rows(1)]), (1, vec![ok_rows(2)])]);
         let mut rs = build_result_set(snapshot, source);
-        assert!(rs.next_table().await.is_err());
+        let err = rs.next_table().await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert_eq!(err.query_id(), Some("test"));
+        assert_eq!(rs.query_id(), "test");
         assert_eq!(rs.cursor.next_ordinal, 0);
         let t = rs.next_table().await.unwrap().unwrap();
         assert_eq!(t.row_count(), 1);
@@ -472,7 +532,40 @@ mod tests {
             (2, vec![ok_rows(1)]),
         ]);
         let rs = build_result_set(snapshot, source);
-        assert!(rs.collect_table().await.is_err());
+        let err = rs.collect_table().await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert_eq!(err.query_id(), Some("test"));
+    }
+
+    #[tokio::test]
+    async fn collect_table_query_scoped_failures_preserve_query_id() {
+        let cases = vec![
+            (
+                "timeout",
+                fake_source(vec![(0, vec![fail_timeout()])]),
+                ErrorKind::Timeout,
+            ),
+            (
+                "protocol",
+                fake_source(vec![(0, vec![fail_protocol()])]),
+                ErrorKind::Protocol,
+            ),
+            (
+                "internal",
+                fake_source(vec![(0, vec![fail_internal().await])]),
+                ErrorKind::Internal,
+            ),
+        ];
+
+        for (label, source, expected_kind) in cases {
+            let err = build_result_set(dummy_snapshot(1), source)
+                .collect_table()
+                .await
+                .unwrap_err();
+
+            assert_eq!(err.kind(), expected_kind, "{label}");
+            assert_eq!(err.query_id(), Some("test"), "{label}");
+        }
     }
 
     #[tokio::test]
@@ -528,7 +621,10 @@ mod tests {
             CollectPolicy::new(NonZeroUsize::new(8).unwrap()),
         );
 
-        assert!(rs.next_table().await.is_err());
+        let err = rs.next_table().await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(err.query_id(), Some("test"));
+        assert_eq!(rs.query_id(), "test");
         assert_eq!(rs.cursor.next_ordinal, 0);
         assert!(rs.inline_rowset.is_some());
 
@@ -624,6 +720,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn collect_failure_propagates_query_id_from_consumed_result_set() {
+        let snapshot = dummy_snapshot(1);
+        let err = build_result_set(snapshot, fake_source(vec![(0, vec![fail()])]))
+            .collect()
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert_eq!(err.query_id(), Some("test"));
+    }
+
+    #[tokio::test]
+    async fn collect_table_with_options_failure_propagates_query_id_from_consumed_result_set() {
+        let snapshot = dummy_snapshot(1);
+        let err = build_result_set(snapshot, fake_source(vec![(0, vec![fail()])]))
+            .collect_table_with_options(
+                CollectOptions::default().with_prefetch_concurrency(NonZeroUsize::new(1).unwrap()),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert_eq!(err.query_id(), Some("test"));
+    }
+
+    #[tokio::test]
     async fn collect_matches_collect_table_dynamic_rows() {
         let snapshot = dummy_snapshot(2);
         let collected_table = build_result_set(
@@ -672,6 +794,97 @@ mod tests {
 
         assert_eq!(rows, vec![CountingRow, CountingRow]);
         assert_eq!(build_plan_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn typed_collect_failure_propagates_query_id_from_consumed_result_set() {
+        let snapshot = dummy_snapshot(1);
+        let err = build_typed_result_set::<CountingRow>(build_result_set(
+            snapshot,
+            fake_source(vec![(0, vec![fail()])]),
+        ))
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert_eq!(err.query_id(), Some("test"));
+    }
+
+    #[tokio::test]
+    async fn typed_collect_table_with_options_failure_propagates_query_id_from_consumed_result_set()
+    {
+        let snapshot = dummy_snapshot(1);
+        let err = match build_typed_result_set::<CountingRow>(build_result_set(
+            snapshot,
+            fake_source(vec![(0, vec![fail()])]),
+        ))
+        .unwrap()
+        .collect_table_with_options(
+            CollectOptions::default().with_prefetch_concurrency(NonZeroUsize::new(1).unwrap()),
+        )
+        .await
+        {
+            Ok(_) => panic!("typed collect_table_with_options should fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert_eq!(err.query_id(), Some("test"));
+    }
+
+    #[tokio::test]
+    async fn typed_collect_decode_error_keeps_query_id_on_materialized_table() {
+        let snapshot = dummy_snapshot(1);
+        let err = build_typed_result_set::<DecodeErrorRow>(build_result_set(
+            Arc::clone(&snapshot),
+            fake_source(vec![(0, vec![ok_rows(1)])]),
+        ))
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Decode);
+        assert!(err.as_cell_decode_error().is_some());
+        assert_eq!(err.query_id(), None);
+
+        let table = build_typed_result_set::<DecodeErrorRow>(build_result_set(
+            snapshot,
+            fake_source(vec![(0, vec![ok_rows(1)])]),
+        ))
+        .unwrap()
+        .collect_table()
+        .await
+        .unwrap();
+        assert_eq!(table.query_id(), "test");
+
+        let err = table.rows().collect::<crate::Result<Vec<_>>>().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Decode);
+        assert!(err.as_cell_decode_error().is_some());
+        assert_eq!(err.query_id(), None);
+        assert_eq!(table.query_id(), "test");
+    }
+
+    #[tokio::test]
+    async fn explicit_table_flow_preserves_query_id_for_schema_errors() {
+        let table = build_result_set(dummy_snapshot(1), fake_source(vec![(0, vec![ok_rows(1)])]))
+            .collect_table()
+            .await
+            .unwrap();
+        assert_eq!(table.query_id(), "test");
+
+        let err = match table.rows::<PlanErrorRow>() {
+            Ok(_) => panic!("schema planning should fail"),
+            Err(err) => err,
+        };
+        assert!(matches!(
+            err.as_schema_error(),
+            Some(SchemaError::MissingColumn(_))
+        ));
+        assert_eq!(err.query_id(), None);
+        assert_eq!(table.query_id(), "test");
     }
 
     #[tokio::test]

--- a/src/result/cell.rs
+++ b/src/result/cell.rs
@@ -38,7 +38,7 @@ impl StringArenaBuilder {
     }
 
     #[cfg(any(test, feature = "bench-internals"))]
-    pub(crate) fn append(&mut self, s: &str) -> Result<TextSpan> {
+    pub(crate) fn append(&mut self, s: &str) -> std::result::Result<TextSpan, RowsetParseError> {
         let start = self.bytes.len();
         let len = s.len();
         self.check_capacity(len)?;
@@ -52,8 +52,8 @@ impl StringArenaBuilder {
 
     pub(crate) fn write_with(
         &mut self,
-        f: impl FnOnce(&mut Vec<u8>) -> Result<()>,
-    ) -> Result<TextSpan> {
+        f: impl FnOnce(&mut Vec<u8>) -> std::result::Result<(), RowsetParseError>,
+    ) -> std::result::Result<TextSpan, RowsetParseError> {
         let start = self.bytes.len();
         if let Err(err) = f(&mut self.bytes) {
             self.bytes.truncate(start);
@@ -68,8 +68,7 @@ impl StringArenaBuilder {
                 limit: u32::MAX as u64,
                 actual: end as u64,
                 scope: "string arena",
-            }
-            .into());
+            });
         }
 
         Ok(TextSpan {
@@ -79,7 +78,7 @@ impl StringArenaBuilder {
     }
 
     #[cfg(any(test, feature = "bench-internals"))]
-    fn check_capacity(&self, additional: usize) -> Result<()> {
+    fn check_capacity(&self, additional: usize) -> std::result::Result<(), RowsetParseError> {
         let new_len = self
             .bytes
             .len()
@@ -91,8 +90,7 @@ impl StringArenaBuilder {
                 limit: u32::MAX as u64,
                 actual: new_len as u64,
                 scope: "string arena",
-            }
-            .into());
+            });
         }
         Ok(())
     }

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -54,7 +54,7 @@ pub mod test_data {
             }
             builder.finish_row()?;
         }
-        builder.finish()
+        Ok(builder.finish()?)
     }
 }
 

--- a/src/result/result_table.rs
+++ b/src/result/result_table.rs
@@ -178,7 +178,7 @@ impl ResultTableBuilder {
         query_id: Arc<str>,
         wire: Option<Bytes>,
         row_count_hint: Option<usize>,
-    ) -> Result<Self> {
+    ) -> std::result::Result<Self, RowsetParseError> {
         let column_count = schema.len();
         let cap = match row_count_hint {
             Some(rows) => column_count
@@ -219,22 +219,21 @@ impl ResultTableBuilder {
 
     pub(crate) fn push_decoded_with(
         &mut self,
-        f: impl FnOnce(&mut Vec<u8>) -> Result<()>,
-    ) -> Result<()> {
+        f: impl FnOnce(&mut Vec<u8>) -> std::result::Result<(), RowsetParseError>,
+    ) -> std::result::Result<(), RowsetParseError> {
         let span = self.decoded.write_with(f)?;
         self.cells.push(Cell::DecodedText(span));
         self.current_row_cells += 1;
         Ok(())
     }
 
-    pub(crate) fn finish_row(&mut self) -> Result<()> {
+    pub(crate) fn finish_row(&mut self) -> std::result::Result<(), RowsetParseError> {
         if self.current_row_cells != self.column_count {
             return Err(RowsetParseError::RowLengthMismatch {
                 row: self.row_count,
                 expected: self.column_count,
                 actual: self.current_row_cells,
-            }
-            .into());
+            });
         }
 
         self.row_count += 1;
@@ -242,7 +241,7 @@ impl ResultTableBuilder {
         Ok(())
     }
 
-    pub(crate) fn finish(self) -> Result<ResultTable> {
+    pub(crate) fn finish(self) -> std::result::Result<ResultTable, RowsetParseError> {
         let ResultTableBuilder {
             schema,
             query_id,
@@ -258,8 +257,7 @@ impl ResultTableBuilder {
                 row: row_count,
                 expected: column_count,
                 actual: current_row_cells,
-            }
-            .into());
+            });
         }
 
         let expected = row_count
@@ -270,8 +268,7 @@ impl ResultTableBuilder {
                 row: row_count,
                 expected: column_count,
                 actual: cells.len() % column_count.max(1),
-            }
-            .into());
+            });
         }
 
         let block = CellBlock {
@@ -310,10 +307,7 @@ mod tests {
         let mut b = ResultTableBuilder::new(schema, Arc::from("test"), None, Some(2)).unwrap();
         b.push_owned_text("a".into());
         let err = b.finish_row().unwrap_err();
-        assert!(matches!(
-            err.as_rowset_parse_error(),
-            Some(RowsetParseError::RowLengthMismatch { .. })
-        ));
+        assert!(matches!(err, RowsetParseError::RowLengthMismatch { .. }));
     }
 
     #[test]
@@ -335,11 +329,7 @@ mod tests {
     fn builder_rejects_overflowing_capacity_hint() {
         let schema = dummy_schema(2);
         match ResultTableBuilder::new(schema, Arc::from("test"), None, Some(usize::MAX)) {
-            Err(err)
-                if matches!(
-                    err.as_rowset_parse_error(),
-                    Some(RowsetParseError::CapacityOverflow)
-                ) => {}
+            Err(RowsetParseError::CapacityOverflow) => {}
             Err(err) => panic!("expected CapacityOverflow, got {err:?}"),
             Ok(_) => panic!("expected CapacityOverflow"),
         }

--- a/src/result/schema.rs
+++ b/src/result/schema.rs
@@ -1,8 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::{
-    AmbiguousColumnError, MissingColumnError, Result, SchemaError, error::RowsetParseError,
-};
+use crate::{AmbiguousColumnError, MissingColumnError, SchemaError, error::RowsetParseError};
 
 /// Index into a result-set column list.
 #[repr(transparent)]
@@ -216,9 +214,11 @@ pub struct Schema {
 }
 
 impl Schema {
-    pub(crate) fn from_columns(columns: Vec<Column>) -> Result<Self> {
+    pub(crate) fn from_columns(
+        columns: Vec<Column>,
+    ) -> std::result::Result<Self, RowsetParseError> {
         if columns.len() > u32::MAX as usize {
-            return Err(RowsetParseError::CapacityOverflow.into());
+            return Err(RowsetParseError::CapacityOverflow);
         }
 
         let indices = ColumnIndexMap::build(&columns);

--- a/src/rowset/gzip.rs
+++ b/src/rowset/gzip.rs
@@ -3,15 +3,15 @@ use std::io::Read;
 use bytes::Bytes;
 use flate2::bufread::GzDecoder;
 
-use crate::{Result, error::ProtocolError};
+use crate::error::ProtocolError;
 
-pub(crate) fn decode_gzip_chunk(body: Bytes) -> Result<Bytes> {
+pub(crate) fn decode_gzip_chunk(body: Bytes) -> std::result::Result<Bytes, ProtocolError> {
     if body.is_empty() {
         return Ok(body);
     }
 
     if body.len() < 2 {
-        return Err(ProtocolError::chunk_format("invalid chunk format").into());
+        return Err(ProtocolError::chunk_format("invalid chunk format"));
     }
 
     if body[0] == 0x1f && body[1] == 0x8b {
@@ -31,11 +31,13 @@ mod tests {
     use std::error::Error as StdError;
 
     use super::*;
-    use crate::ErrorKind;
+    use crate::{Error, ErrorKind};
 
     #[test]
     fn malformed_gzip_is_protocol_error() {
-        let err = decode_gzip_chunk(Bytes::from_static(b"\x1f\x8bgarbage")).unwrap_err();
+        let err: Error = decode_gzip_chunk(Bytes::from_static(b"\x1f\x8bgarbage"))
+            .unwrap_err()
+            .into();
 
         assert_eq!(err.kind(), ErrorKind::Protocol);
         assert!(err.to_string().contains("gzip decompression failed"));

--- a/src/rowset/parser.rs
+++ b/src/rowset/parser.rs
@@ -13,11 +13,12 @@ use bytes::Bytes;
 use super::{
     ParseWorkload, decode_gzip_chunk,
     json_string::{self, JsonStringFragment, JsonStringScanError},
-    workload::execute_parse_work,
+    workload::{ParseWorkError, execute_parse_work},
 };
 use crate::{
-    Error, Result,
-    error::RowsetParseError,
+    error::{
+        InternalError, QueryScopedError, QueryScopedRepr, QueryScopedResult, RowsetParseError,
+    },
     result::{RawSpan, ResultTable, ResultTableBuilder, Schema},
     runtime::BlockingParseLimiter,
 };
@@ -28,13 +29,15 @@ enum RowsetShape {
     ChunkFragmentSequence,
 }
 
+type ParseResult<T> = std::result::Result<T, RowsetParseError>;
+
 fn parse_table_with_shape(
     schema: Arc<Schema>,
     query_id: Arc<str>,
     body: Bytes,
     shape: RowsetShape,
     row_count_hint: Option<usize>,
-) -> Result<ResultTable> {
+) -> ParseResult<ResultTable> {
     let mut builder =
         ResultTableBuilder::new(schema, query_id, Some(body.clone()), row_count_hint)?;
     let mut scanner = JsonScanner::new(&body);
@@ -97,11 +100,9 @@ fn parse_table_with_shape(
     builder.finish()
 }
 
-fn checked_row_count_hint(row_count: Option<u64>) -> Result<Option<usize>> {
+fn checked_row_count_hint(row_count: Option<u64>) -> ParseResult<Option<usize>> {
     row_count
-        .map(|rows| {
-            usize::try_from(rows).map_err(|_| Error::from(RowsetParseError::CapacityOverflow))
-        })
+        .map(|rows| usize::try_from(rows).map_err(|_| RowsetParseError::CapacityOverflow))
         .transpose()
 }
 
@@ -109,7 +110,7 @@ fn checked_row_count_hint(row_count: Option<u64>) -> Result<Option<usize>> {
 ///
 /// This treats JSON-insignificant whitespace around `[` / `]` as equivalent,
 /// so `[ ]` and `[]` are both empty arrays.
-pub(crate) fn inline_rowset_has_rows(body: &[u8]) -> Result<bool> {
+pub(crate) fn inline_rowset_has_rows_inner(body: &[u8]) -> ParseResult<bool> {
     let mut scanner = JsonScanner::new(body);
     scanner.skip_ws();
     scanner.expect(b'[')?;
@@ -132,11 +133,11 @@ pub(crate) fn inline_rowset_has_rows(body: &[u8]) -> Result<bool> {
 }
 
 #[cfg(any(test, feature = "bench-internals"))]
-pub fn inline_rows_to_result_table(
+pub(crate) fn inline_rows_to_result_table_inner(
     schema: Arc<Schema>,
     query_id: Arc<str>,
     rows: Vec<Vec<Option<String>>>,
-) -> Result<ResultTable> {
+) -> ParseResult<ResultTable> {
     let mut builder = ResultTableBuilder::new(schema, query_id, None, Some(rows.len()))?;
     for row in rows {
         for cell in row {
@@ -187,7 +188,7 @@ impl<'a> JsonScanner<'a> {
         self.offset >= self.bytes.len()
     }
 
-    fn expect(&mut self, b: u8) -> Result<()> {
+    fn expect(&mut self, b: u8) -> ParseResult<()> {
         match self.peek() {
             Some(c) if c == b => {
                 self.advance();
@@ -197,24 +198,22 @@ impl<'a> JsonScanner<'a> {
         }
     }
 
-    fn err_unexpected(&self, expected: &'static str) -> Error {
+    fn err_unexpected(&self, expected: &'static str) -> RowsetParseError {
         RowsetParseError::UnexpectedToken {
             offset: self.offset,
             expected,
         }
-        .into()
     }
 
-    fn err_string(&self, reason: impl Into<Box<str>>) -> Error {
+    fn err_string(&self, reason: impl Into<Box<str>>) -> RowsetParseError {
         RowsetParseError::InvalidString {
             offset: self.offset,
             reason: reason.into(),
         }
-        .into()
     }
 
     /// Parse a row: `[` cell (`,` cell)* `]`.
-    fn parse_row(&mut self, builder: &mut ResultTableBuilder) -> Result<()> {
+    fn parse_row(&mut self, builder: &mut ResultTableBuilder) -> ParseResult<()> {
         self.expect(b'[')?;
         self.skip_ws();
         if self.peek() == Some(b']') {
@@ -243,7 +242,7 @@ impl<'a> JsonScanner<'a> {
 
     /// Parse a single JSON value as a cell. Snowflake's driver-API rowset
     /// emits each cell as either `null` or a JSON string.
-    fn parse_cell(&mut self, builder: &mut ResultTableBuilder) -> Result<()> {
+    fn parse_cell(&mut self, builder: &mut ResultTableBuilder) -> ParseResult<()> {
         match self.peek() {
             Some(b'n') => {
                 self.expect_keyword(b"null")?;
@@ -255,7 +254,7 @@ impl<'a> JsonScanner<'a> {
         }
     }
 
-    fn expect_keyword(&mut self, kw: &[u8]) -> Result<()> {
+    fn expect_keyword(&mut self, kw: &[u8]) -> ParseResult<()> {
         let start = self.offset;
         if self.bytes.len() - self.offset < kw.len() {
             return Err(self.err_unexpected(keyword_label(kw)));
@@ -269,7 +268,7 @@ impl<'a> JsonScanner<'a> {
 
     /// Parse a JSON string. Records a `RawSpan` if no escapes; otherwise
     /// unescapes once into the builder's arena.
-    fn parse_string_into_cell(&mut self, builder: &mut ResultTableBuilder) -> Result<()> {
+    fn parse_string_into_cell(&mut self, builder: &mut ResultTableBuilder) -> ParseResult<()> {
         debug_assert_eq!(self.peek(), Some(b'"'));
         self.advance(); // consume "
         let content_start = self.offset;
@@ -291,8 +290,7 @@ impl<'a> JsonScanner<'a> {
                             limit: u32::MAX as u64,
                             actual: (content_start + len) as u64,
                             scope: "wire span",
-                        }
-                        .into());
+                        });
                     }
                     builder.push_raw_text(RawSpan {
                         start: content_start as u32,
@@ -322,7 +320,7 @@ impl<'a> JsonScanner<'a> {
         prefix_start: usize,
         prefix_has_non_ascii: bool,
         builder: &mut ResultTableBuilder,
-    ) -> Result<()> {
+    ) -> ParseResult<()> {
         let prefix = &self.bytes[prefix_start..self.offset];
         if prefix_has_non_ascii {
             validate_utf8(prefix, prefix_start)?;
@@ -334,24 +332,28 @@ impl<'a> JsonScanner<'a> {
         let mut local_offset = self.offset;
         let result = builder.push_decoded_with(|buf: &mut Vec<u8>| {
             buf.extend_from_slice(prefix);
-            json_string::scan_json_string_body(bytes, &mut local_offset, |fragment| -> Result<()> {
-                match fragment {
-                    JsonStringFragment::Raw {
-                        bytes,
-                        start_offset,
-                    } => {
-                        if !bytes.is_ascii() {
-                            validate_utf8(bytes, start_offset)?;
+            json_string::scan_json_string_body(
+                bytes,
+                &mut local_offset,
+                |fragment| -> ParseResult<()> {
+                    match fragment {
+                        JsonStringFragment::Raw {
+                            bytes,
+                            start_offset,
+                        } => {
+                            if !bytes.is_ascii() {
+                                validate_utf8(bytes, start_offset)?;
+                            }
+                            buf.extend_from_slice(bytes);
                         }
-                        buf.extend_from_slice(bytes);
+                        JsonStringFragment::DecodedByte(byte) => buf.push(byte),
+                        JsonStringFragment::Codepoint(codepoint) => {
+                            json_string::push_utf8(buf, codepoint);
+                        }
                     }
-                    JsonStringFragment::DecodedByte(byte) => buf.push(byte),
-                    JsonStringFragment::Codepoint(codepoint) => {
-                        json_string::push_utf8(buf, codepoint);
-                    }
-                }
-                Ok(())
-            })
+                    Ok(())
+                },
+            )
             .map_err(map_json_string_scan_error)
         });
         self.offset = local_offset;
@@ -367,46 +369,36 @@ fn utf8_bom_prefix_len(bytes: &[u8]) -> usize {
     }
 }
 
-fn map_json_string_scan_error(err: JsonStringScanError<Error>) -> Error {
+fn map_json_string_scan_error(err: JsonStringScanError<RowsetParseError>) -> RowsetParseError {
     match err {
-        JsonStringScanError::UnterminatedString { offset } => {
-            Error::from(RowsetParseError::InvalidString {
-                offset,
-                reason: Box::from("unterminated string"),
-            })
-        }
-        JsonStringScanError::TrailingBackslash { offset } => {
-            Error::from(RowsetParseError::InvalidString {
-                offset,
-                reason: Box::from("trailing backslash"),
-            })
-        }
-        JsonStringScanError::UnknownEscape { offset, escape } => {
-            Error::from(RowsetParseError::InvalidString {
-                offset,
-                reason: format!("unknown escape: \\{}", escape as char).into_boxed_str(),
-            })
-        }
-        JsonStringScanError::ControlCharacter { offset } => {
-            Error::from(RowsetParseError::InvalidString {
-                offset,
-                reason: Box::from("control character in string"),
-            })
-        }
+        JsonStringScanError::UnterminatedString { offset } => RowsetParseError::InvalidString {
+            offset,
+            reason: Box::from("unterminated string"),
+        },
+        JsonStringScanError::TrailingBackslash { offset } => RowsetParseError::InvalidString {
+            offset,
+            reason: Box::from("trailing backslash"),
+        },
+        JsonStringScanError::UnknownEscape { offset, escape } => RowsetParseError::InvalidString {
+            offset,
+            reason: format!("unknown escape: \\{}", escape as char).into_boxed_str(),
+        },
+        JsonStringScanError::ControlCharacter { offset } => RowsetParseError::InvalidString {
+            offset,
+            reason: Box::from("control character in string"),
+        },
         JsonStringScanError::InvalidUnicodeEscape { offset }
         | JsonStringScanError::InvalidUnicodeSurrogatePair { offset } => {
-            Error::from(RowsetParseError::InvalidUnicodeEscape { offset })
+            RowsetParseError::InvalidUnicodeEscape { offset }
         }
         JsonStringScanError::Visitor(err) => err,
     }
 }
 
-fn validate_utf8(bytes: &[u8], start_offset: usize) -> Result<()> {
-    std::str::from_utf8(bytes).map_err(|err| {
-        Error::from(RowsetParseError::InvalidString {
-            offset: start_offset + err.valid_up_to(),
-            reason: Box::from("invalid UTF-8 in string"),
-        })
+fn validate_utf8(bytes: &[u8], start_offset: usize) -> ParseResult<()> {
+    std::str::from_utf8(bytes).map_err(|err| RowsetParseError::InvalidString {
+        offset: start_offset + err.valid_up_to(),
+        reason: Box::from("invalid UTF-8 in string"),
     })?;
     Ok(())
 }
@@ -433,36 +425,56 @@ fn keyword_label(kw: &[u8]) -> &'static str {
     }
 }
 
-/// Parse the inline rowset bytes (already extracted from `data.rowset`)
-/// using the span scanner. Bytes must be a `[..]` array.
 #[cfg(any(test, feature = "bench-internals"))]
 pub(crate) fn parse_inline_result_table(
     schema: Arc<Schema>,
     query_id: Arc<str>,
     body: Bytes,
-) -> Result<ResultTable> {
+) -> crate::Result<ResultTable> {
     parse_table_with_shape(schema, query_id, body, RowsetShape::InlineArray, None)
+        .map_err(crate::Error::from)
 }
 
+/// Parse the inline rowset bytes (already extracted from `data.rowset`)
+/// using the span scanner. Bytes must be a `[..]` array.
 pub(crate) async fn parse_inline_result_table_async(
     schema: Arc<Schema>,
     query_id: Arc<str>,
     body: Bytes,
     row_count: Option<u64>,
     blocking_parse_limiter: Option<BlockingParseLimiter>,
-) -> Result<ResultTable> {
+) -> QueryScopedResult<ResultTable> {
     let workload = ParseWorkload::inline_rowset(body.len(), row_count, schema.len());
-    let row_count_hint = checked_row_count_hint(row_count)?;
-    let (_, table) = execute_parse_work(workload, blocking_parse_limiter, move || {
+    let row_count_hint = match checked_row_count_hint(row_count) {
+        Ok(hint) => hint,
+        Err(err) => {
+            return Err(QueryScopedError::new(query_id, err));
+        }
+    };
+    let query_id_for_work = Arc::clone(&query_id);
+
+    let parse_work_result = execute_parse_work(workload, blocking_parse_limiter, move || {
         parse_table_with_shape(
             schema,
-            query_id,
+            query_id_for_work,
             body,
             RowsetShape::InlineArray,
             row_count_hint,
         )
     })
-    .await?;
+    .await;
+
+    let table = match parse_work_result {
+        Ok((_, table)) => table,
+        Err(ParseWorkError::Join(error)) => {
+            return Err(QueryScopedError::new(
+                query_id,
+                InternalError::future_join(error),
+            ));
+        }
+        Err(ParseWorkError::Work(error)) => return Err(QueryScopedError::new(query_id, error)),
+    };
+
     Ok(table)
 }
 
@@ -471,7 +483,7 @@ pub(crate) fn parse_remote_chunk_result_table(
     schema: Arc<Schema>,
     query_id: Arc<str>,
     body: Bytes,
-) -> Result<ResultTable> {
+) -> crate::Result<ResultTable> {
     parse_table_with_shape(
         schema,
         query_id,
@@ -479,6 +491,7 @@ pub(crate) fn parse_remote_chunk_result_table(
         RowsetShape::ChunkFragmentSequence,
         None,
     )
+    .map_err(crate::Error::from)
 }
 
 pub(crate) async fn parse_remote_chunk_result_table_async(
@@ -487,19 +500,39 @@ pub(crate) async fn parse_remote_chunk_result_table_async(
     body: Bytes,
     workload: ParseWorkload,
     blocking_parse_limiter: Option<BlockingParseLimiter>,
-) -> Result<ResultTable> {
-    let row_count_hint = checked_row_count_hint(workload.row_count)?;
-    let (_, table) = execute_parse_work(workload, blocking_parse_limiter, move || {
-        let bytes = decode_gzip_chunk(body)?;
+) -> QueryScopedResult<ResultTable> {
+    let row_count_hint = match checked_row_count_hint(workload.row_count) {
+        Ok(hint) => hint,
+        Err(err) => {
+            return Err(QueryScopedError::new(query_id, err));
+        }
+    };
+    let query_id_for_work = Arc::clone(&query_id);
+
+    let parse_work_result = execute_parse_work(workload, blocking_parse_limiter, move || {
+        let bytes = decode_gzip_chunk(body).map_err(QueryScopedRepr::from)?;
         parse_table_with_shape(
             schema,
-            query_id,
+            query_id_for_work,
             bytes,
             RowsetShape::ChunkFragmentSequence,
             row_count_hint,
         )
+        .map_err(QueryScopedRepr::from)
     })
-    .await?;
+    .await;
+
+    let table = match parse_work_result {
+        Ok((_, table)) => table,
+        Err(ParseWorkError::Join(error)) => {
+            return Err(QueryScopedError::new(
+                query_id,
+                InternalError::future_join(error),
+            ));
+        }
+        Err(ParseWorkError::Work(error)) => return Err(QueryScopedError::new(query_id, error)),
+    };
+
     Ok(table)
 }
 
@@ -523,6 +556,10 @@ mod tests {
             ParseExecution, should_spawn_blocking_parse,
         },
     };
+
+    fn inline_rowset_has_rows(body: &[u8]) -> crate::Result<bool> {
+        inline_rowset_has_rows_inner(body).map_err(crate::Error::from)
+    }
 
     fn schema(n: usize) -> Arc<Schema> {
         let cols = (0..n)
@@ -576,7 +613,7 @@ mod tests {
         let rs = t
             .rows::<(String, Option<String>)>()
             .unwrap()
-            .collect::<Result<Vec<_>>>()
+            .collect::<crate::Result<Vec<_>>>()
             .unwrap();
         let r0 = &rs[0];
         let r1 = &rs[1];
@@ -739,14 +776,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_inline_rowset_alias() {
-        let body = Bytes::from(r#"[["x"]]"#);
-        let s = schema(1);
-        let t = parse_inline_result_table(s, qid(), body).unwrap();
-        assert_eq!(t.row_count(), 1);
-    }
-
-    #[test]
     fn parse_remote_chunk_fragment_table_allows_leading_utf8_bom() {
         let body = Bytes::from_static(b"\xEF\xBB\xBF[\"a\"],[\"b\"]");
         let s = schema(1);
@@ -806,7 +835,7 @@ mod tests {
 
     fn assert_invalid_cell_token_rejected<F>(parse: F, body: String)
     where
-        F: Fn(Bytes) -> Result<ResultTable>,
+        F: Fn(Bytes) -> crate::Result<ResultTable>,
     {
         let err = parse(Bytes::from(body)).unwrap_err();
         assert!(matches!(
@@ -908,7 +937,7 @@ mod tests {
     #[tokio::test]
     async fn execute_parse_work_small_input_stays_inline() {
         let workload = ParseWorkload::inline_rowset(1024, None, 2);
-        let (path, value) = execute_parse_work(workload, None, || Ok::<_, Error>(7usize))
+        let (path, value) = execute_parse_work(workload, None, || Ok::<_, crate::Error>(7usize))
             .await
             .unwrap();
         assert_eq!(path, ParseExecution::Inline);
@@ -918,7 +947,7 @@ mod tests {
     #[tokio::test]
     async fn execute_parse_work_large_input_uses_spawn_blocking() {
         let workload = ParseWorkload::inline_rowset(BLOCKING_PARSE_BYTES, None, 2);
-        let (path, value) = execute_parse_work(workload, None, || Ok::<_, Error>(11usize))
+        let (path, value) = execute_parse_work(workload, None, || Ok::<_, crate::Error>(11usize))
             .await
             .unwrap();
         assert_eq!(path, ParseExecution::SpawnBlocking);
@@ -936,7 +965,7 @@ mod tests {
             first_probe.enter();
             std::thread::sleep(Duration::from_millis(50));
             first_probe.exit();
-            Ok::<_, Error>(())
+            Ok::<_, crate::Error>(())
         });
 
         let second_probe = Arc::clone(&probe);
@@ -944,7 +973,7 @@ mod tests {
             second_probe.enter();
             std::thread::sleep(Duration::from_millis(50));
             second_probe.exit();
-            Ok::<_, Error>(())
+            Ok::<_, crate::Error>(())
         });
 
         tokio::try_join!(first, second).unwrap();
@@ -954,11 +983,11 @@ mod tests {
     #[tokio::test]
     async fn execute_parse_work_maps_join_error() {
         let workload = ParseWorkload::inline_rowset(BLOCKING_PARSE_BYTES, None, 2);
-        let err = execute_parse_work(workload, None, || -> Result<()> {
+        let err = execute_parse_work(workload, None, || -> crate::Result<()> {
             panic!("boom");
         })
         .await
         .unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::Internal);
+        assert!(matches!(err, ParseWorkError::Join(_)));
     }
 }

--- a/src/rowset/workload.rs
+++ b/src/rowset/workload.rs
@@ -1,4 +1,6 @@
-use crate::{Result, error::InternalError, runtime::BlockingParseLimiter};
+use tokio::task::JoinError;
+
+use crate::runtime::BlockingParseLimiter;
 
 // These thresholds intentionally allow modest inline parsing so callers avoid
 // paying `spawn_blocking` overhead for medium-sized rowsets, while still
@@ -73,14 +75,21 @@ pub(crate) enum ParseExecution {
     SpawnBlocking,
 }
 
-pub(crate) async fn execute_parse_work<T, F>(
+#[derive(Debug)]
+pub(crate) enum ParseWorkError<E> {
+    Join(JoinError),
+    Work(E),
+}
+
+pub(crate) async fn execute_parse_work<T, E, F>(
     workload: ParseWorkload,
     blocking_parse_limiter: Option<BlockingParseLimiter>,
     work: F,
-) -> Result<(ParseExecution, T)>
+) -> std::result::Result<(ParseExecution, T), ParseWorkError<E>>
 where
     T: Send + 'static,
-    F: FnOnce() -> Result<T> + Send + 'static,
+    E: Send + 'static,
+    F: FnOnce() -> std::result::Result<T, E> + Send + 'static,
 {
     if should_spawn_blocking_parse(&workload) {
         let permit = match blocking_parse_limiter {
@@ -93,10 +102,16 @@ where
             work()
         })
         .await
-        .map_err(InternalError::future_join)?;
+        .map_err(ParseWorkError::Join)?;
 
-        Ok((ParseExecution::SpawnBlocking, result?))
+        Ok((
+            ParseExecution::SpawnBlocking,
+            result.map_err(ParseWorkError::Work)?,
+        ))
     } else {
-        Ok((ParseExecution::Inline, work()?))
+        Ok((
+            ParseExecution::Inline,
+            work().map_err(ParseWorkError::Work)?,
+        ))
     }
 }

--- a/src/statement/client.rs
+++ b/src/statement/client.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use http::header::{ACCEPT, AUTHORIZATION};
 use reqwest::{Client, Url};
@@ -6,8 +9,11 @@ use tokio::time::sleep;
 use uuid::Uuid;
 
 use crate::{
-    Result,
-    error::{ConfigError, NetworkError, ProtocolError, TimeoutError},
+    Error, Result,
+    error::{
+        ConfigError, NetworkError, ProtocolError, QueryScopedError, QueryScopedResult,
+        TimeoutError, classify_request_error,
+    },
     query::QueryRequest,
 };
 
@@ -54,25 +60,31 @@ impl StatementApiClient {
             .json(request)
             .send()
             .await
-            .map_err(NetworkError::request)?;
+            .map_err(classify_request_error)?;
 
         let status = response.status();
-        let body = response.bytes().await.map_err(NetworkError::request)?;
+        let body = response.bytes().await.map_err(classify_request_error)?;
         if !status.is_success() {
             return Err(NetworkError::http_status(status.as_u16(), &body).into());
         }
 
-        parse_response(body)
+        parse_response(body).map_err(Error::from)
     }
 
     pub(crate) async fn poll_async_results(
         &self,
         poll_relative_url: &str,
         timeout: Duration,
-    ) -> Result<SnowflakeResponse> {
+        query_id: Arc<str>,
+    ) -> QueryScopedResult<SnowflakeResponse> {
         const POLL_INTERVAL: Duration = Duration::from_secs(10);
 
-        let poll_url = resolve_poll_url(&self.base_url, poll_relative_url)?;
+        let poll_url = match resolve_poll_url(&self.base_url, poll_relative_url) {
+            Ok(url) => url,
+            Err(err) => {
+                return Err(QueryScopedError::new(query_id, err));
+            }
+        };
         let deadline = Instant::now() + timeout;
 
         loop {
@@ -85,36 +97,69 @@ impl StatementApiClient {
                     format!(r#"Snowflake Token="{}""#, self.session_token),
                 )
                 .send()
-                .await
-                .map_err(NetworkError::request)?;
+                .await;
+
+            let resp = match resp {
+                Ok(resp) => resp,
+                Err(error) => {
+                    if error.is_timeout() {
+                        return Err(QueryScopedError::new(
+                            query_id,
+                            TimeoutError::request(error),
+                        ));
+                    }
+                    return Err(QueryScopedError::new(query_id, NetworkError::Http(error)));
+                }
+            };
 
             let status = resp.status();
-            let body = resp.bytes().await.map_err(NetworkError::request)?;
+            let body = match resp.bytes().await {
+                Ok(body) => body,
+                Err(error) => {
+                    if error.is_timeout() {
+                        return Err(QueryScopedError::new(
+                            query_id,
+                            TimeoutError::request(error),
+                        ));
+                    }
+                    return Err(QueryScopedError::new(query_id, NetworkError::Http(error)));
+                }
+            };
             if !status.is_success() {
-                return Err(NetworkError::http_status(status.as_u16(), &body).into());
+                return Err(QueryScopedError::new(
+                    query_id,
+                    NetworkError::http_status(status.as_u16(), &body),
+                ));
             }
 
-            let response = parse_response(body)?;
-            if response.code.as_deref() != Some(QUERY_IN_PROGRESS_ASYNC_CODE)
-                && response.code.as_deref() != Some(QUERY_IN_PROGRESS_CODE)
-            {
-                return Ok(response);
+            match parse_response(body) {
+                Ok(response)
+                    if response.code.as_deref() != Some(QUERY_IN_PROGRESS_ASYNC_CODE)
+                        && response.code.as_deref() != Some(QUERY_IN_PROGRESS_CODE) =>
+                {
+                    return Ok(response);
+                }
+                Ok(_) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(QueryScopedError::new(query_id, TimeoutError::query()));
+                    }
+                    sleep(remaining.min(POLL_INTERVAL)).await;
+                }
+                Err(err) => return Err(QueryScopedError::new(query_id, err)),
             }
-
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return Err(TimeoutError::query().into());
-            }
-            sleep(remaining.min(POLL_INTERVAL)).await;
         }
     }
 }
 
-fn resolve_poll_url(base_url: &Url, poll_relative_url: &str) -> Result<Url> {
+fn resolve_poll_url(
+    base_url: &Url,
+    poll_relative_url: &str,
+) -> std::result::Result<Url, ProtocolError> {
     const FIELD: &str = "data.getResultUrl";
 
     if poll_relative_url.trim().is_empty() {
-        return Err(ProtocolError::invalid_field(FIELD, "must not be empty").into());
+        return Err(ProtocolError::invalid_field(FIELD, "must not be empty"));
     }
 
     if let Ok(url) = Url::parse(poll_relative_url) {
@@ -130,9 +175,16 @@ fn resolve_poll_url(base_url: &Url, poll_relative_url: &str) -> Result<Url> {
     Ok(url)
 }
 
-fn validate_same_origin_absolute_url(base_url: &Url, url: &Url, field: &'static str) -> Result<()> {
+fn validate_same_origin_absolute_url(
+    base_url: &Url,
+    url: &Url,
+    field: &'static str,
+) -> std::result::Result<(), ProtocolError> {
     if !url.username().is_empty() || url.password().is_some() {
-        return Err(ProtocolError::invalid_field(field, "must not contain credentials").into());
+        return Err(ProtocolError::invalid_field(
+            field,
+            "must not contain credentials",
+        ));
     }
 
     let same_origin = url.scheme() == base_url.scheme()
@@ -143,8 +195,7 @@ fn validate_same_origin_absolute_url(base_url: &Url, url: &Url, field: &'static 
         return Err(ProtocolError::invalid_field(
             field,
             "must be relative or same-origin absolute URL",
-        )
-        .into());
+        ));
     }
 
     Ok(())
@@ -152,6 +203,10 @@ fn validate_same_origin_absolute_url(base_url: &Url, url: &Url, field: &'static 
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use tokio::net::TcpListener;
+
     use super::*;
     use crate::ErrorKind;
 
@@ -181,20 +236,52 @@ mod tests {
     fn resolve_poll_url_rejects_cross_origin_and_credentialed_absolute_urls() {
         let base_url = Url::parse("https://example.com/").unwrap();
 
-        let err = resolve_poll_url(&base_url, "https://attacker.example/query")
-            .expect_err("cross-origin poll URL must fail");
+        let err: Error = resolve_poll_url(&base_url, "https://attacker.example/query")
+            .expect_err("cross-origin poll URL must fail")
+            .into();
         assert_eq!(err.kind(), ErrorKind::Protocol);
         assert_eq!(
             err.to_string(),
             "invalid Snowflake response field data.getResultUrl: must be relative or same-origin absolute URL"
         );
 
-        let err = resolve_poll_url(&base_url, "https://user:pass@example.com/query")
-            .expect_err("credentialed poll URL must fail");
+        let err: Error = resolve_poll_url(&base_url, "https://user:pass@example.com/query")
+            .expect_err("credentialed poll URL must fail")
+            .into();
         assert_eq!(err.kind(), ErrorKind::Protocol);
         assert_eq!(
             err.to_string(),
             "invalid Snowflake response field data.getResultUrl: must not contain credentials"
         );
+    }
+
+    #[tokio::test]
+    async fn submit_timeout_is_timeout_error() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+
+        let client = StatementApiClient::new(
+            reqwest::Client::builder()
+                .timeout(Duration::from_millis(50))
+                .build()
+                .unwrap(),
+            Url::parse(&format!("http://{addr}/")).unwrap(),
+            "test-token".to_string(),
+        );
+
+        let err = client
+            .submit(&crate::query::QueryRequest::from("select 1"))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Timeout);
+        assert!(err.is_timeout());
+
+        server.abort();
+        let _ = server.await;
     }
 }

--- a/src/statement/executor.rs
+++ b/src/statement/executor.rs
@@ -1,8 +1,8 @@
-use std::{num::NonZeroUsize, time::Duration};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use crate::{
     chunk::ChunkDownloader,
-    error::{ProtocolError, ServerError},
+    error::{ProtocolError, QueryScopedError, QueryScopedResult, ServerError, SessionExpiredError},
     query::QueryRequest,
     query_result::{
         CollectPolicy, InlineRowset, ResultSet,
@@ -18,7 +18,7 @@ use super::{
     manifest::ResultManifest,
     response::{
         DEFAULT_TIMEOUT_SECONDS, QUERY_IN_PROGRESS_ASYNC_CODE, QUERY_IN_PROGRESS_CODE,
-        RawQueryResponse, SESSION_EXPIRED,
+        RawQueryResponse, SESSION_EXPIRED, SnowflakeResponse,
     },
 };
 
@@ -27,6 +27,34 @@ pub(crate) struct StatementExecutor {
     async_completion_timeout: Duration,
     default_collect_concurrency: NonZeroUsize,
     runtime: QueryRuntime,
+}
+
+struct QueryScopedResponse {
+    query_id: Arc<str>,
+    response: SnowflakeResponse,
+}
+
+impl QueryScopedResponse {
+    fn from_submit(response: SnowflakeResponse) -> Result<Self> {
+        match response
+            .data
+            .as_ref()
+            .map(|data| Arc::clone(&data.query_id))
+        {
+            Some(query_id) => Ok(Self { query_id, response }),
+            None if response.code.as_deref() == Some(SESSION_EXPIRED) => {
+                Err(SessionExpiredError::new(response.code, response.message, None).into())
+            }
+            None if !response.success => {
+                Err(ServerError::new(response.code, response.message, None).into())
+            }
+            None => Err(ProtocolError::missing_field("data").into()),
+        }
+    }
+
+    fn into_parts(self) -> (Arc<str>, super::response::SnowflakeResponse) {
+        (self.query_id, self.response)
+    }
 }
 
 impl StatementExecutor {
@@ -49,52 +77,85 @@ impl StatementExecutor {
     }
 
     pub(crate) async fn execute(self, request: QueryRequest) -> Result<ResultSet> {
-        let mut response = self.api.submit(&request).await?;
+        let response = QueryScopedResponse::from_submit(self.api.submit(&request).await?)?;
+        self.execute_query_scoped(response)
+            .await
+            .map_err(Error::from)
+    }
+
+    async fn execute_query_scoped(
+        self,
+        response: QueryScopedResponse,
+    ) -> QueryScopedResult<ResultSet> {
+        let (query_id, mut response) = response.into_parts();
 
         let response_code = response.code.as_deref();
         if response_code == Some(QUERY_IN_PROGRESS_ASYNC_CODE)
             || response_code == Some(QUERY_IN_PROGRESS_CODE)
         {
-            let Some(data) = response.data else {
-                return Err(ProtocolError::missing_field("data").into());
+            let data = response
+                .data
+                .take()
+                .expect("query-scoped responses always carry a query id in data");
+            let Some(result_url) = data.get_result_url else {
+                return Err(QueryScopedError::new(
+                    query_id,
+                    ProtocolError::no_polling_url(),
+                ));
             };
 
-            match data.get_result_url {
-                Some(result_url) => {
-                    response = self
-                        .api
-                        .poll_async_results(&result_url, self.async_completion_timeout)
-                        .await?;
-                }
-                None => {
-                    return Err(ProtocolError::no_polling_url().into());
-                }
-            }
+            response = self
+                .api
+                .poll_async_results(
+                    &result_url,
+                    self.async_completion_timeout,
+                    Arc::clone(&query_id),
+                )
+                .await?;
         }
 
         if let Some(SESSION_EXPIRED) = response.code.as_deref() {
-            return Err(Error::session_expired(response.code, response.message));
+            return Err(QueryScopedError::new(
+                query_id,
+                SessionExpiredError::new(
+                    response.code,
+                    response.message,
+                    response.data.as_ref().map(|data| data.query_id.clone()),
+                ),
+            ));
         }
 
         if !response.success {
-            let query_id = response.data.as_ref().map(|data| data.query_id.clone());
-            return Err(ServerError::new(response.code, response.message, query_id).into());
+            return Err(QueryScopedError::new(
+                query_id,
+                ServerError::new(
+                    response.code,
+                    response.message,
+                    response.data.as_ref().map(|data| data.query_id.clone()),
+                ),
+            ));
         }
 
         let Some(data) = response.data else {
-            return Err(ProtocolError::missing_field("data").into());
+            return Err(QueryScopedError::new(
+                query_id,
+                ProtocolError::missing_field("data"),
+            ));
         };
 
-        if let Some(ref format) = data.query_result_format {
-            if format != "json" {
-                return Err(ProtocolError::unsupported_result_format(format.clone()).into());
-            }
+        if let Some(ref format) = data.query_result_format
+            && format != "json"
+        {
+            return Err(QueryScopedError::new(
+                query_id,
+                ProtocolError::unsupported_result_format(format.clone()),
+            ));
         }
 
         self.build_result_set(data)
     }
 
-    fn build_result_set(self, data: RawQueryResponse) -> Result<ResultSet> {
+    fn build_result_set(self, data: RawQueryResponse) -> QueryScopedResult<ResultSet> {
         let manifest = ResultManifest::try_from(data)?;
         let cursor = PartitionCursor::new(manifest.snapshot.partitions.len());
 
@@ -132,12 +193,16 @@ mod tests {
     use reqwest::{Client, Url};
     use tokio::time::timeout;
 
-    use super::super::client::StatementApiClient;
     use super::*;
     use crate::{
+        ErrorKind, SnowflakeQueryConfig,
+        query::QueryRequest,
         rowset::BLOCKING_PARSE_CELLS,
         runtime::QueryRuntime,
-        statement::response::{RawQueryResponse, RawQueryResponseChunk, RawQueryResponseRowType},
+        statement::{
+            client::StatementApiClient,
+            response::{RawQueryResponse, RawQueryResponseChunk, RawQueryResponseRowType},
+        },
     };
 
     fn executor() -> StatementExecutor {
@@ -173,10 +238,47 @@ mod tests {
         Url::parse(&format!("http://{addr}/")).unwrap()
     }
 
+    fn spawn_disconnect_server() -> Url {
+        let listener = StdTcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 4096];
+            let _ = stream.read(&mut buf);
+        });
+
+        Url::parse(&format!("http://{addr}/")).unwrap()
+    }
+
+    fn spawn_response_sequence_server(responses: Vec<Option<&'static str>>) -> Url {
+        let listener = StdTcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        thread::spawn(move || {
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0_u8; 4096];
+                let _ = stream.read(&mut buf);
+
+                if let Some(body) = response {
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    stream.write_all(response.as_bytes()).unwrap();
+                }
+            }
+        });
+
+        Url::parse(&format!("http://{addr}/")).unwrap()
+    }
+
     fn chunk_only_response(row_types: Option<Vec<RawQueryResponseRowType>>) -> RawQueryResponse {
         RawQueryResponse {
             parameters: None,
-            query_id: "query-id".to_string(),
+            query_id: Arc::from("query-id"),
             get_result_url: None,
             returned: None,
             total: None,
@@ -212,7 +314,7 @@ mod tests {
     fn whitespace_empty_inline_response(rowset: &'static [u8]) -> RawQueryResponse {
         RawQueryResponse {
             parameters: None,
-            query_id: "query-id".to_string(),
+            query_id: Arc::from("query-id"),
             get_result_url: None,
             returned: None,
             total: None,
@@ -225,6 +327,24 @@ mod tests {
         }
     }
 
+    async fn execute_single_response_err(body: &'static str) -> crate::Error {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_single_response_server(body),
+            session_token: "test-token".to_string(),
+            query: SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        match StatementExecutor::new(&session)
+            .execute(QueryRequest::from("select 1"))
+            .await
+        {
+            Ok(_) => panic!("expected statement execution to fail"),
+            Err(err) => err,
+        }
+    }
+
     #[test]
     fn statement_executor_reuses_session_query_runtime() {
         let runtime = QueryRuntime::with_blocking_parse_concurrency(NonZeroUsize::new(1).unwrap());
@@ -232,7 +352,7 @@ mod tests {
             http: Client::new(),
             base_url: Url::parse("https://example.com/").unwrap(),
             session_token: "test-token".to_string(),
-            query: crate::SnowflakeQueryConfig::default(),
+            query: SnowflakeQueryConfig::default(),
             runtime: runtime.clone(),
         };
 
@@ -246,81 +366,98 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_async_response_with_invalid_polling_url_is_protocol_error() {
-        let session = SnowflakeSession {
-            http: Client::new(),
-            base_url: spawn_single_response_server(
+    async fn execute_async_response_invalid_polling_urls_are_protocol_errors() {
+        for (label, body, expected_message) in [
+            (
+                "malformed absolute URL",
                 r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"http://[::1"}}"#,
+                "invalid URL in Snowflake response field data.getResultUrl; value: http://[::1",
             ),
-            session_token: "test-token".to_string(),
-            query: crate::SnowflakeQueryConfig::default(),
-            runtime: QueryRuntime::new(),
-        };
-
-        let err = StatementExecutor::new(&session)
-            .execute(crate::query::QueryRequest::from("select 1"))
-            .await;
-        let err = match err {
-            Ok(_) => panic!("expected invalid getResultUrl to fail"),
-            Err(err) => err,
-        };
-
-        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
-        assert!(err.to_string().contains("data.getResultUrl"));
-    }
-
-    #[tokio::test]
-    async fn execute_async_response_with_cross_origin_polling_url_is_protocol_error() {
-        let session = SnowflakeSession {
-            http: Client::new(),
-            base_url: spawn_single_response_server(
+            (
+                "cross-origin absolute URL",
                 r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"https://attacker.example/query"}}"#,
+                "invalid Snowflake response field data.getResultUrl: must be relative or same-origin absolute URL",
             ),
-            session_token: "test-token".to_string(),
-            query: crate::SnowflakeQueryConfig::default(),
-            runtime: QueryRuntime::new(),
-        };
-
-        let err = StatementExecutor::new(&session)
-            .execute(crate::query::QueryRequest::from("select 1"))
-            .await;
-        let err = match err {
-            Ok(_) => panic!("expected cross-origin getResultUrl to fail"),
-            Err(err) => err,
-        };
-
-        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
-        assert_eq!(
-            err.to_string(),
-            "invalid Snowflake response field data.getResultUrl: must be relative or same-origin absolute URL"
-        );
+            (
+                "empty polling URL",
+                r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"   "}}"#,
+                "invalid Snowflake response field data.getResultUrl: must not be empty",
+            ),
+        ] {
+            let err = execute_single_response_err(body).await;
+            assert_eq!(err.kind(), ErrorKind::Protocol, "{label}");
+            assert_eq!(err.to_string(), expected_message, "{label}");
+            assert_eq!(err.query_id(), Some("query-id"), "{label}");
+        }
     }
 
     #[tokio::test]
-    async fn execute_async_response_with_empty_polling_url_is_protocol_error() {
-        let session = SnowflakeSession {
-            http: Client::new(),
-            base_url: spawn_single_response_server(
-                r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"   "}}"#,
+    async fn execute_async_response_without_polling_url_preserves_query_id() {
+        let err = execute_single_response_err(
+            r#"{"code":"333334","success":true,"data":{"queryId":"query-id"}}"#,
+        )
+        .await;
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(
+            err.to_string(),
+            "async response doesn't contain a URL to poll for results"
+        );
+        assert_eq!(err.query_id(), Some("query-id"));
+    }
+
+    #[tokio::test]
+    async fn execute_async_poll_timeout_preserves_query_id() {
+        let executor = StatementExecutor {
+            api: StatementApiClient::new(
+                Client::new(),
+                spawn_response_sequence_server(vec![
+                    Some(
+                        r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"/poll"}}"#,
+                    ),
+                    Some(
+                        r#"{"code":"333334","success":true,"data":{"queryId":"query-id","getResultUrl":"/poll"}}"#,
+                    ),
+                ]),
+                "test-token".to_string(),
             ),
-            session_token: "test-token".to_string(),
-            query: crate::SnowflakeQueryConfig::default(),
+            async_completion_timeout: Duration::ZERO,
+            default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime: QueryRuntime::new(),
         };
 
-        let err = StatementExecutor::new(&session)
-            .execute(crate::query::QueryRequest::from("select 1"))
-            .await;
-        let err = match err {
-            Ok(_) => panic!("expected empty getResultUrl to fail"),
+        let err = match executor.execute(QueryRequest::from("select 1")).await {
+            Ok(_) => panic!("poll timeout must fail"),
             Err(err) => err,
         };
 
-        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
-        assert_eq!(
-            err.to_string(),
-            "invalid Snowflake response field data.getResultUrl: must not be empty"
-        );
+        assert_eq!(err.kind(), ErrorKind::Timeout);
+        assert_eq!(err.query_id(), Some("query-id"));
+    }
+
+    #[tokio::test]
+    async fn execute_unsupported_result_format_preserves_query_id() {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_single_response_server(
+                r#"{"success":true,"data":{"queryId":"query-id","queryResultFormat":"arrow"}}"#,
+            ),
+            session_token: "test-token".to_string(),
+            query: SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        let err = match StatementExecutor::new(&session)
+            .execute(QueryRequest::from("select 1"))
+            .await
+        {
+            Ok(_) => panic!("unsupported result format must fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        assert_eq!(err.to_string(), "unsupported result format: arrow");
+        assert_eq!(err.query_id(), Some("query-id"));
     }
 
     #[tokio::test]
@@ -328,28 +465,107 @@ mod tests {
         let session = SnowflakeSession {
             http: Client::new(),
             base_url: spawn_single_response_server(
-                r#"{"code":"390112","message":"Your session has expired. Please login again.","success":false,"data":null}"#,
+                r#"{"code":"390112","message":"Your session has expired. Please login again.","success":false,"data":{"queryId":"query-id"}}"#,
             ),
             session_token: "test-token".to_string(),
-            query: crate::SnowflakeQueryConfig::default(),
+            query: SnowflakeQueryConfig::default(),
             runtime: QueryRuntime::new(),
         };
 
         let err = match StatementExecutor::new(&session)
-            .execute(crate::query::QueryRequest::from("select 1"))
+            .execute(QueryRequest::from("select 1"))
             .await
         {
             Ok(_) => panic!("session expired response must fail"),
             Err(err) => err,
         };
 
-        assert_eq!(err.kind(), crate::ErrorKind::SessionExpired);
+        assert_eq!(err.kind(), ErrorKind::SessionExpired);
         assert!(err.is_session_expired());
         assert_eq!(err.snowflake_code(), Some("390112"));
         assert_eq!(
             err.snowflake_message(),
             Some("Your session has expired. Please login again.")
         );
+        assert_eq!(err.query_id(), Some("query-id"));
+    }
+
+    #[tokio::test]
+    async fn execute_session_expired_without_query_id_preserves_snowflake_fields() {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_single_response_server(
+                r#"{"code":"390112","message":"Your session has expired. Please login again.","success":false,"data":null}"#,
+            ),
+            session_token: "test-token".to_string(),
+            query: SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        let err = match StatementExecutor::new(&session)
+            .execute(QueryRequest::from("select 1"))
+            .await
+        {
+            Ok(_) => panic!("session expired response must fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::SessionExpired);
+        assert!(err.is_session_expired());
+        assert_eq!(err.snowflake_code(), Some("390112"));
+        assert_eq!(
+            err.snowflake_message(),
+            Some("Your session has expired. Please login again.")
+        );
+        assert_eq!(err.query_id(), None);
+    }
+
+    #[tokio::test]
+    async fn execute_server_error_preserves_query_id() {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_single_response_server(
+                r#"{"code":"123456","message":"statement failed","success":false,"data":{"queryId":"query-id"}}"#,
+            ),
+            session_token: "test-token".to_string(),
+            query: SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        let err = match StatementExecutor::new(&session)
+            .execute(QueryRequest::from("select 1"))
+            .await
+        {
+            Ok(_) => panic!("server error response must fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::Server);
+        assert_eq!(err.snowflake_code(), Some("123456"));
+        assert_eq!(err.snowflake_message(), Some("statement failed"));
+        assert_eq!(err.query_id(), Some("query-id"));
+    }
+
+    #[tokio::test]
+    async fn execute_network_failure_has_no_query_id() {
+        let session = SnowflakeSession {
+            http: Client::new(),
+            base_url: spawn_disconnect_server(),
+            session_token: "test-token".to_string(),
+            query: SnowflakeQueryConfig::default(),
+            runtime: QueryRuntime::new(),
+        };
+
+        let err = match StatementExecutor::new(&session)
+            .execute(QueryRequest::from("select 1"))
+            .await
+        {
+            Ok(_) => panic!("network failure must not yield a result set"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert_eq!(err.query_id(), None);
     }
 
     #[tokio::test]
@@ -368,7 +584,7 @@ mod tests {
         };
         let response = RawQueryResponse {
             parameters: None,
-            query_id: "query-id".to_string(),
+            query_id: Arc::from("query-id"),
             get_result_url: None,
             returned: Some(BLOCKING_PARSE_CELLS as i64),
             total: None,
@@ -416,7 +632,7 @@ mod tests {
         };
         let response = RawQueryResponse {
             parameters: None,
-            query_id: "query-id".to_string(),
+            query_id: Arc::from("query-id"),
             get_result_url: None,
             returned: Some(BLOCKING_PARSE_CELLS as i64),
             total: None,
@@ -459,7 +675,7 @@ mod tests {
         };
         let response = RawQueryResponse {
             parameters: None,
-            query_id: "query-id".to_string(),
+            query_id: Arc::from("query-id"),
             get_result_url: None,
             returned: Some(BLOCKING_PARSE_CELLS as i64),
             total: None,
@@ -501,9 +717,13 @@ mod tests {
             ),
         ] {
             match executor().build_result_set(chunk_only_response(row_types)) {
-                Err(err)
-                    if err.kind() == crate::ErrorKind::Protocol && err.to_string() == expected => {}
-                Err(other) => panic!("expected rowtype metadata error, got {other:?}"),
+                Err(err) => {
+                    let err = crate::Error::from(err);
+                    if err.kind() == ErrorKind::Protocol && err.to_string() == expected {
+                        continue;
+                    }
+                    panic!("expected rowtype metadata error, got {err:?}");
+                }
                 Ok(_) => {
                     panic!("expected chunk-only response with {label} rowtype metadata to fail")
                 }

--- a/src/statement/manifest.rs
+++ b/src/statement/manifest.rs
@@ -3,13 +3,12 @@ use std::{collections::HashMap, sync::Arc};
 use bytes::Bytes;
 
 use crate::{
-    Error, Result,
-    error::ProtocolError,
+    error::{ProtocolError, QueryScopedError, QueryScopedResult},
     query_result::snapshot::{
         DownloadLocator, PartitionSpec, ResolvedLease, ResultIdentity, ResultSnapshot,
     },
     result::{Column, ColumnType, Schema},
-    rowset::parser::inline_rowset_has_rows,
+    rowset::parser::inline_rowset_has_rows_inner,
 };
 
 use super::response::{RawQueryResponse, resolve_download_headers};
@@ -26,9 +25,9 @@ pub(crate) struct InlineRowset {
 }
 
 impl TryFrom<RawQueryResponse> for ResultManifest {
-    type Error = Error;
+    type Error = QueryScopedError;
 
-    fn try_from(value: RawQueryResponse) -> Result<Self> {
+    fn try_from(value: RawQueryResponse) -> QueryScopedResult<Self> {
         let RawQueryResponse {
             query_id,
             returned,
@@ -43,7 +42,12 @@ impl TryFrom<RawQueryResponse> for ResultManifest {
 
         let has_inline = match row_set_bytes.as_ref() {
             None => false,
-            Some(bytes) => inline_rowset_has_rows(bytes)?,
+            Some(bytes) => match inline_rowset_has_rows_inner(bytes) {
+                Ok(has_rows) => has_rows,
+                Err(err) => {
+                    return Err(QueryScopedError::new(query_id, err));
+                }
+            },
         };
 
         let chunks = chunks.unwrap_or_default();
@@ -55,13 +59,20 @@ impl TryFrom<RawQueryResponse> for ResultManifest {
 
         if has_inline || !chunks.is_empty() {
             match row_types.as_ref() {
-                None => return Err(ProtocolError::missing_field("data.rowtype").into()),
+                None => {
+                    return Err(QueryScopedError::new(
+                        query_id,
+                        ProtocolError::missing_field("data.rowtype"),
+                    ));
+                }
                 Some(row_types) if row_types.is_empty() => {
-                    return Err(ProtocolError::invalid_field(
-                        "data.rowtype",
-                        "must not be empty when result data is present",
-                    )
-                    .into());
+                    return Err(QueryScopedError::new(
+                        query_id,
+                        ProtocolError::invalid_field(
+                            "data.rowtype",
+                            "must not be empty when result data is present",
+                        ),
+                    ));
                 }
                 Some(_) => {}
             }
@@ -81,9 +92,20 @@ impl TryFrom<RawQueryResponse> for ResultManifest {
                 Column::new(row_type.name, index as u32, row_type.nullable, ty)
             })
             .collect();
-        let schema = Arc::new(Schema::from_columns(columns)?);
+        let schema = match Schema::from_columns(columns) {
+            Ok(schema) => schema,
+            Err(err) => {
+                return Err(QueryScopedError::new(query_id, err));
+            }
+        };
+        let schema = Arc::new(schema);
 
-        let download_headers = resolve_download_headers(&qrmk, &chunk_headers)?;
+        let download_headers = match resolve_download_headers(&qrmk, &chunk_headers) {
+            Ok(headers) => headers,
+            Err(err) => {
+                return Err(QueryScopedError::new(query_id, err));
+            }
+        };
         let mut partitions = Vec::new();
         let mut locators = HashMap::new();
 
@@ -107,11 +129,8 @@ impl TryFrom<RawQueryResponse> for ResultManifest {
             );
         }
 
-        let query_id: Arc<str> = Arc::from(query_id);
         let snapshot = Arc::new(ResultSnapshot {
-            identity: ResultIdentity {
-                query_id: Arc::clone(&query_id),
-            },
+            identity: ResultIdentity { query_id },
             schema: Arc::clone(&schema),
             partitions,
         });
@@ -154,7 +173,7 @@ mod tests {
     fn manifest_requires_rowtype_when_inline_data_is_present() {
         let response = RawQueryResponse {
             parameters: None,
-            query_id: "query-id".to_string(),
+            query_id: Arc::from("query-id"),
             get_result_url: None,
             returned: Some(1),
             total: None,
@@ -168,7 +187,7 @@ mod tests {
 
         let err = match ResultManifest::try_from(response) {
             Ok(_) => panic!("missing rowtype metadata must fail"),
-            Err(err) => err,
+            Err(err) => crate::Error::from(err),
         };
         assert_eq!(err.kind(), crate::ErrorKind::Protocol);
         assert_eq!(
@@ -181,7 +200,7 @@ mod tests {
     fn manifest_rejects_empty_rowtype_when_result_data_is_present() {
         let response = RawQueryResponse {
             parameters: None,
-            query_id: "query-id".to_string(),
+            query_id: Arc::from("query-id"),
             get_result_url: None,
             returned: None,
             total: None,
@@ -200,7 +219,7 @@ mod tests {
 
         let err = match ResultManifest::try_from(response) {
             Ok(_) => panic!("empty rowtype metadata must fail"),
-            Err(err) => err,
+            Err(err) => crate::Error::from(err),
         };
         assert_eq!(err.kind(), crate::ErrorKind::Protocol);
         assert_eq!(
@@ -213,7 +232,7 @@ mod tests {
     fn manifest_accepts_non_empty_rowtype_when_result_data_is_present() {
         let response = RawQueryResponse {
             parameters: None,
-            query_id: "query-id".to_string(),
+            query_id: Arc::from("query-id"),
             get_result_url: None,
             returned: Some(1),
             total: None,

--- a/src/statement/response.rs
+++ b/src/statement/response.rs
@@ -5,7 +5,7 @@ use http::{HeaderMap, HeaderValue};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 
-use crate::{Error, Result, error::ProtocolError};
+use crate::error::ProtocolError;
 
 pub(crate) const SESSION_EXPIRED: &str = "390112";
 pub(crate) const QUERY_IN_PROGRESS_CODE: &str = "333333";
@@ -29,7 +29,7 @@ pub(crate) struct SnowflakeResponse {
 pub(crate) struct RawQueryResponse {
     #[allow(unused)]
     pub(crate) parameters: Option<Vec<RawQueryResponseParameter>>,
-    pub(crate) query_id: String,
+    pub(crate) query_id: Arc<str>,
     pub(crate) get_result_url: Option<String>,
     #[allow(unused)]
     pub(crate) returned: Option<i64>,
@@ -80,7 +80,7 @@ struct BorrowedRawQueryResponse<'a> {
 
 /// Parse a response body, keeping the rowset as a zero-copy `Bytes` slice
 /// of the input.
-pub(crate) fn parse_response(body: Bytes) -> Result<SnowflakeResponse> {
+pub(crate) fn parse_response(body: Bytes) -> std::result::Result<SnowflakeResponse, ProtocolError> {
     let borrowed: BorrowedSnowflakeResponse<'_> =
         serde_json::from_slice(strip_utf8_bom(body.as_ref()))
             .map_err(|e| ProtocolError::json_parse(e, &body))?;
@@ -92,10 +92,11 @@ pub(crate) fn parse_response(body: Bytes) -> Result<SnowflakeResponse> {
                 .row_set
                 .map(|row_set| row_set_bytes_from_raw_value(&body, row_set))
                 .transpose()?;
-            Ok::<RawQueryResponse, Error>(RawQueryResponse {
+            Ok::<RawQueryResponse, ProtocolError>(RawQueryResponse {
                 parameters: d.parameters,
                 query_id: d
                     .query_id
+                    .map(Arc::from)
                     .ok_or_else(|| ProtocolError::missing_field("data.queryId"))?,
                 get_result_url: d.get_result_url,
                 returned: d.returned,
@@ -118,7 +119,10 @@ pub(crate) fn parse_response(body: Bytes) -> Result<SnowflakeResponse> {
     })
 }
 
-fn row_set_bytes_from_raw_value(body: &Bytes, raw: &RawValue) -> Result<Bytes> {
+fn row_set_bytes_from_raw_value(
+    body: &Bytes,
+    raw: &RawValue,
+) -> std::result::Result<Bytes, ProtocolError> {
     let raw_bytes = raw.get().as_bytes();
     // `BorrowedRawQueryResponse<'_>` uses `#[serde(borrow)] &'a RawValue`, so
     // `raw_bytes` is expected to alias the original response buffer. We rely on
@@ -141,12 +145,11 @@ fn row_set_bytes_from_raw_value(body: &Bytes, raw: &RawValue) -> Result<Bytes> {
     Ok(body.slice(start..end))
 }
 
-fn json_scan_error(body: &Bytes, message: impl Into<String>) -> Error {
+fn json_scan_error(body: &Bytes, message: impl Into<String>) -> ProtocolError {
     ProtocolError::json_parse(
         serde_json::Error::io(io::Error::new(io::ErrorKind::InvalidData, message.into())),
         body,
     )
-    .into()
 }
 
 fn strip_utf8_bom(bytes: &[u8]) -> &[u8] {
@@ -197,7 +200,7 @@ pub(crate) struct RawQueryResponseChunk {
 pub(crate) fn resolve_download_headers(
     qrmk: &Option<String>,
     chunk_headers: &Option<HashMap<String, String>>,
-) -> Result<Arc<HeaderMap>> {
+) -> std::result::Result<Arc<HeaderMap>, ProtocolError> {
     // Branch on chunk_headers presence, not emptiness: if Snowflake
     // returns `chunkHeaders: {}` that empty map is used as-is, without
     // falling back to qrmk-derived SSE-C headers.
@@ -222,6 +225,7 @@ pub(crate) fn resolve_download_headers(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Error, ErrorKind};
 
     #[test]
     fn test_deserialize_session_expired() {
@@ -293,10 +297,8 @@ mod tests {
         let body = Bytes::from(
             r#"{"message":"\uD83D","data":{"queryId":"q1","rowset":[["ok"]],"rowtype":[],"queryResultFormat":"json"},"success":true}"#,
         );
-        assert!(matches!(
-            parse_response(body),
-            Err(err) if err.kind() == crate::ErrorKind::Protocol
-        ));
+        let err: Error = parse_response(body).unwrap_err().into();
+        assert_eq!(err.kind(), ErrorKind::Protocol);
     }
 
     #[test]
@@ -312,8 +314,8 @@ mod tests {
     fn parse_response_missing_query_id_is_protocol_error() {
         let body = Bytes::from(r#"{"data":{"rowset":null},"success":true}"#);
 
-        let err = parse_response(body).unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        let err: Error = parse_response(body).unwrap_err().into();
+        assert_eq!(err.kind(), ErrorKind::Protocol);
         assert_eq!(
             err.to_string(),
             "missing required field in Snowflake response: data.queryId"
@@ -375,13 +377,17 @@ mod tests {
         let mut map = HashMap::new();
         map.insert("x-custom".to_string(), "bad\nvalue".to_string());
 
-        let err = resolve_download_headers(&None, &Some(map)).unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        let err: Error = resolve_download_headers(&None, &Some(map))
+            .unwrap_err()
+            .into();
+        assert_eq!(err.kind(), ErrorKind::Protocol);
     }
 
     #[test]
     fn resolve_headers_invalid_qrmk_is_protocol_error() {
-        let err = resolve_download_headers(&Some("bad\nvalue".into()), &None).unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::Protocol);
+        let err: Error = resolve_download_headers(&Some("bad\nvalue".into()), &None)
+            .unwrap_err()
+            .into();
+        assert_eq!(err.kind(), ErrorKind::Protocol);
     }
 }


### PR DESCRIPTION
## What changed

`Error::query_id()` now also returns the query ID for failures that occur during query execution. Previously it returned `Some` only for `Session::query` server-side rejections.

The semantics are best-effort:

- `Some` whenever the connector could extract a query ID from the failure path.
- `None` does not mean "Snowflake did not assign a query ID". It can also be `None` when response parsing failed before the ID could be extracted, or when the caller still holds a `ResultSet` / `ResultTable` and can obtain the ID through that path.
- If an API that reliably exposes the query ID (e.g. `ResultSet::query_id`) is available, prefer it.

## Why

In the previous implementation the query ID was treated as a value held inside `ServerError`, so `Error::query_id()` returned `None` for failures that occurred after Snowflake had already accepted the query. Users could not trace failed queries on the Snowflake console, which hurt operational diagnosability.

It also means callers no longer need to pre-clone `*ResultSet::query_id()` before invoking `self`-consuming APIs such as `*ResultSet::collect_table` / `*ResultSet::collect` just to recover the query ID on failure.