### PR TITLE
refactor(result): separate cell decode issues from contextual errors

### DIFF
--- a/benches/result_table.rs
+++ b/benches/result_table.rs
@@ -14,7 +14,10 @@ use snowflake_connector_rs::bench_support::{
     decode_gzip_chunk, make_result_table_from_rows, make_schema, parse_remote_chunk_result_table,
     parse_remote_chunk_result_table_async_with_workload, parse_statement_envelope,
 };
-use snowflake_connector_rs::{ColumnType, DynamicRow, ResultTable, Schema};
+use snowflake_connector_rs::{
+    DynamicRow, ResultTable,
+    result::{ColumnType, Schema},
+};
 
 #[derive(snowflake_connector_rs::FromRow)]
 struct BenchRow {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -10,7 +10,7 @@ pub(crate) fn expand(model: &FromRowDerive) -> TokenStream2 {
 
     let plan_fields = model.fields.iter().map(|field| {
         let ident = &field.plan_ident;
-        quote! { #ident: #crate_path::ColumnIndex }
+        quote! { #ident: #crate_path::result::ColumnIndex }
     });
 
     let build_plan_lines = model
@@ -34,7 +34,7 @@ pub(crate) fn expand(model: &FromRowDerive) -> TokenStream2 {
                 type Plan = #plan_ident;
 
                 fn build_plan(
-                    ctx: #crate_path::RowPlanContext<'_>,
+                    ctx: #crate_path::result::RowPlanContext<'_>,
                 ) -> #crate_path::Result<Self::Plan> {
                     let schema = ctx.schema();
                     #(#build_plan_lines)*
@@ -42,7 +42,7 @@ pub(crate) fn expand(model: &FromRowDerive) -> TokenStream2 {
                 }
 
                 fn from_row_with_plan(
-                    row: #crate_path::RowRef<'_>,
+                    row: #crate_path::result::RowRef<'_>,
                     plan: &Self::Plan,
                 ) -> #crate_path::Result<Self> {
                     #row_body

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use crate::{
-    Result, ResultTable, Schema,
+    Result, ResultTable,
+    result::Schema,
     rowset::{self, parser},
     statement::parse_response,
 };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-mod decode;
+pub(crate) mod decode;
 mod display;
 mod parse;
 mod query_scoped;
@@ -546,9 +546,48 @@ mod tests {
 
     use tokio::net::TcpListener;
 
-    use crate::result::{ColumnIndex, ColumnType};
+    use crate::result::{
+        CellDecodeIssue, CellDecodeResult, CellRef, ColumnType, FromCell,
+        test_data::{make_result_table_from_rows, make_schema},
+    };
 
     use super::*;
+
+    #[derive(Debug)]
+    struct NoSourceDecode;
+
+    impl FromCell for NoSourceDecode {
+        fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+            let _ = cell.required_raw()?;
+            Err(CellDecodeIssue::builder("bad value").build())
+        }
+    }
+
+    #[derive(Debug)]
+    struct WithSourceDecode;
+
+    impl FromCell for WithSourceDecode {
+        fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+            let raw = cell.required_raw()?;
+            raw.parse::<u32>()
+                .map(|_| Self)
+                .map_err(|e| CellDecodeIssue::builder("bad value").source(e).build())
+        }
+    }
+
+    fn decode_error<T: FromCell>(value: &str) -> Error {
+        let schema = make_schema(vec![(
+            "COL".to_string(),
+            ColumnType::Text { length: None },
+            true,
+        )]);
+        let table =
+            make_result_table_from_rows(schema, vec![vec![Some(value.to_string())]]).unwrap();
+        match table.rows::<(T,)>().unwrap().next().unwrap() {
+            Ok(_) => panic!("decode_error helper should produce an error"),
+            Err(err) => err,
+        }
+    }
 
     #[test]
     fn error_accessors_expose_structured_details() {
@@ -764,16 +803,7 @@ mod tests {
         let schema_error: Error = SchemaError::MissingColumn(MissingColumnError::new("col")).into();
         assert!(StdError::source(&schema_error).is_none());
 
-        let decode_error: Error = CellDecodeError::new(
-            0,
-            ColumnIndex::new(0),
-            "COL",
-            "integer",
-            ColumnType::Text { length: None },
-            Some("x"),
-            "bad value",
-        )
-        .into();
+        let decode_error = decode_error::<NoSourceDecode>("x");
         assert!(StdError::source(&decode_error).is_none());
 
         let parse_error: Error = RowsetParseError::CapacityOverflow.into();
@@ -788,19 +818,32 @@ mod tests {
         assert!(schema_error.as_schema_error().is_some());
         assert!(schema_error.as_cell_decode_error().is_none());
 
-        let decode_error: Error = CellDecodeError::new(
-            0,
-            ColumnIndex::new(0),
-            "COL",
-            "integer",
-            ColumnType::Text { length: None },
-            Some("x"),
-            "bad value",
-        )
-        .into();
+        let decode_error = decode_error::<NoSourceDecode>("x");
         assert_eq!(decode_error.kind(), ErrorKind::Decode);
         assert!(decode_error.as_cell_decode_error().is_some());
         assert!(decode_error.as_schema_error().is_none());
+    }
+
+    #[test]
+    fn cell_decode_errors_expose_issue_then_underlying_source() {
+        let err = decode_error::<WithSourceDecode>("x");
+        let decode = err
+            .as_cell_decode_error()
+            .expect("typed row decode should expose a CellDecodeError");
+
+        assert_eq!(decode.issue().reason(), "bad value");
+
+        let issue = StdError::source(decode).expect("decode error should expose CellDecodeIssue");
+        assert_eq!(issue.to_string(), "bad value");
+        assert!(StdError::source(issue).is_some());
+
+        let top = StdError::source(&err).expect("top-level Error should expose CellDecodeIssue");
+        assert_eq!(top.to_string(), "bad value");
+        assert!(StdError::source(top).is_some());
+        assert_eq!(
+            StdError::source(&err).map(|source| source.to_string()),
+            StdError::source(decode).map(|source| source.to_string())
+        );
     }
 
     #[test]

--- a/src/error/decode.rs
+++ b/src/error/decode.rs
@@ -4,67 +4,131 @@ use crate::result::{ColumnIndex, ColumnType};
 
 use super::{VALUE_PREVIEW_MAX_CHARS, truncate_preview_chars};
 
-/// Cell decode failure with row/column context.
-#[derive(Debug, Clone)]
-pub struct CellDecodeError {
-    row: usize,
-    column: ColumnIndex,
-    column_name: Box<str>,
-    expected: Cow<'static, str>,
-    actual: ColumnType,
-    value_preview: Option<Box<str>>,
+/// Result alias for cell-local decode failures.
+pub type CellDecodeResult<T> = std::result::Result<T, CellDecodeIssue>;
+
+/// Cell-local reason why decoding a value failed.
+///
+/// This describes only the local conversion problem. Row, column, and
+/// value context live on [`CellDecodeError`].
+#[derive(Debug)]
+pub struct CellDecodeIssue {
     reason: Box<str>,
+    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 }
 
-impl CellDecodeError {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        row: usize,
-        column: ColumnIndex,
-        column_name: impl Into<Box<str>>,
-        expected: impl Into<Cow<'static, str>>,
-        actual: ColumnType,
-        value_preview: Option<&str>,
-        reason: impl Into<Box<str>>,
-    ) -> Self {
-        Self {
-            row,
-            column,
-            column_name: column_name.into(),
-            expected: expected.into(),
-            actual,
-            value_preview: value_preview
-                .map(|preview| truncate_preview_chars(preview, VALUE_PREVIEW_MAX_CHARS)),
+impl CellDecodeIssue {
+    pub fn builder(reason: impl Into<Box<str>>) -> CellDecodeIssueBuilder {
+        CellDecodeIssueBuilder {
             reason: reason.into(),
+            source: None,
         }
     }
 
-    pub fn row(&self) -> usize {
-        self.row
+    pub fn reason(&self) -> &str {
+        &self.reason
     }
 
-    pub fn column(&self) -> ColumnIndex {
-        self.column
+    pub fn source(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
+        self.source.as_deref()
+    }
+}
+
+impl std::fmt::Display for CellDecodeIssue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.reason)
+    }
+}
+
+impl std::error::Error for CellDecodeIssue {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_deref().map(|source| source as _)
+    }
+}
+
+#[derive(Debug)]
+pub struct CellDecodeIssueBuilder {
+    reason: Box<str>,
+    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+impl CellDecodeIssueBuilder {
+    pub fn source(
+        mut self,
+        source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    pub fn build(self) -> CellDecodeIssue {
+        CellDecodeIssue {
+            reason: self.reason,
+            source: self.source,
+        }
+    }
+}
+
+/// Cell decode failure with row and column context.
+#[derive(Debug)]
+pub struct CellDecodeError {
+    row_index: usize,
+    column_index: ColumnIndex,
+    column_name: Box<str>,
+    target_type_name: Cow<'static, str>,
+    actual_column_type: ColumnType,
+    raw_value_preview: Option<Box<str>>,
+    issue: CellDecodeIssue,
+}
+
+impl CellDecodeError {
+    pub(crate) fn new(
+        row_index: usize,
+        column_index: ColumnIndex,
+        column_name: impl Into<Box<str>>,
+        target_type_name: impl Into<Cow<'static, str>>,
+        actual_column_type: ColumnType,
+        raw_value_preview: Option<&str>,
+        issue: CellDecodeIssue,
+    ) -> Self {
+        Self {
+            row_index,
+            column_index,
+            column_name: column_name.into(),
+            target_type_name: target_type_name.into(),
+            actual_column_type,
+            raw_value_preview: raw_value_preview
+                .map(|preview| truncate_preview_chars(preview, VALUE_PREVIEW_MAX_CHARS)),
+            issue,
+        }
+    }
+
+    pub fn row_index(&self) -> usize {
+        self.row_index
+    }
+
+    pub fn column_index(&self) -> ColumnIndex {
+        self.column_index
     }
 
     pub fn column_name(&self) -> &str {
         &self.column_name
     }
 
-    pub fn expected(&self) -> &str {
-        &self.expected
+    pub fn target_type_name(&self) -> &str {
+        &self.target_type_name
     }
 
-    pub fn actual(&self) -> &ColumnType {
-        &self.actual
+    pub fn actual_column_type(&self) -> &ColumnType {
+        &self.actual_column_type
     }
 
-    pub fn value_preview(&self) -> Option<&str> {
-        self.value_preview.as_deref()
+    pub fn raw_value_preview(&self) -> Option<&str> {
+        self.raw_value_preview.as_deref()
     }
 
-    pub fn reason(&self) -> &str {
-        &self.reason
+    pub fn issue(&self) -> &CellDecodeIssue {
+        &self.issue
     }
 }
 
@@ -72,17 +136,27 @@ impl std::fmt::Display for CellDecodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "row {} column {:?} ({}): expected {}, found {:?}",
-            self.row, self.column, self.column_name, self.expected, self.actual
+            "row_index {} column_index {:?} ({}): target_type {}, found {:?}",
+            self.row_index,
+            self.column_index,
+            self.column_name,
+            self.target_type_name,
+            self.actual_column_type
         )?;
-        if let Some(preview) = &self.value_preview {
+        if let Some(preview) = &self.raw_value_preview {
             write!(f, ", value: {preview:?}")?;
         }
-        if !self.reason.is_empty() {
-            write!(f, " ({})", self.reason)?;
+        if !self.issue.reason().is_empty() {
+            write!(f, " ({})", self.issue.reason())?;
         }
         Ok(())
     }
 }
 
-impl std::error::Error for CellDecodeError {}
+impl std::error::Error for CellDecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.issue
+            .source()
+            .map(|_| &self.issue as &(dyn std::error::Error + 'static))
+    }
+}

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -217,7 +217,7 @@ impl StdError for Error {
                 ..
             } => None,
             Repr::Schema(_) => None,
-            Repr::CellDecode(_) => None,
+            Repr::CellDecode(error) => StdError::source(error),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ mod chunk;
 mod config;
 mod error;
 mod query_result;
-mod result;
+pub mod result;
 mod rowset;
 mod runtime;
 mod session;
@@ -89,10 +89,7 @@ pub use error::{
     Error, ErrorKind, InvalidColumnIndexError, MissingColumnError, Result, SchemaError,
 };
 pub use query_result::{CollectOptions, ResultSet, TypedResultSet};
-pub use result::{
-    CellRef, Column, ColumnIndex, ColumnType, DecimalValue, DynamicRow, FromCell, FromRow,
-    ResultTable, RowPlanContext, RowRef, Rows, Schema, SnowflakeValue, TypedResultTable,
-};
+pub use result::{DynamicRow, FromRow, ResultTable, TypedResultTable};
 pub use session::SnowflakeSession;
 pub use statement::builder::{IntoStatement, NamedBinds, PositionalBinds, Statement, UnboundBinds};
 

--- a/src/query_result/result_set.rs
+++ b/src/query_result/result_set.rs
@@ -299,7 +299,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        CellDecodeError, ErrorKind, MissingColumnError, SchemaError,
+        ErrorKind, MissingColumnError, SchemaError,
         error::QueryScopedRepr,
         query_result::{
             TypedResultSet,
@@ -308,7 +308,8 @@ mod tests {
             snapshot::{PartitionCursor, PartitionSpec, ResultIdentity, ResultSnapshot},
         },
         result::{
-            Column, ColumnIndex, ColumnType, DynamicRow, FromRow, RowPlanContext, RowRef, Schema,
+            CellDecodeIssue, CellDecodeResult, CellRef, Column, ColumnIndex, ColumnType,
+            DynamicRow, FromCell, FromRow, RowPlanContext, RowRef, Schema,
         },
         rowset::BLOCKING_PARSE_CELLS,
         runtime::QueryRuntime,
@@ -482,6 +483,16 @@ mod tests {
     #[derive(Debug)]
     struct DecodeErrorRow;
 
+    #[derive(Debug)]
+    struct DecodeErrorCell;
+
+    impl FromCell for DecodeErrorCell {
+        fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+            let _ = cell.required_raw()?;
+            Err(CellDecodeIssue::builder("simulated decode failure").build())
+        }
+    }
+
     impl FromRow for DecodeErrorRow {
         type Plan = ();
 
@@ -489,20 +500,9 @@ mod tests {
             Ok(())
         }
 
-        fn from_row_with_plan(_: RowRef<'_>, _: &Self::Plan) -> crate::Result<Self> {
-            Err(CellDecodeError::new(
-                0,
-                ColumnIndex::new(0),
-                "X",
-                "text",
-                ColumnType::Fixed {
-                    precision: None,
-                    scale: Some(0),
-                },
-                Some("bad"),
-                "simulated decode failure",
-            )
-            .into())
+        fn from_row_with_plan(row: RowRef<'_>, _: &Self::Plan) -> crate::Result<Self> {
+            row.get::<DecodeErrorCell>(ColumnIndex::new(0))?;
+            unreachable!("decode failure should bubble out before constructing DecodeErrorRow")
         }
     }
 

--- a/src/result/cell.rs
+++ b/src/result/cell.rs
@@ -1,11 +1,9 @@
-use std::borrow::Cow;
-
 use bytes::Bytes;
 
 use crate::{
     error::RowsetParseError,
-    result::schema::{Column, ColumnType},
-    {CellDecodeError, Error, Result},
+    result::schema::Column,
+    result::{CellDecodeIssue, CellDecodeResult},
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -145,72 +143,50 @@ impl CellBlock {
     }
 }
 
-/// Lightweight view into a single cell.
+/// Borrowed view of a single cell.
+///
+/// Contains the cell's raw text (or NULL), column metadata, and row index.
+/// `CellRef` is copyable and does not own the underlying result data.
 #[derive(Clone, Copy, Debug)]
 pub struct CellRef<'a> {
-    pub(crate) row: usize,
+    pub(crate) row_index: usize,
     pub(crate) column: &'a Column,
     pub(crate) raw: Option<&'a str>,
 }
 
 impl<'a> CellRef<'a> {
+    /// Returns `true` when the cell is SQL `NULL`.
     pub fn is_null(self) -> bool {
         self.raw.is_none()
     }
 
+    /// Borrows the cell's raw text as Snowflake delivered it.
+    ///
+    /// Returns `None` for SQL `NULL`. The format is column-type specific
+    /// (e.g. `"123"` for integers, an epoch fragment for timestamps);
+    /// usually you'll let a [`FromCell`](crate::FromCell) implementation
+    /// parse it rather than reading the raw text directly.
     pub fn raw(self) -> Option<&'a str> {
         self.raw
     }
 
+    /// Borrows the column metadata for this cell.
     pub fn column(self) -> &'a Column {
         self.column
     }
 
-    pub fn column_type(self) -> &'a ColumnType {
-        self.column.ty()
+    /// Zero-based index of the row this cell came from.
+    pub fn row_index(self) -> usize {
+        self.row_index
     }
 
-    pub fn row(self) -> usize {
-        self.row
-    }
-
-    /// Convert NULL into a `CellDecodeError`. Otherwise return the raw text.
+    /// Returns the raw text when the cell is not SQL `NULL`.
     ///
-    /// # Errors
-    ///
-    /// Returns `ErrorKind::Decode` when the cell is `NULL`; inspect the
-    /// detail via [`crate::Error::as_cell_decode_error`].
-    pub fn required_raw(self, expected: impl Into<Cow<'static, str>>) -> Result<&'a str> {
+    /// `NULL` is reported as a [`CellDecodeIssue`](crate::result::CellDecodeIssue).
+    pub fn required_raw(self) -> CellDecodeResult<&'a str> {
         match self.raw {
             Some(s) => Ok(s),
-            None => Err(CellDecodeError::new(
-                self.row,
-                self.column.index(),
-                self.column.name(),
-                expected,
-                self.column.ty().clone(),
-                None,
-                "value is NULL",
-            )
-            .into()),
+            None => Err(CellDecodeIssue::builder("value is NULL").build()),
         }
-    }
-
-    /// Build a context-aware decode error for the underlying cell.
-    pub fn decode_error(
-        self,
-        expected: impl Into<Cow<'static, str>>,
-        reason: impl Into<Box<str>>,
-    ) -> Error {
-        CellDecodeError::new(
-            self.row,
-            self.column.index(),
-            self.column.name(),
-            expected,
-            self.column.ty().clone(),
-            self.raw,
-            reason,
-        )
-        .into()
     }
 }

--- a/src/result/decode.rs
+++ b/src/result/decode.rs
@@ -1,49 +1,128 @@
-use std::{borrow::Cow, iter::repeat_n};
+use std::iter::repeat_n;
 
 use chrono::{DateTime, Days, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
 use crate::result::{
+    CellDecodeIssue, CellDecodeResult,
     cell::CellRef,
     dynamic::DecimalValue,
     plan::RowPlanContext,
     row::RowRef,
     schema::{ColumnIndex, ColumnType},
 };
-use crate::{ColumnCountMismatchError, Error, Result, SchemaError};
+use crate::{ColumnCountMismatchError, Result, SchemaError};
 
 const LEGACY_TIMESTAMP_TZ_SHIFT: i128 = 16_384;
 
-/// Trait for decoding a single cell into a Rust value.
+/// Decode a single result-set cell into a Rust value.
+///
+/// Implementations exist for primitive Rust types,
+/// [`SnowflakeValue`](crate::result::SnowflakeValue),
+/// [`DecimalValue`](crate::result::DecimalValue), and `Option<T>`.
+/// Implement it yourself when adapting Snowflake values into domain types.
+///
+/// # Example
+///
+/// A custom decoder that wraps `f64` for type safety:
+///
+/// ```
+/// use snowflake_connector_rs::result::{
+///     CellDecodeIssue, CellDecodeResult, CellRef, FromCell,
+/// };
+///
+/// struct CelsiusTemp(f64);
+///
+/// impl FromCell for CelsiusTemp {
+///     fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+///         let raw = cell.required_raw()?;
+///         raw.parse::<f64>().map(CelsiusTemp).map_err(|e| {
+///             CellDecodeIssue::builder("not a valid temperature")
+///                 .source(e)
+///                 .build()
+///         })
+///     }
+/// }
+/// ```
 pub trait FromCell: Sized {
-    fn expected() -> Cow<'static, str>;
-
     /// Decode a single cell into `Self`.
     ///
+    /// Implementations should reject `NULL` for non-`Option` targets and
+    /// describe conversion failures with [`CellDecodeIssue`].
+    ///
     /// # Errors
     ///
-    /// Implementations may return any [`crate::Error`] appropriate for their
-    /// decode logic.
-    fn from_cell(cell: CellRef<'_>) -> Result<Self>;
+    /// Implementations should return only cell-local issues here.
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self>;
 }
 
-/// Trait for materializing a row into a Rust type using a precomputed plan.
+/// Decode an entire row into a Rust type.
+///
+/// Implementations may use an associated plan to cache schema-dependent
+/// state before decoding individual rows.
+///
+/// # Example
+///
+/// Hand-written equivalent of `#[derive(FromRow)]` for a two-column row:
+///
+/// ```
+/// use snowflake_connector_rs::{
+///     FromRow, Result,
+///     result::{ColumnIndex, RowPlanContext, RowRef},
+/// };
+///
+/// struct UserRow {
+///     id: i64,
+///     name: String,
+/// }
+///
+/// struct UserRowPlan {
+///     id: ColumnIndex,
+///     name: ColumnIndex,
+/// }
+///
+/// impl FromRow for UserRow {
+///     type Plan = UserRowPlan;
+///
+///     fn build_plan(ctx: RowPlanContext<'_>) -> Result<Self::Plan> {
+///         let schema = ctx.schema();
+///         Ok(UserRowPlan {
+///             id: schema.column("ID")?,
+///             name: schema.column("NAME")?,
+///         })
+///     }
+///
+///     fn from_row_with_plan(row: RowRef<'_>, plan: &Self::Plan) -> Result<Self> {
+///         Ok(UserRow {
+///             id: row.get(plan.id)?,
+///             name: row.get(plan.name)?,
+///         })
+///     }
+/// }
+/// ```
 pub trait FromRow: Sized {
+    /// Per-table state reused while decoding rows.
+    ///
+    /// `Send + Sync` so the plan can be shared across threads when an
+    /// iterator is moved between tasks.
     type Plan: Send + Sync;
 
-    /// Build a reusable decode plan for `Self` from result-set metadata.
+    /// Build the per-table decode plan from the result-set metadata.
     ///
     /// # Errors
     ///
-    /// Implementations may return any [`crate::Error`] appropriate for schema
-    /// validation or planning.
+    /// Implementations may return any [`Error`](crate::Error) appropriate
+    /// for schema validation or planning. Conventional errors include
+    /// [`SchemaError::MissingColumn`](crate::SchemaError::MissingColumn)
+    /// and
+    /// [`SchemaError::ColumnCountMismatch`](crate::SchemaError::ColumnCountMismatch).
     fn build_plan(ctx: RowPlanContext<'_>) -> Result<Self::Plan>;
 
-    /// Materialize a row using a precomputed plan.
+    /// Decode a single row using the associated plan.
     ///
     /// # Errors
     ///
-    /// Implementations may return any [`crate::Error`] appropriate for row
-    /// conversion.
+    /// Implementations may return any [`Error`](crate::Error) appropriate
+    /// for row conversion.
     fn from_row_with_plan(row: RowRef<'_>, plan: &Self::Plan) -> Result<Self>;
 }
 
@@ -67,10 +146,7 @@ impl FromRow for () {
 }
 
 impl<T: FromCell> FromCell for Option<T> {
-    fn expected() -> Cow<'static, str> {
-        T::expected()
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
         if cell.is_null() {
             Ok(None)
         } else {
@@ -79,288 +155,264 @@ impl<T: FromCell> FromCell for Option<T> {
     }
 }
 
-// Generic decode error helper that uses T::expected()
-fn err_with<T: FromCell>(cell: CellRef<'_>, reason: impl Into<Box<str>>) -> Error {
-    cell.decode_error(T::expected(), reason)
-}
-
-fn ensure_column_type<T: FromCell>(cell: CellRef<'_>, ok: bool) -> Result<()> {
+fn ensure_column_type(cell: CellRef<'_>, ok: bool) -> CellDecodeResult<()> {
     if ok {
         Ok(())
     } else {
-        Err(err_with::<T>(
-            cell,
-            format!("incompatible column type: {:?}", cell.column_type()),
+        Err(CellDecodeIssue::builder(format!(
+            "incompatible column type: {:?}",
+            cell.column().ty()
         ))
+        .build())
     }
 }
 
 macro_rules! impl_int_from_cell {
-    ($t:ty, $expected:expr) => {
+    ($t:ty) => {
         impl FromCell for $t {
-            fn expected() -> Cow<'static, str> {
-                Cow::Borrowed($expected)
-            }
-            fn from_cell(cell: CellRef<'_>) -> Result<Self> {
+            fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
                 // Integers are only valid for `FIXED` with `scale = 0`.
-                match cell.column_type() {
+                match cell.column().ty() {
                     ColumnType::Fixed { scale, .. } => {
                         let s = scale.unwrap_or(0);
                         if s != 0 {
-                            return Err(err_with::<Self>(
-                                cell,
-                                format!("integer cannot decode FIXED with scale {s}"),
-                            ));
+                            return Err(CellDecodeIssue::builder(format!(
+                                "integer cannot decode FIXED with scale {s}"
+                            ))
+                            .build());
                         }
                     }
                     _ => {
-                        ensure_column_type::<Self>(cell, false)?;
+                        ensure_column_type(cell, false)?;
                         unreachable!()
                     }
                 }
-                let raw = cell.required_raw(Self::expected())?;
-                raw.parse::<$t>()
-                    .map_err(|e| err_with::<Self>(cell, format!("parse error: {e}")))
+                let raw = cell.required_raw()?;
+                raw.parse::<$t>().map_err(|e| {
+                    CellDecodeIssue::builder(format!("parse error: {e}"))
+                        .source(e)
+                        .build()
+                })
             }
         }
     };
 }
 
-impl_int_from_cell!(i8, "i8");
-impl_int_from_cell!(i16, "i16");
-impl_int_from_cell!(i32, "i32");
-impl_int_from_cell!(i64, "i64");
-impl_int_from_cell!(i128, "i128");
-impl_int_from_cell!(u8, "u8");
-impl_int_from_cell!(u16, "u16");
-impl_int_from_cell!(u32, "u32");
-impl_int_from_cell!(u64, "u64");
-impl_int_from_cell!(u128, "u128");
+impl_int_from_cell!(i8);
+impl_int_from_cell!(i16);
+impl_int_from_cell!(i32);
+impl_int_from_cell!(i64);
+impl_int_from_cell!(i128);
+impl_int_from_cell!(u8);
+impl_int_from_cell!(u16);
+impl_int_from_cell!(u32);
+impl_int_from_cell!(u64);
+impl_int_from_cell!(u128);
 
 impl FromCell for f64 {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("f64")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        ensure_column_type::<Self>(
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        ensure_column_type(
             cell,
             matches!(
-                cell.column_type(),
+                cell.column().ty(),
                 ColumnType::Real | ColumnType::Fixed { .. }
             ),
         )?;
 
-        let raw = cell.required_raw(Self::expected())?;
-        raw.parse::<f64>()
-            .map_err(|e| err_with::<Self>(cell, format!("parse error: {e}")))
+        let raw = cell.required_raw()?;
+        raw.parse::<f64>().map_err(|e| {
+            CellDecodeIssue::builder(format!("parse error: {e}"))
+                .source(e)
+                .build()
+        })
     }
 }
 
 impl FromCell for f32 {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("f32")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        ensure_column_type::<Self>(
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        ensure_column_type(
             cell,
             matches!(
-                cell.column_type(),
+                cell.column().ty(),
                 ColumnType::Real | ColumnType::Fixed { .. }
             ),
         )?;
 
-        let raw = cell.required_raw(Self::expected())?;
-        raw.parse::<f32>()
-            .map_err(|e| err_with::<Self>(cell, format!("parse error: {e}")))
+        let raw = cell.required_raw()?;
+        raw.parse::<f32>().map_err(|e| {
+            CellDecodeIssue::builder(format!("parse error: {e}"))
+                .source(e)
+                .build()
+        })
     }
 }
 
 impl FromCell for String {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("String")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        cell.required_raw(Self::expected()).map(|s| s.to_owned())
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        cell.required_raw().map(|s| s.to_owned())
     }
 }
 
 impl FromCell for DecimalValue {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("DecimalValue")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        let (precision, scale) = match cell.column_type() {
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        let (precision, scale) = match cell.column().ty() {
             ColumnType::Fixed { precision, scale } => (*precision, *scale),
             other => {
-                return Err(err_with::<Self>(
-                    cell,
-                    format!("incompatible column type: {other:?}"),
-                ));
+                return Err(CellDecodeIssue::builder(format!(
+                    "incompatible column type: {other:?}"
+                ))
+                .build());
             }
         };
-        let raw = cell.required_raw(Self::expected())?;
+        let raw = cell.required_raw()?;
         Ok(DecimalValue::new(raw, precision, scale))
     }
 }
 
 impl FromCell for bool {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("bool")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        ensure_column_type::<Self>(cell, matches!(cell.column_type(), ColumnType::Boolean))?;
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        ensure_column_type(cell, matches!(cell.column().ty(), ColumnType::Boolean))?;
 
-        let raw = cell.required_raw(Self::expected())?;
+        let raw = cell.required_raw()?;
         if raw.eq_ignore_ascii_case("1") || raw.eq_ignore_ascii_case("true") {
             Ok(true)
         } else if raw.eq_ignore_ascii_case("0") || raw.eq_ignore_ascii_case("false") {
             Ok(false)
         } else {
-            Err(err_with::<Self>(cell, format!("'{raw}' is not bool")))
+            Err(CellDecodeIssue::builder(format!("'{raw}' is not bool")).build())
         }
     }
 }
 
 impl FromCell for NaiveDate {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("NaiveDate")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        ensure_column_type::<Self>(cell, matches!(cell.column_type(), ColumnType::Date))?;
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        ensure_column_type(cell, matches!(cell.column().ty(), ColumnType::Date))?;
 
-        let raw = cell.required_raw(Self::expected())?;
-        let days = raw
-            .parse::<i64>()
-            .map_err(|_| err_with::<Self>(cell, format!("'{raw}' is not Date")))?;
+        let raw = cell.required_raw()?;
+        let days = raw.parse::<i64>().map_err(|e| {
+            CellDecodeIssue::builder(format!("'{raw}' is not Date"))
+                .source(e)
+                .build()
+        })?;
         let unix_epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch");
 
         if days >= 0 {
             unix_epoch
                 .checked_add_days(Days::new(days as u64))
-                .ok_or_else(|| err_with::<Self>(cell, format!("'{raw}' is not a valid date")))
+                .ok_or_else(|| {
+                    CellDecodeIssue::builder(format!("'{raw}' is not a valid date")).build()
+                })
         } else {
             unix_epoch
                 .checked_sub_days(Days::new(days.unsigned_abs()))
-                .ok_or_else(|| err_with::<Self>(cell, format!("'{raw}' is not a valid date")))
+                .ok_or_else(|| {
+                    CellDecodeIssue::builder(format!("'{raw}' is not a valid date")).build()
+                })
         }
     }
 }
 
 impl FromCell for NaiveTime {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("NaiveTime")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        ensure_column_type::<Self>(cell, matches!(cell.column_type(), ColumnType::Time { .. }))?;
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        ensure_column_type(cell, matches!(cell.column().ty(), ColumnType::Time { .. }))?;
 
-        let raw = cell.required_raw(Self::expected())?;
-        let scale = match cell.column_type() {
+        let raw = cell.required_raw()?;
+        let scale = match cell.column().ty() {
             ColumnType::Time { scale } => match *scale {
                 None => 0usize,
                 Some(s) if (0..=9).contains(&s) => s as usize,
                 Some(s) => {
-                    return Err(err_with::<Self>(cell, format!("invalid time scale: {s}")));
+                    return Err(
+                        CellDecodeIssue::builder(format!("invalid time scale: {s}")).build()
+                    );
                 }
             },
             _ => 0,
         };
-        let (secs, nsec) =
-            parse_time_seconds_and_nanos(raw, scale).map_err(|m| err_with::<Self>(cell, m))?;
+        let (secs, nsec) = parse_time_seconds_and_nanos(raw, scale)
+            .map_err(|m| CellDecodeIssue::builder(m).build())?;
 
         NaiveTime::from_num_seconds_from_midnight_opt(secs, nsec)
-            .ok_or_else(|| err_with::<Self>(cell, format!("invalid time: {raw}")))
+            .ok_or_else(|| CellDecodeIssue::builder(format!("invalid time: {raw}")).build())
     }
 }
 
 impl FromCell for NaiveDateTime {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("NaiveDateTime")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        ensure_column_type::<Self>(
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        ensure_column_type(
             cell,
-            matches!(cell.column_type(), ColumnType::TimestampNtz { .. }),
+            matches!(cell.column().ty(), ColumnType::TimestampNtz { .. }),
         )?;
 
-        let raw = cell.required_raw(Self::expected())?;
-        let scale = timestamp_scale(cell.column_type()).unwrap_or(9);
+        let raw = cell.required_raw()?;
+        let scale = timestamp_scale(cell.column().ty()).unwrap_or(9);
 
         parse_timestamp_epoch(raw, scale)
             .map(|dt| dt.naive_utc())
-            .map_err(|m| err_with::<Self>(cell, m))
+            .map_err(|m| CellDecodeIssue::builder(m).build())
     }
 }
 
 impl FromCell for DateTime<Utc> {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("DateTime<Utc>")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        let raw = cell.required_raw(Self::expected())?;
-        let scale = timestamp_scale(cell.column_type()).unwrap_or(9);
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        let raw = cell.required_raw()?;
+        let scale = timestamp_scale(cell.column().ty()).unwrap_or(9);
 
-        match cell.column_type() {
+        match cell.column().ty() {
             ColumnType::TimestampLtz { .. } => {
-                parse_timestamp_epoch(raw, scale).map_err(|m| err_with::<Self>(cell, m))
+                parse_timestamp_epoch(raw, scale).map_err(|m| CellDecodeIssue::builder(m).build())
             }
-            ColumnType::TimestampTz { .. } => {
-                parse_timestamp_tz_as_utc(raw, scale).map_err(|m| err_with::<Self>(cell, m))
-            }
-            other => Err(err_with::<Self>(
-                cell,
-                format!("unsupported column type for DateTime<Utc>: {other:?}"),
-            )),
+            ColumnType::TimestampTz { .. } => parse_timestamp_tz_as_utc(raw, scale)
+                .map_err(|m| CellDecodeIssue::builder(m).build()),
+            other => Err(CellDecodeIssue::builder(format!(
+                "unsupported column type for DateTime<Utc>: {other:?}"
+            ))
+            .build()),
         }
     }
 }
 
 impl FromCell for DateTime<FixedOffset> {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("DateTime<FixedOffset>")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        let raw = cell.required_raw(Self::expected())?;
-        let scale = timestamp_scale(cell.column_type()).unwrap_or(9);
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        let raw = cell.required_raw()?;
+        let scale = timestamp_scale(cell.column().ty()).unwrap_or(9);
 
-        match cell.column_type() {
-            ColumnType::TimestampTz { .. } => {
-                parse_timestamp_tz_with_offset(raw, scale).map_err(|m| err_with::<Self>(cell, m))
-            }
-            other => Err(err_with::<Self>(
-                cell,
-                format!("unsupported column type for DateTime<FixedOffset>: {other:?}"),
-            )),
+        match cell.column().ty() {
+            ColumnType::TimestampTz { .. } => parse_timestamp_tz_with_offset(raw, scale)
+                .map_err(|m| CellDecodeIssue::builder(m).build()),
+            other => Err(CellDecodeIssue::builder(format!(
+                "unsupported column type for DateTime<FixedOffset>: {other:?}"
+            ))
+            .build()),
         }
     }
 }
 
 impl FromCell for serde_json::Value {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("json")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        ensure_column_type::<Self>(
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        ensure_column_type(
             cell,
             matches!(
-                cell.column_type(),
+                cell.column().ty(),
                 ColumnType::Variant | ColumnType::Object | ColumnType::Array
             ),
         )?;
 
-        let raw = cell.required_raw(Self::expected())?;
-        serde_json::from_str(raw).map_err(|e| err_with::<Self>(cell, format!("invalid json: {e}")))
+        let raw = cell.required_raw()?;
+        serde_json::from_str(raw).map_err(|e| {
+            CellDecodeIssue::builder(format!("invalid json: {e}"))
+                .source(e)
+                .build()
+        })
     }
 }
 
 impl FromCell for Vec<u8> {
-    fn expected() -> Cow<'static, str> {
-        Cow::Borrowed("binary")
-    }
-    fn from_cell(cell: CellRef<'_>) -> Result<Self> {
-        ensure_column_type::<Self>(cell, matches!(cell.column_type(), ColumnType::Binary))?;
+    fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+        ensure_column_type(cell, matches!(cell.column().ty(), ColumnType::Binary))?;
 
-        let raw = cell.required_raw(Self::expected())?;
-        decode_hex(raw).map_err(|m| err_with::<Self>(cell, m))
+        let raw = cell.required_raw()?;
+        decode_hex(raw).map_err(|m| CellDecodeIssue::builder(m).build())
     }
 }
 
@@ -663,7 +715,7 @@ macro_rules! impl_tuple_from_row {
             }
 
             fn from_row_with_plan(row: RowRef<'_>, plan: &Self::Plan) -> Result<Self> {
-                Ok(($($t::from_cell(row.cell(plan[$idx])?)?,)*))
+                Ok(($(row.get::<$t>(plan[$idx])?,)*))
             }
         }
     };
@@ -766,17 +818,13 @@ mod tests {
         assert!(err.contains("Could not decode timestamp"), "actual: {err}");
     }
 
+    /// Snowflake documents timestamp scales in the `0..=9` range.
     #[test]
-    fn parse_timestamp_epoch_rejects_negative_scale() {
-        let err = parse_timestamp_epoch("0.1", -1).unwrap_err();
-        assert!(err.contains("invalid timestamp scale"), "actual: {err}");
-    }
-
-    /// Scale > 9 is also outside Snowflake's documented `0..=9` range.
-    #[test]
-    fn parse_timestamp_epoch_rejects_scale_above_9() {
-        let err = parse_timestamp_epoch("0.1", 10).unwrap_err();
-        assert!(err.contains("invalid timestamp scale"), "actual: {err}");
+    fn parse_timestamp_epoch_rejects_out_of_range_scale() {
+        for scale in [-1, 10] {
+            let err = parse_timestamp_epoch("0.1", scale).unwrap_err();
+            assert!(err.contains("invalid timestamp scale"), "actual: {err}");
+        }
     }
 
     #[test]
@@ -858,21 +906,14 @@ mod tests {
     }
 
     #[test]
-    fn parse_timestamp_tz_with_offset_rejects_unrepresentable_west_boundary_offset() {
-        let err = parse_timestamp_tz_with_offset("0 0", 9).unwrap_err();
-        assert!(
-            err.contains("out of range for DateTime<FixedOffset>"),
-            "actual: {err}"
-        );
-    }
-
-    #[test]
-    fn parse_timestamp_tz_with_offset_rejects_unrepresentable_east_boundary_offset() {
-        let err = parse_timestamp_tz_with_offset("0 2880", 9).unwrap_err();
-        assert!(
-            err.contains("out of range for DateTime<FixedOffset>"),
-            "actual: {err}"
-        );
+    fn parse_timestamp_tz_with_offset_rejects_unrepresentable_boundary_offsets() {
+        for raw in ["0 0", "0 2880"] {
+            let err = parse_timestamp_tz_with_offset(raw, 9).unwrap_err();
+            assert!(
+                err.contains("out of range for DateTime<FixedOffset>"),
+                "actual: {err}"
+            );
+        }
     }
 
     #[test]
@@ -900,9 +941,42 @@ mod tests {
         make_result_table_from_rows(schema, vec![vec![Some(value.to_string())]]).unwrap()
     }
 
+    fn one_nullable_cell_table(ty: ColumnType, value: Option<&str>) -> ResultTable {
+        let schema = make_schema(vec![("X".to_string(), ty, true)]);
+        make_result_table_from_rows(
+            schema,
+            vec![vec![value.map(std::string::ToString::to_string)]],
+        )
+        .unwrap()
+    }
+
     fn zero_cell_table(row_count: usize) -> ResultTable {
         let schema = make_schema(vec![]);
         make_result_table_from_rows(schema, (0..row_count).map(|_| Vec::new()).collect()).unwrap()
+    }
+
+    #[derive(Debug)]
+    struct CelsiusTemp;
+
+    impl FromCell for CelsiusTemp {
+        fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+            let raw = cell.required_raw()?;
+            raw.parse::<f64>().map(|_| CelsiusTemp).map_err(|e| {
+                CellDecodeIssue::builder("not a valid temperature")
+                    .source(e)
+                    .build()
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct AlwaysFails;
+
+    impl FromCell for AlwaysFails {
+        fn from_cell(cell: CellRef<'_>) -> CellDecodeResult<Self> {
+            let _ = cell.required_raw()?;
+            Err(CellDecodeIssue::builder("always fails").build())
+        }
     }
 
     #[test]
@@ -928,6 +1002,85 @@ mod tests {
             Some(SchemaError::ColumnCountMismatch(error))
                 if error.expected() == 0 && error.actual() == 1
         ));
+    }
+
+    #[test]
+    fn option_preserves_null_as_ok_none() {
+        let table = one_nullable_cell_table(ColumnType::Text { length: None }, None);
+        let value = table
+            .rows::<(Option<String>,)>()
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .0;
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn custom_from_cell_parse_failure_is_contextualized_and_preserves_source() {
+        let err = one_cell_table(ColumnType::Text { length: None }, "abc")
+            .rows::<(CelsiusTemp,)>()
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap_err();
+
+        let decode = err
+            .as_cell_decode_error()
+            .expect("custom decode failure should be contextualized");
+
+        assert_eq!(decode.row_index(), 0);
+        assert_eq!(decode.column_index(), ColumnIndex::new(0));
+        assert_eq!(decode.column_name(), "X");
+        assert_eq!(decode.issue().reason(), "not a valid temperature");
+        assert_eq!(
+            decode.actual_column_type(),
+            &ColumnType::Text { length: None }
+        );
+        assert_eq!(decode.raw_value_preview(), Some("abc"));
+        assert!(decode.target_type_name().ends_with("CelsiusTemp"));
+        assert!(std::error::Error::source(decode).is_some());
+        assert!(decode.issue().source().is_some());
+        assert!(std::error::Error::source(&err).is_some());
+    }
+
+    #[test]
+    fn built_in_parse_failure_preserves_source() {
+        let err = one_cell_table(ColumnType::Real, "abc")
+            .rows::<(f64,)>()
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap_err();
+
+        let decode = err
+            .as_cell_decode_error()
+            .expect("built-in parse failure should be contextualized");
+
+        assert!(decode.issue().reason().contains("parse error"));
+        assert!(std::error::Error::source(decode).is_some());
+        assert!(decode.issue().source().is_some());
+        assert!(std::error::Error::source(&err).is_some());
+    }
+
+    #[test]
+    fn long_raw_value_preview_is_truncated() {
+        let raw = "x".repeat(256);
+        let err = one_cell_table(ColumnType::Text { length: None }, &raw)
+            .rows::<(AlwaysFails,)>()
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap_err();
+
+        let decode = err.as_cell_decode_error().expect("decode failure expected");
+        let preview = decode
+            .raw_value_preview()
+            .expect("preview should be present for non-null values");
+
+        assert!(preview.ends_with("..."), "preview: {preview}");
+        assert!(preview.len() <= 131, "preview length: {}", preview.len());
     }
 
     #[test]
@@ -961,35 +1114,32 @@ mod tests {
         assert!(err.as_cell_decode_error().is_some());
     }
 
-    /// A `TEXT "42"` cell must NOT decode as `i64` even though the parse
-    /// would succeed — column-type metadata is the authority.
+    /// Integers only accept `FIXED(scale=0)` columns; nearby shapes must fail.
     #[test]
-    fn integer_rejects_text_column() {
-        let t = one_cell_table(ColumnType::Text { length: None }, "42");
-        let e = t.rows::<(i64,)>().unwrap().next().unwrap().unwrap_err();
-        assert!(e.as_cell_decode_error().is_some(), "got {e:?}");
-    }
-
-    /// `BOOLEAN "1"` decoded as `i64` must fail; integers require `FIXED`.
-    #[test]
-    fn integer_rejects_boolean_column() {
-        let t = one_cell_table(ColumnType::Boolean, "1");
-        let e = t.rows::<(i64,)>().unwrap().next().unwrap().unwrap_err();
-        assert!(e.as_cell_decode_error().is_some());
-    }
-
-    /// `FIXED(scale=2)` already had a guard; keep it locked down.
-    #[test]
-    fn integer_rejects_fixed_with_scale() {
-        let t = one_cell_table(
-            ColumnType::Fixed {
-                precision: Some(10),
-                scale: Some(2),
-            },
-            "12",
-        );
-        let e = t.rows::<(i64,)>().unwrap().next().unwrap().unwrap_err();
-        assert!(e.as_cell_decode_error().is_some());
+    fn integer_rejects_non_integer_column_shapes() {
+        for (label, ty, raw) in [
+            ("text", ColumnType::Text { length: None }, "42"),
+            ("boolean", ColumnType::Boolean, "1"),
+            (
+                "scaled fixed",
+                ColumnType::Fixed {
+                    precision: Some(10),
+                    scale: Some(2),
+                },
+                "12",
+            ),
+        ] {
+            let err = one_cell_table(ty, raw)
+                .rows::<(i64,)>()
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap_err();
+            assert!(
+                err.as_cell_decode_error().is_some(),
+                "{label} unexpectedly decoded as i64: {err:?}"
+            );
+        }
     }
 
     /// `TEXT "true"` must NOT decode as `bool`.

--- a/src/result/dynamic.rs
+++ b/src/result/dynamic.rs
@@ -1,9 +1,10 @@
-use std::{mem, sync::Arc};
+use std::{any::type_name, mem, sync::Arc};
 
+use base64::Engine as _;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
 use crate::result::{
-    FromRow, RowPlanContext,
+    CellDecodeIssue, CellDecodeResult, FromRow, RowPlanContext,
     cell::CellRef,
     decode::{
         decode_hex, parse_time_seconds_and_nanos, parse_timestamp_epoch,
@@ -12,8 +13,17 @@ use crate::result::{
     row::RowRef,
     schema::{ColumnIndex, ColumnType, Schema},
 };
-use crate::{DuplicateColumnNameError, InvalidColumnIndexError, Result, SchemaError};
+use crate::{
+    CellDecodeError, DuplicateColumnNameError, InvalidColumnIndexError, Result, SchemaError,
+};
 
+/// Result-side representation of a Snowflake `NUMBER` / `DECIMAL` cell
+/// with non-zero scale.
+///
+/// Snowflake decimals can carry up to 38 digits of precision, which does
+/// not fit in any native Rust numeric type. `DecimalValue` therefore
+/// preserves the value as the exact string Snowflake delivered, alongside
+/// the column's declared precision and scale (when reported).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DecimalValue {
     raw: Box<str>,
@@ -22,7 +32,11 @@ pub struct DecimalValue {
 }
 
 impl DecimalValue {
-    pub fn new(raw: impl Into<Box<str>>, precision: Option<i64>, scale: Option<i64>) -> Self {
+    pub(crate) fn new(
+        raw: impl Into<Box<str>>,
+        precision: Option<i64>,
+        scale: Option<i64>,
+    ) -> Self {
         Self {
             raw: raw.into(),
             precision,
@@ -30,42 +44,89 @@ impl DecimalValue {
         }
     }
 
+    /// Borrow the underlying decimal string.
     pub fn raw(&self) -> &str {
         &self.raw
     }
 
+    /// Total digit count declared on the source column, when reported.
     pub fn precision(&self) -> Option<i64> {
         self.precision
     }
 
+    /// Digits to the right of the decimal point, when reported.
     pub fn scale(&self) -> Option<i64> {
         self.scale
     }
 }
 
+/// Decoded value of a single cell on the dynamic-typing path.
+///
+/// Each variant corresponds to a Snowflake result type.
+///
+/// # Example
+///
+/// ```
+/// use snowflake_connector_rs::result::SnowflakeValue;
+///
+/// let value = SnowflakeValue::Integer(42);
+/// match value {
+///     SnowflakeValue::Integer(n) => assert_eq!(n, 42),
+///     SnowflakeValue::Null => unreachable!(),
+///     other => panic!("unexpected variant: {other:?}"),
+/// }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub enum SnowflakeValue {
+    /// SQL `NULL`.
     Null,
+    /// `BOOLEAN`.
     Boolean(bool),
+    /// Integer-shaped `NUMBER` (scale 0) that fits in `i128`.
     Integer(i128),
+    /// `FLOAT` / `DOUBLE` / `REAL`.
     Float(f64),
+    /// `NUMBER` with non-zero scale — preserved as text via [`DecimalValue`].
     Decimal(DecimalValue),
+    /// `TEXT` / `VARCHAR` / `CHAR` / `STRING`.
     String(String),
+    /// `DATE`.
     Date(NaiveDate),
+    /// `TIME`.
     Time(NaiveTime),
+    /// `TIMESTAMP_NTZ`.
     TimestampNtz(NaiveDateTime),
+    /// `TIMESTAMP_LTZ`, anchored to UTC.
     TimestampLtz(DateTime<Utc>),
+    /// `TIMESTAMP_TZ`, with the wire-reported offset preserved.
     TimestampTz(DateTime<FixedOffset>),
+    /// `VARIANT` / `OBJECT` / `ARRAY` — semi-structured payloads decoded
+    /// as JSON.
     Json(serde_json::Value),
+    /// `BINARY`, decoded from Snowflake's hex representation.
     Binary(Vec<u8>),
 }
 
 impl SnowflakeValue {
+    /// Returns `true` for [`SnowflakeValue::Null`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use snowflake_connector_rs::result::SnowflakeValue;
+    ///
+    /// assert!(SnowflakeValue::Null.is_null());
+    /// assert!(!SnowflakeValue::Integer(0).is_null());
+    /// ```
     pub fn is_null(&self) -> bool {
         matches!(self, SnowflakeValue::Null)
     }
 }
 
+/// A row decoded into the dynamic [`SnowflakeValue`] vocabulary.
+///
+/// Values are stored in column order and can be accessed by
+/// [`ColumnIndex`] or by raw column name.
 #[derive(Clone, Debug)]
 pub struct DynamicRow {
     schema: Arc<Schema>,
@@ -73,39 +134,62 @@ pub struct DynamicRow {
 }
 
 impl DynamicRow {
-    /// Returns the shared schema metadata for this row.
+    /// Borrow the shared schema this row was decoded against.
     pub fn schema(&self) -> &Schema {
         &self.schema
     }
 
-    /// Returns all decoded values in column order.
+    /// Borrow all decoded values in column order.
     pub fn values(&self) -> &[SnowflakeValue] {
         &self.values
     }
 
-    /// Borrows a value by resolved column index.
-    pub fn at(&self, index: ColumnIndex) -> std::result::Result<&SnowflakeValue, SchemaError> {
+    /// Borrow the value of a column resolved by raw label (case-sensitive).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaError::MissingColumn`] when no column carries the
+    /// name, or [`SchemaError::AmbiguousColumn`] when several do.
+    pub fn value(&self, name: &str) -> std::result::Result<&SnowflakeValue, SchemaError> {
+        let idx = self.schema.column(name)?;
+        self.value_at(idx)
+    }
+
+    /// Borrow the value at a resolved column index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaError::InvalidColumnIndex`] when `index` is out of
+    /// range for this row's schema.
+    pub fn value_at(
+        &self,
+        index: ColumnIndex,
+    ) -> std::result::Result<&SnowflakeValue, SchemaError> {
         self.schema.column_at(index).ok_or_else(|| {
             SchemaError::InvalidColumnIndex(InvalidColumnIndexError::new(index, self.schema.len()))
         })?;
         Ok(&self.values[index.as_usize()])
     }
 
-    /// Borrows a value by exact raw result label (case-sensitive).
-    pub fn get(&self, name: &str) -> std::result::Result<&SnowflakeValue, SchemaError> {
-        let idx = self.schema.column(name)?;
-        self.at(idx)
-    }
-
-    /// Moves a decoded value out of the row by exact raw result label
-    /// (case-sensitive), replacing the slot with `Null`.
+    /// Move a value out of the row by raw label, replacing the slot with
+    /// [`SnowflakeValue::Null`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaError::MissingColumn`] when no column carries the
+    /// name, or [`SchemaError::AmbiguousColumn`] when several do.
     pub fn take(&mut self, name: &str) -> std::result::Result<SnowflakeValue, SchemaError> {
         let idx = self.schema.column(name)?;
         self.take_at(idx)
     }
 
-    /// Moves a decoded value out of the row by resolved column index,
-    /// replacing the slot with `Null`.
+    /// Move a value out of the row by resolved index, replacing the slot
+    /// with [`SnowflakeValue::Null`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaError::InvalidColumnIndex`] when `index` is out of
+    /// range for this row's schema.
     pub fn take_at(
         &mut self,
         index: ColumnIndex,
@@ -120,12 +204,19 @@ impl DynamicRow {
         ))
     }
 
-    /// Consumes the row and returns its schema and decoded values.
+    /// Consume the row, returning the shared schema and the decoded values
+    /// in column order.
+    ///
     pub fn into_parts(self) -> (Arc<Schema>, Box<[SnowflakeValue]>) {
         (self.schema, self.values)
     }
 
-    /// Consumes the row into a JSON object keyed by raw result labels.
+    /// Consume the row into a `serde_json::Map` keyed by raw column label.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaError::DuplicateColumnName`] when two columns share
+    /// the same raw label — JSON object keys must be unique.
     pub fn into_json_object(
         self,
     ) -> std::result::Result<serde_json::Map<String, serde_json::Value>, SchemaError> {
@@ -146,6 +237,13 @@ impl DynamicRow {
 }
 
 impl SnowflakeValue {
+    /// Convert this value into a [`serde_json::Value`].
+    ///
+    /// Lossy in the cases where Snowflake's value range exceeds JSON's
+    /// numeric range: `i128` integers outside `i64`/`u64` range and
+    /// non-finite floats fall back to string. `Decimal` values render as
+    /// their original decimal text. Dates/times/timestamps render in their
+    /// canonical string form, and `Binary` is base64-encoded.
     pub fn into_json_value(self) -> serde_json::Value {
         match self {
             SnowflakeValue::Null => serde_json::Value::Null,
@@ -171,7 +269,6 @@ impl SnowflakeValue {
             SnowflakeValue::TimestampTz(dt) => serde_json::Value::String(dt.to_rfc3339()),
             SnowflakeValue::Json(v) => v,
             SnowflakeValue::Binary(bytes) => {
-                use base64::Engine as _;
                 serde_json::Value::String(base64::engine::general_purpose::STANDARD.encode(&bytes))
             }
         }
@@ -182,14 +279,24 @@ impl FromRow for DynamicRow {
     type Plan = Arc<Schema>;
 
     fn build_plan(ctx: RowPlanContext<'_>) -> Result<Self::Plan> {
-        Ok(ctx.clone_schema())
+        Ok(ctx.schema_arc())
     }
 
     fn from_row_with_plan(row: RowRef<'_>, plan: &Self::Plan) -> Result<Self> {
         let mut values = Vec::with_capacity(plan.len());
         for (offset, col) in plan.columns().iter().enumerate() {
             let cell = row.cell_at_offset(col, offset);
-            values.push(decode_dynamic(cell)?);
+            values.push(decode_dynamic(cell).map_err(|issue| {
+                CellDecodeError::new(
+                    cell.row_index(),
+                    cell.column().index(),
+                    cell.column().name(),
+                    type_name::<SnowflakeValue>(),
+                    cell.column().ty().clone(),
+                    cell.raw(),
+                    issue,
+                )
+            })?);
         }
 
         Ok(DynamicRow {
@@ -199,13 +306,13 @@ impl FromRow for DynamicRow {
     }
 }
 
-fn decode_dynamic(cell: CellRef<'_>) -> Result<SnowflakeValue> {
+fn decode_dynamic(cell: CellRef<'_>) -> CellDecodeResult<SnowflakeValue> {
     if cell.is_null() {
         return Ok(SnowflakeValue::Null);
     }
 
     let raw = cell.raw().expect("non-null checked above");
-    let ty = cell.column_type();
+    let ty = cell.column().ty();
 
     match ty {
         ColumnType::Boolean => {
@@ -214,7 +321,7 @@ fn decode_dynamic(cell: CellRef<'_>) -> Result<SnowflakeValue> {
             } else if raw.eq_ignore_ascii_case("0") || raw.eq_ignore_ascii_case("false") {
                 Ok(SnowflakeValue::Boolean(false))
             } else {
-                Err(cell.decode_error("bool", format!("'{raw}' is not bool")))
+                Err(CellDecodeIssue::builder(format!("'{raw}' is not bool")).build())
             }
         }
         ColumnType::Fixed { precision, scale } => {
@@ -227,22 +334,25 @@ fn decode_dynamic(cell: CellRef<'_>) -> Result<SnowflakeValue> {
                 raw, *precision, *scale,
             )))
         }
-        ColumnType::Real => raw
-            .parse::<f64>()
-            .map(SnowflakeValue::Float)
-            .map_err(|e| cell.decode_error("f64", format!("parse error: {e}"))),
+        ColumnType::Real => raw.parse::<f64>().map(SnowflakeValue::Float).map_err(|e| {
+            CellDecodeIssue::builder(format!("parse error: {e}"))
+                .source(e)
+                .build()
+        }),
         ColumnType::Text { .. } => Ok(SnowflakeValue::String(raw.to_string())),
         ColumnType::Date => {
-            let days = raw
-                .parse::<i64>()
-                .map_err(|_| cell.decode_error("Date", format!("'{raw}' not Date")))?;
+            let days = raw.parse::<i64>().map_err(|e| {
+                CellDecodeIssue::builder(format!("'{raw}' not Date"))
+                    .source(e)
+                    .build()
+            })?;
             let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch");
             let date = if days >= 0 {
                 epoch.checked_add_days(chrono::Days::new(days as u64))
             } else {
                 epoch.checked_sub_days(chrono::Days::new(days.unsigned_abs()))
             }
-            .ok_or_else(|| cell.decode_error("Date", format!("'{raw}' not Date")))?;
+            .ok_or_else(|| CellDecodeIssue::builder(format!("'{raw}' not Date")).build())?;
             Ok(SnowflakeValue::Date(date))
         }
         ColumnType::Time { scale } => {
@@ -250,40 +360,45 @@ fn decode_dynamic(cell: CellRef<'_>) -> Result<SnowflakeValue> {
                 None => 0usize,
                 Some(s) if (0..=9).contains(s) => *s as usize,
                 Some(s) => {
-                    return Err(cell.decode_error("Time", format!("invalid time scale: {s}")));
+                    return Err(
+                        CellDecodeIssue::builder(format!("invalid time scale: {s}")).build()
+                    );
                 }
             };
             let (secs, nsec) = parse_time_seconds_and_nanos(raw, scale)
-                .map_err(|m| cell.decode_error("Time", m))?;
+                .map_err(|m| CellDecodeIssue::builder(m).build())?;
             let t = NaiveTime::from_num_seconds_from_midnight_opt(secs, nsec)
-                .ok_or_else(|| cell.decode_error("Time", format!("invalid time: {raw}")))?;
+                .ok_or_else(|| CellDecodeIssue::builder(format!("invalid time: {raw}")).build())?;
             Ok(SnowflakeValue::Time(t))
         }
         ColumnType::TimestampNtz { scale } => {
             let scale = scale.unwrap_or(9);
             let dt = parse_timestamp_epoch(raw, scale)
-                .map_err(|m| cell.decode_error("TimestampNtz", m))?;
+                .map_err(|m| CellDecodeIssue::builder(m).build())?;
             Ok(SnowflakeValue::TimestampNtz(dt.naive_utc()))
         }
         ColumnType::TimestampLtz { scale } => {
             let scale = scale.unwrap_or(9);
             let dt = parse_timestamp_epoch(raw, scale)
-                .map_err(|m| cell.decode_error("TimestampLtz", m))?;
+                .map_err(|m| CellDecodeIssue::builder(m).build())?;
             Ok(SnowflakeValue::TimestampLtz(dt))
         }
         ColumnType::TimestampTz { scale } => {
             let scale = scale.unwrap_or(9);
             let dt = parse_timestamp_tz_with_offset(raw, scale)
-                .map_err(|m| cell.decode_error("TimestampTz", m))?;
+                .map_err(|m| CellDecodeIssue::builder(m).build())?;
             Ok(SnowflakeValue::TimestampTz(dt))
         }
         ColumnType::Variant | ColumnType::Object | ColumnType::Array => {
-            let v = serde_json::from_str(raw)
-                .map_err(|e| cell.decode_error("json", format!("invalid json: {e}")))?;
+            let v = serde_json::from_str(raw).map_err(|e| {
+                CellDecodeIssue::builder(format!("invalid json: {e}"))
+                    .source(e)
+                    .build()
+            })?;
             Ok(SnowflakeValue::Json(v))
         }
         ColumnType::Binary => {
-            let bytes = decode_hex(raw).map_err(|m| cell.decode_error("binary", m))?;
+            let bytes = decode_hex(raw).map_err(|m| CellDecodeIssue::builder(m).build())?;
             Ok(SnowflakeValue::Binary(bytes))
         }
         ColumnType::Geography
@@ -314,7 +429,7 @@ mod tests {
     fn dynamic_row_keeps_text_cells_as_strings() {
         for value in [r#"{"a":1}"#, "plain text"] {
             let row = one_cell_row(ColumnType::Text { length: None }, value);
-            match row.get("PAYLOAD").unwrap() {
+            match row.value("PAYLOAD").unwrap() {
                 SnowflakeValue::String(actual) => assert_eq!(actual, value),
                 other => panic!("expected String, got {other:?}"),
             }
@@ -324,25 +439,43 @@ mod tests {
     #[test]
     fn dynamic_row_decodes_variant_cells_as_json() {
         let row = one_cell_row(ColumnType::Variant, r#"{"a":1}"#);
-        match row.get("PAYLOAD").unwrap() {
+        match row.value("PAYLOAD").unwrap() {
             SnowflakeValue::Json(value) => assert_eq!(value["a"], 1),
             other => panic!("expected Json, got {other:?}"),
         }
     }
 
     #[test]
-    fn dynamic_row_at_rejects_invalid_indices() {
+    fn dynamic_row_decode_failure_reports_contextual_error() {
+        let schema = make_schema(vec![("PAYLOAD".to_string(), ColumnType::Boolean, false)]);
+        let table =
+            make_result_table_from_rows(schema, vec![vec![Some("maybe".to_string())]]).unwrap();
+
+        let err = table.dynamic_rows().unwrap().next().unwrap().unwrap_err();
+        let decode = err
+            .as_cell_decode_error()
+            .expect("dynamic row decode should yield CellDecodeError");
+
+        assert_eq!(decode.row_index(), 0);
+        assert_eq!(decode.column_name(), "PAYLOAD");
+        assert_eq!(decode.issue().reason(), "'maybe' is not bool");
+        assert!(decode.target_type_name().ends_with("SnowflakeValue"));
+        assert_eq!(decode.raw_value_preview(), Some("maybe"));
+    }
+
+    #[test]
+    fn dynamic_row_value_at_rejects_invalid_indices() {
         let row = one_cell_row(ColumnType::Text { length: None }, "value");
         let index = ColumnIndex::new(1);
         assert!(matches!(
-            row.at(index),
+            row.value_at(index),
             Err(SchemaError::InvalidColumnIndex(error))
                 if error.index() == index && error.len() == 1
         ));
     }
 
     #[test]
-    fn dynamic_row_get_returns_exact_label_match() {
+    fn dynamic_row_value_returns_exact_label_match() {
         let schema = make_schema(vec![
             (
                 "ID".to_string(),
@@ -368,8 +501,8 @@ mod tests {
         .unwrap();
         let row = table.dynamic_rows().unwrap().next().unwrap().unwrap();
 
-        assert_eq!(row.get("ID").unwrap(), &SnowflakeValue::Integer(1));
-        assert_eq!(row.get("id").unwrap(), &SnowflakeValue::Integer(2));
+        assert_eq!(row.value("ID").unwrap(), &SnowflakeValue::Integer(1));
+        assert_eq!(row.value("id").unwrap(), &SnowflakeValue::Integer(2));
     }
 
     #[test]
@@ -381,7 +514,7 @@ mod tests {
             row.take_at(index).unwrap(),
             SnowflakeValue::String("value".into())
         );
-        assert_eq!(row.at(index).unwrap(), &SnowflakeValue::Null);
+        assert_eq!(row.value_at(index).unwrap(), &SnowflakeValue::Null);
         assert_eq!(row.take_at(index).unwrap(), SnowflakeValue::Null);
     }
 
@@ -404,7 +537,7 @@ mod tests {
             row.take("PAYLOAD").unwrap(),
             SnowflakeValue::String("value".into())
         );
-        assert_eq!(row.get("PAYLOAD").unwrap(), &SnowflakeValue::Null,);
+        assert_eq!(row.value("PAYLOAD").unwrap(), &SnowflakeValue::Null,);
         assert_eq!(row.take("PAYLOAD").unwrap(), SnowflakeValue::Null);
     }
 
@@ -418,26 +551,7 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_row_into_parts_preserves_schema_and_values() {
-        let schema = make_schema(vec![(
-            "PAYLOAD".to_string(),
-            ColumnType::Text { length: None },
-            true,
-        )]);
-        let table =
-            make_result_table_from_rows(schema, vec![vec![Some("value".to_string())]]).unwrap();
-        let row = table.dynamic_rows().unwrap().next().unwrap().unwrap();
-
-        let (schema, values) = row.into_parts();
-        assert!(ptr::eq(schema.as_ref(), table.schema()));
-        assert_eq!(
-            values.as_ref(),
-            &[SnowflakeValue::String("value".to_string())]
-        );
-    }
-
-    #[test]
-    fn dynamic_row_into_parts_supports_schema_coordinated_walk() {
+    fn dynamic_row_into_parts_preserves_schema_and_supports_walk() {
         let schema = make_schema(vec![
             (
                 "ID".to_string(),
@@ -461,6 +575,7 @@ mod tests {
         let row = table.dynamic_rows().unwrap().next().unwrap().unwrap();
 
         let (schema, values) = row.into_parts();
+        assert!(ptr::eq(schema.as_ref(), table.schema()));
         let walked = schema
             .columns()
             .iter()

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -16,6 +16,7 @@ pub use row::{RowRef, Rows};
 pub use schema::{Column, ColumnIndex, ColumnType, Schema};
 pub use typed_result_table::TypedResultTable;
 
+pub use crate::error::decode::{CellDecodeIssue, CellDecodeResult};
 pub(crate) use cell::RawSpan;
 pub(crate) use result_table::ResultTableBuilder;
 

--- a/src/result/plan.rs
+++ b/src/result/plan.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::result::Schema;
 
-/// Shared context available while building a [`crate::FromRow`] plan.
+/// Schema context for building a row decode plan.
 #[derive(Clone, Copy)]
 pub struct RowPlanContext<'a> {
     schema: &'a Arc<Schema>,
@@ -13,11 +13,13 @@ impl<'a> RowPlanContext<'a> {
         Self { schema }
     }
 
+    /// Borrow the schema describing the result-set columns.
     pub fn schema(&self) -> &'a Schema {
         self.schema.as_ref()
     }
 
-    pub fn clone_schema(&self) -> Arc<Schema> {
+    /// Returns the shared `Arc<Schema>`.
+    pub fn schema_arc(&self) -> Arc<Schema> {
         Arc::clone(self.schema)
     }
 }

--- a/src/result/result_table.rs
+++ b/src/result/result_table.rs
@@ -15,7 +15,10 @@ use crate::{
 
 const CAPACITY_RESERVE_CELL_LIMIT: usize = 64 * 1024 * 1024;
 
-/// Materialized batch of rows sharing a single `Schema` and cell storage.
+/// Fully materialized rows with a shared schema and query id.
+///
+/// `ResultTable` is the untyped table handle. Rows can be decoded into a
+/// typed representation or inspected dynamically.
 #[derive(Debug)]
 pub struct ResultTable {
     schema: Arc<Schema>,
@@ -41,40 +44,38 @@ impl ResultTable {
         }
     }
 
+    /// Borrow the schema describing the result-set columns.
     pub fn schema(&self) -> &Schema {
         &self.schema
     }
 
+    /// Snowflake-assigned query id for this table.
     pub fn query_id(&self) -> &str {
         &self.query_id
     }
 
+    /// Total number of rows across this table.
     pub fn row_count(&self) -> usize {
         self.row_count
     }
 
+    /// Returns `true` when [`row_count`](Self::row_count) is zero.
     pub fn is_empty(&self) -> bool {
         self.row_count == 0
     }
 
-    /// Create a typed row iterator for this table.
+    /// Iterate the table as typed rows of `T`.
     ///
     /// # Errors
     ///
-    /// Returns any error produced by [`FromRow::build_plan`] for `T` when
-    /// preparing to iterate this table.
-    ///
-    /// Built-in and derive-based row types typically use
-    /// `ErrorKind::Decode` when this table's schema does not match `T`;
-    /// inspect the detail via [`crate::Error::as_schema_error`].
+    /// Returns an error when building the row decode plan fails.
     pub fn rows<T: FromRow>(&self) -> Result<Rows<'_, T>> {
         Rows::new(self)
     }
 
-    /// Create a dynamic row iterator for this table.
+    /// Iterate the table as [`DynamicRow`] values.
     ///
-    /// This uses the built-in [`DynamicRow`] plan, which currently reuses the
-    /// table schema directly and therefore cannot fail.
+    /// Iterate the table as dynamically typed rows.
     pub fn dynamic_rows(&self) -> Result<Rows<'_, DynamicRow>> {
         self.rows::<DynamicRow>()
     }

--- a/src/result/row.rs
+++ b/src/result/row.rs
@@ -1,7 +1,7 @@
-use std::{marker::PhantomData, sync::Arc};
+use std::{any::type_name, marker::PhantomData, sync::Arc};
 
 use crate::{
-    Error, InvalidColumnIndexError, Result, SchemaError,
+    CellDecodeError, Error, InvalidColumnIndexError, Result, SchemaError,
     result::{
         cell::{CellBlock, CellRef},
         decode::{FromCell, FromRow},
@@ -11,7 +11,9 @@ use crate::{
     },
 };
 
-/// Lightweight view into a single row.
+/// Borrowed view of a single row.
+///
+/// `RowRef` is copyable and does not own the underlying result data.
 #[derive(Clone, Copy)]
 pub struct RowRef<'a> {
     table: &'a ResultTable,
@@ -21,16 +23,17 @@ pub struct RowRef<'a> {
 }
 
 impl<'a> RowRef<'a> {
+    /// Zero-based index of this row within the result set.
     pub fn row_index(self) -> usize {
         self.global_row
     }
 
-    /// Borrow a cell by column index.
+    /// Borrow a cell by resolved column index.
     ///
     /// # Errors
     ///
-    /// Returns `ErrorKind::Decode` when `index` is out of bounds for
-    /// this row's schema; inspect the detail via [`crate::Error::as_schema_error`].
+    /// Returns [`ErrorKind::Decode`](crate::ErrorKind::Decode) when
+    /// `index` is out of bounds for this row's schema.
     pub fn cell(self, index: ColumnIndex) -> Result<CellRef<'a>> {
         let column = self.table.schema().column_at(index).ok_or_else(|| {
             Error::from(SchemaError::InvalidColumnIndex(
@@ -42,7 +45,7 @@ impl<'a> RowRef<'a> {
         let raw = self.block.cell_text(cell);
 
         Ok(CellRef {
-            row: self.global_row,
+            row_index: self.global_row,
             column,
             raw,
         })
@@ -57,7 +60,7 @@ impl<'a> RowRef<'a> {
         let raw = self.block.cell_text(cell);
 
         CellRef {
-            row: self.global_row,
+            row_index: self.global_row,
             column,
             raw,
         }
@@ -67,20 +70,34 @@ impl<'a> RowRef<'a> {
     ///
     /// # Errors
     ///
-    /// Returns `ErrorKind::Decode` when `index` is out of bounds for
-    /// this row's schema or when [`FromCell::from_cell`] fails for `T`. Use
-    /// [`crate::Error::as_schema_error`] to inspect schema mismatches and
-    /// [`crate::Error::as_cell_decode_error`] for conversion failures.
+    /// Returns [`ErrorKind::Decode`](crate::ErrorKind::Decode) when
+    /// `index` is out of bounds or the cell cannot be decoded as `T`.
     pub fn get<T: FromCell>(self, index: ColumnIndex) -> Result<T> {
-        T::from_cell(self.cell(index)?)
+        let cell = self.cell(index)?;
+        T::from_cell(cell).map_err(|issue| {
+            CellDecodeError::new(
+                cell.row_index(),
+                cell.column().index(),
+                cell.column().name(),
+                type_name::<T>(),
+                cell.column().ty().clone(),
+                cell.raw(),
+                issue,
+            )
+            .into()
+        })
     }
 
+    /// Borrows the schema describing the result-set columns.
     pub fn schema(self) -> &'a Schema {
         self.table.schema()
     }
 }
 
-/// Typed iterator over the rows of a `ResultTable`.
+/// Typed iterator over result rows.
+///
+/// Iteration is non-allocating beyond what `T`'s decode requires: the
+/// `Arc`-shared schema and decode plan are reused across rows.
 pub struct Rows<'a, T: FromRow> {
     table: &'a ResultTable,
     plan: Arc<T::Plan>,
@@ -159,6 +176,7 @@ impl<T: FromRow> ExactSizeIterator for Rows<'_, T> {}
 mod tests {
     use std::sync::Arc;
 
+    use super::*;
     use crate::result::{
         ColumnType,
         result_table::{ResultTable, ResultTableStorage},
@@ -233,7 +251,7 @@ mod tests {
             ResultTableStorage::Single(block) => block.as_ref(),
             ResultTableStorage::Chunks(_) => panic!("expected single block"),
         };
-        let row = super::RowRef {
+        let row = RowRef {
             table: &table,
             block,
             global_row: 0,
@@ -245,7 +263,7 @@ mod tests {
             let checked = row.cell(column.index()).unwrap();
             assert_eq!(direct.raw(), checked.raw());
             assert_eq!(direct.column().name(), checked.column().name());
-            assert_eq!(direct.row(), checked.row());
+            assert_eq!(direct.row_index(), checked.row_index());
         }
     }
 }

--- a/src/result/schema.rs
+++ b/src/result/schema.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use crate::{AmbiguousColumnError, MissingColumnError, SchemaError, error::RowsetParseError};
 
-/// Index into a result-set column list.
+/// Position of a column inside a result-set schema.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ColumnIndex(u32);
@@ -12,50 +12,105 @@ impl ColumnIndex {
         Self(index)
     }
 
+    /// Returns the index as `usize` for slice-style access.
     pub fn as_usize(self) -> usize {
         self.0 as usize
     }
 }
 
+/// Snowflake column type as reported by the result-set metadata.
+///
+/// Variants mirror the wire-level type tags Snowflake returns for each
+/// result column. A handful of variants carry the type's parameters
+/// (precision/scale/length) when the server provides them.
+///
+/// Unknown or unrecognized server-side types fall through to
+/// [`ColumnType::Unknown`] rather than failing — this keeps the connector
+/// usable when Snowflake introduces new types.
+///
+/// # Example
+///
+/// ```
+/// use snowflake_connector_rs::result::ColumnType;
+///
+/// let ty = ColumnType::Fixed { precision: Some(10), scale: Some(2) };
+/// assert_eq!(ty.precision(), Some(10));
+/// assert_eq!(ty.scale(), Some(2));
+/// assert_eq!(ty.length(), None);
+/// assert_eq!(ty.as_str(), "fixed");
+///
+/// let text = ColumnType::Text { length: Some(255) };
+/// assert_eq!(text.length(), Some(255));
+/// assert_eq!(text.precision(), None);
+/// assert_eq!(text.as_str(), "text");
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ColumnType {
+    /// `NUMBER` / `DECIMAL` / `NUMERIC` / `INT` / etc. — exact-precision
+    /// numbers. `precision` and `scale` come from the column definition
+    /// when reported by Snowflake.
     Fixed {
+        /// Total digit count, when reported.
         precision: Option<i64>,
+        /// Digits to the right of the decimal point. Zero means integer.
         scale: Option<i64>,
     },
+    /// `FLOAT` / `DOUBLE` / `REAL` — IEEE 754 floating-point.
     Real,
+    /// `TEXT` / `VARCHAR` / `CHAR` / `STRING` — variable-length string.
     Text {
+        /// Maximum byte length, when reported by Snowflake.
         length: Option<i64>,
     },
+    /// `BOOLEAN`.
     Boolean,
+    /// `DATE` (calendar day, no time-of-day component).
     Date,
+    /// `TIME` (time-of-day, no date component).
     Time {
+        /// Fractional-seconds precision (digits, 0–9).
         scale: Option<i64>,
     },
+    /// `TIMESTAMP_NTZ` — timestamp without time zone.
     TimestampNtz {
+        /// Fractional-seconds precision.
         scale: Option<i64>,
     },
+    /// `TIMESTAMP_LTZ` — timestamp with local-time-zone semantics.
     TimestampLtz {
+        /// Fractional-seconds precision.
         scale: Option<i64>,
     },
+    /// `TIMESTAMP_TZ` — timestamp with explicit offset.
     TimestampTz {
+        /// Fractional-seconds precision.
         scale: Option<i64>,
     },
+    /// `VARIANT` — semi-structured value.
     Variant,
+    /// `OBJECT` — semi-structured map.
     Object,
+    /// `ARRAY` — semi-structured array.
     Array,
+    /// `BINARY` — byte buffer.
     Binary,
+    /// `GEOGRAPHY`.
     Geography,
+    /// `GEOMETRY`.
     Geometry,
+    /// `VECTOR`.
     Vector,
+    /// Type tag the connector did not recognize. The original (lowercased)
+    /// server-side tag is preserved for diagnostics; values come through as
+    /// raw text.
     Unknown {
+        /// Original lowercased Snowflake type tag.
         snowflake_type: Box<str>,
     },
 }
 
 impl ColumnType {
-    /// Build a `ColumnType` from the raw rowtype metadata returned by Snowflake.
-    pub fn from_driver_metadata(
+    pub(crate) fn from_driver_metadata(
         snowflake_type: &str,
         length: Option<i64>,
         precision: Option<i64>,
@@ -85,8 +140,10 @@ impl ColumnType {
         }
     }
 
-    /// Wire-level type tag (lowercase Snowflake `rowtype.type`).
-    pub fn wire_type(&self) -> &str {
+    /// Returns the lowercase Snowflake type tag (matching the
+    /// `rowtype.type` field).
+    ///
+    pub fn as_str(&self) -> &str {
         match self {
             ColumnType::Fixed { .. } => "fixed",
             ColumnType::Real => "real",
@@ -108,6 +165,8 @@ impl ColumnType {
         }
     }
 
+    /// Numeric precision for [`ColumnType::Fixed`]; `None` for any other
+    /// variant.
     pub fn precision(&self) -> Option<i64> {
         if let ColumnType::Fixed { precision, .. } = self {
             *precision
@@ -116,6 +175,8 @@ impl ColumnType {
         }
     }
 
+    /// Scale for variants that carry one (`Fixed`, `Time`, the `Timestamp*`
+    /// family); `None` for any other variant.
     pub fn scale(&self) -> Option<i64> {
         match self {
             ColumnType::Fixed { scale, .. }
@@ -127,6 +188,8 @@ impl ColumnType {
         }
     }
 
+    /// Maximum byte length for [`ColumnType::Text`]; `None` for any other
+    /// variant.
     pub fn length(&self) -> Option<i64> {
         match self {
             ColumnType::Text { length } => *length,
@@ -135,6 +198,7 @@ impl ColumnType {
     }
 }
 
+/// Metadata for a single result-set column.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Column {
     name: Arc<str>,
@@ -144,7 +208,12 @@ pub struct Column {
 }
 
 impl Column {
-    pub fn new(name: impl Into<Arc<str>>, index: u32, nullable: bool, ty: ColumnType) -> Self {
+    pub(crate) fn new(
+        name: impl Into<Arc<str>>,
+        index: u32,
+        nullable: bool,
+        ty: ColumnType,
+    ) -> Self {
         Self {
             name: name.into(),
             index: ColumnIndex(index),
@@ -153,15 +222,19 @@ impl Column {
         }
     }
 
+    /// Raw column name as Snowflake reported it (case-sensitive).
     pub fn name(&self) -> &str {
         &self.name
     }
+    /// Zero-based position of this column within the schema.
     pub fn index(&self) -> ColumnIndex {
         self.index
     }
+    /// Whether the column may carry SQL `NULL`.
     pub fn nullable(&self) -> bool {
         self.nullable
     }
+    /// The column's Snowflake type.
     pub fn ty(&self) -> &ColumnType {
         &self.ty
     }
@@ -207,6 +280,9 @@ impl ColumnIndexMap {
     }
 }
 
+/// Ordered metadata describing the columns of a result set.
+///
+/// Lookups are case-sensitive and match the raw label Snowflake reported.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Schema {
     columns: Box<[Column]>,
@@ -228,24 +304,35 @@ impl Schema {
         })
     }
 
+    /// Borrows the columns in declaration order.
     pub fn columns(&self) -> &[Column] {
         &self.columns
     }
 
+    /// Returns the number of columns.
     pub fn len(&self) -> usize {
         self.columns.len()
     }
 
+    /// Returns `true` when the result set has no columns.
     pub fn is_empty(&self) -> bool {
         self.columns.is_empty()
     }
 
-    /// Borrows column metadata by index.
+    /// Borrow column metadata by index.
     pub fn column_at(&self, index: ColumnIndex) -> Option<&Column> {
         self.columns.get(index.as_usize())
     }
 
-    /// Resolves an exact raw result label (case-sensitive).
+    /// Resolve a column name to its [`ColumnIndex`].
+    ///
+    /// Matching is case-sensitive against the raw label Snowflake reported
+    /// (a quoted `"Id"` and an unquoted `ID` are distinct).
+    ///
+    /// # Errors
+    ///
+    /// - [`SchemaError::MissingColumn`] when no column carries the name.
+    /// - [`SchemaError::AmbiguousColumn`] when several columns share it.
     pub fn column(&self, name: &str) -> std::result::Result<ColumnIndex, SchemaError> {
         lookup_result(name, self.indices.get(name))
     }

--- a/src/result/typed_result_table.rs
+++ b/src/result/typed_result_table.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, sync::Arc};
 
 use crate::result::{FromRow, ResultTable, Rows, Schema};
 
-/// Typed view over a materialized [`ResultTable`] paired with a precomputed decode plan.
+/// A [`ResultTable`] paired with a pre-built decode plan for row type `T`.
 pub struct TypedResultTable<T: FromRow> {
     table: ResultTable,
     plan: Arc<T::Plan>,
@@ -18,26 +18,32 @@ impl<T: FromRow> TypedResultTable<T> {
         }
     }
 
+    /// Snowflake-assigned query id for this table.
     pub fn query_id(&self) -> &str {
         self.table.query_id()
     }
 
+    /// Borrow the schema describing the result-set columns.
     pub fn schema(&self) -> &Schema {
         self.table.schema()
     }
 
+    /// Total number of rows across this table.
     pub fn row_count(&self) -> usize {
         self.table.row_count()
     }
 
+    /// Returns `true` when [`row_count`](Self::row_count) is zero.
     pub fn is_empty(&self) -> bool {
         self.table.is_empty()
     }
 
+    /// Iterate the table as typed rows of `T`.
     pub fn rows(&self) -> Rows<'_, T> {
         Rows::from_arc_plan(&self.table, Arc::clone(&self.plan))
     }
 
+    /// Return the underlying [`ResultTable`].
     pub fn into_inner(self) -> ResultTable {
         self.table
     }

--- a/src/rowset/parser.rs
+++ b/src/rowset/parser.rs
@@ -549,8 +549,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        ColumnType,
-        result::test_data::make_schema,
+        result::{ColumnType, test_data::make_schema},
         rowset::workload::{
             BLOCKING_GZIP_COMPRESSED_BYTES, BLOCKING_PARSE_BYTES, BLOCKING_PARSE_CELLS,
             ParseExecution, should_spawn_blocking_parse,

--- a/tests/cases/test_basic_operations.rs
+++ b/tests/cases/test_basic_operations.rs
@@ -1,7 +1,10 @@
 use super::common;
 
 use chrono::{NaiveDate, NaiveDateTime};
-use snowflake_connector_rs::{ColumnType, DecimalValue, Result};
+use snowflake_connector_rs::{
+    Result,
+    result::{ColumnType, DecimalValue},
+};
 
 #[tokio::test]
 async fn test_basic_operations() -> Result<()> {
@@ -64,27 +67,39 @@ async fn test_basic_operations() -> Result<()> {
     let rows = table
         .rows::<(i64, String, DecimalValue, bool, NaiveDate, NaiveDateTime)>()?
         .collect::<Result<Vec<_>>>()?;
-    assert_eq!(
-        rows,
-        vec![
-            (
-                1,
-                "hello".to_string(),
-                DecimalValue::new("99.99", Some(10), Some(2)),
-                true,
-                NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
-                NaiveDateTime::parse_from_str("2023-01-01 12:00:00", "%Y-%m-%d %H:%M:%S").unwrap()
-            ),
-            (
-                2,
-                "world".to_string(),
-                DecimalValue::new("149.99", Some(10), Some(2)),
-                false,
-                NaiveDate::from_ymd_opt(2023, 1, 2).unwrap(),
-                NaiveDateTime::parse_from_str("2023-01-02 15:30:00", "%Y-%m-%d %H:%M:%S").unwrap()
-            )
-        ]
-    );
+    let expected = [
+        (
+            1_i64,
+            "hello",
+            ("99.99", Some(10), Some(2)),
+            true,
+            NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
+            NaiveDateTime::parse_from_str("2023-01-01 12:00:00", "%Y-%m-%d %H:%M:%S").unwrap(),
+        ),
+        (
+            2,
+            "world",
+            ("149.99", Some(10), Some(2)),
+            false,
+            NaiveDate::from_ymd_opt(2023, 1, 2).unwrap(),
+            NaiveDateTime::parse_from_str("2023-01-02 15:30:00", "%Y-%m-%d %H:%M:%S").unwrap(),
+        ),
+    ];
+    assert_eq!(rows.len(), expected.len());
+
+    for (actual, expected) in rows.iter().zip(expected) {
+        let (id, value, price, is_active, created_date, updated_at) = actual;
+        let (exp_id, exp_value, (exp_raw, exp_precision, exp_scale), exp_active, exp_date, exp_ts) =
+            expected;
+        assert_eq!(*id, exp_id);
+        assert_eq!(value, exp_value);
+        assert_eq!(price.raw(), exp_raw);
+        assert_eq!(price.precision(), exp_precision);
+        assert_eq!(price.scale(), exp_scale);
+        assert_eq!(*is_active, exp_active);
+        assert_eq!(*created_date, exp_date);
+        assert_eq!(*updated_at, exp_ts);
+    }
 
     let columns = table.schema().columns();
     assert_eq!(columns.len(), 6);
@@ -129,13 +144,15 @@ async fn test_basic_operations() -> Result<()> {
         .await?
         .collect()
         .await?;
-    assert_eq!(
-        price_rows,
-        vec![
-            (1, DecimalValue::new("99.99", Some(10), Some(2))),
-            (2, DecimalValue::new("149.99", Some(10), Some(2))),
-        ]
-    );
+    let expected_prices = [(1_i64, "99.99"), (2, "149.99")];
+    assert_eq!(price_rows.len(), expected_prices.len());
+
+    for ((id, price), (exp_id, exp_raw)) in price_rows.iter().zip(expected_prices) {
+        assert_eq!(*id, exp_id);
+        assert_eq!(price.raw(), exp_raw);
+        assert_eq!(price.precision(), Some(10));
+        assert_eq!(price.scale(), Some(2));
+    }
 
     Ok(())
 }

--- a/tests/cases/test_chunk.rs
+++ b/tests/cases/test_chunk.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroUsize;
 
-use snowflake_connector_rs::{CollectOptions, ColumnType, Result};
+use snowflake_connector_rs::{CollectOptions, Result, result::ColumnType};
 
 use super::common;
 

--- a/tests/cases/test_decode.rs
+++ b/tests/cases/test_decode.rs
@@ -2,7 +2,7 @@ use super::common;
 
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
-use snowflake_connector_rs::{Result, SchemaError, SnowflakeValue};
+use snowflake_connector_rs::{Result, SchemaError, result::SnowflakeValue};
 
 #[tokio::test]
 async fn test_decode() -> Result<()> {
@@ -28,7 +28,7 @@ async fn test_decode() -> Result<()> {
     assert_eq!(table.row_count(), 1);
 
     let row = table.dynamic_rows()?.next().unwrap()?;
-    let status = row.get("status").unwrap();
+    let status = row.value("status").unwrap();
     assert_eq!(
         status,
         &SnowflakeValue::String("Table EXAMPLE successfully created.".to_owned()),
@@ -51,7 +51,7 @@ async fn test_decode() -> Result<()> {
     assert_eq!(table.row_count(), 1);
 
     let row = table.dynamic_rows()?.next().unwrap()?;
-    let number_of_rows_inserted = row.get("number of rows inserted").unwrap();
+    let number_of_rows_inserted = row.value("number of rows inserted").unwrap();
     assert_eq!(number_of_rows_inserted, &SnowflakeValue::Integer(1));
 
     let table = session
@@ -111,7 +111,7 @@ async fn test_decode() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_dynamic_row_get_resolves_escaped_identifiers() -> Result<()> {
+async fn test_dynamic_row_value_resolves_escaped_identifiers() -> Result<()> {
     let client = common::connect()?;
     let session = client.create_session().await?;
 
@@ -129,17 +129,17 @@ async fn test_dynamic_row_get_resolves_escaped_identifiers() -> Result<()> {
 
     let row = table.dynamic_rows()?.next().unwrap()?;
 
-    assert_eq!(row.get("ID").unwrap(), &SnowflakeValue::Integer(1));
-    assert_eq!(row.get("id").unwrap(), &SnowflakeValue::Integer(2));
-    assert_eq!(row.get("my column").unwrap(), &SnowflakeValue::Integer(3));
-    assert_eq!(row.get("MixedCase").unwrap(), &SnowflakeValue::Integer(4));
+    assert_eq!(row.value("ID").unwrap(), &SnowflakeValue::Integer(1));
+    assert_eq!(row.value("id").unwrap(), &SnowflakeValue::Integer(2));
+    assert_eq!(row.value("my column").unwrap(), &SnowflakeValue::Integer(3));
+    assert_eq!(row.value("MixedCase").unwrap(), &SnowflakeValue::Integer(4));
 
     assert!(matches!(
-        row.get("MIXEDCASE"),
+        row.value("MIXEDCASE"),
         Err(SchemaError::MissingColumn(_))
     ));
     assert!(matches!(
-        row.get("MY COLUMN"),
+        row.value("MY COLUMN"),
         Err(SchemaError::MissingColumn(_))
     ));
 

--- a/tests/cases/test_derive.rs
+++ b/tests/cases/test_derive.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDateTime;
 
-use snowflake_connector_rs::{DecimalValue, FromRow, Result, SchemaError};
+use snowflake_connector_rs::{FromRow, Result, SchemaError, result::DecimalValue};
 
 use super::common;
 
@@ -136,19 +136,15 @@ async fn derive_named_lookup_variants_decode_expected_rows() -> Result<()> {
         .collect()
         .await?;
 
-    assert_eq!(
-        prices,
-        vec![
-            PriceRow {
-                id: 1,
-                price: DecimalValue::new("99.99", Some(10), Some(2)),
-            },
-            PriceRow {
-                id: 2,
-                price: DecimalValue::new("149.99", Some(10), Some(2)),
-            },
-        ]
-    );
+    let expected_prices = [(1_i64, "99.99"), (2, "149.99")];
+    assert_eq!(prices.len(), expected_prices.len());
+
+    for (row, (exp_id, exp_raw)) in prices.iter().zip(expected_prices) {
+        assert_eq!(row.id, exp_id);
+        assert_eq!(row.price.raw(), exp_raw);
+        assert_eq!(row.price.precision(), Some(10));
+        assert_eq!(row.price.scale(), Some(2));
+    }
 
     let keywords = session
         .query_as::<KeywordRow, _>("SELECT 1 AS TYPE")
@@ -220,7 +216,7 @@ async fn derive_required_fields_surface_schema_and_decode_errors() -> Result<()>
     match err.as_cell_decode_error() {
         Some(err) => {
             assert_eq!(err.column_name(), "NOTE");
-            assert_eq!(err.reason(), "value is NULL");
+            assert_eq!(err.issue().reason(), "value is NULL");
         }
         other => panic!("expected Decode error, got: {other:?}"),
     }

--- a/tests/cases/test_query_id.rs
+++ b/tests/cases/test_query_id.rs
@@ -1,6 +1,6 @@
 use super::common;
 
-use snowflake_connector_rs::{ColumnType, Result};
+use snowflake_connector_rs::{Result, result::ColumnType};
 
 #[tokio::test]
 async fn result_set_query_id_and_schema_survive_inline_empty_and_chunked_paths() -> Result<()> {

--- a/tests/cases/test_session_parameters.rs
+++ b/tests/cases/test_session_parameters.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::common;
 
-use snowflake_connector_rs::{Result, SnowflakeValue};
+use snowflake_connector_rs::{Result, result::SnowflakeValue};
 
 #[tokio::test]
 async fn test_session_parameters_support_bulk_and_incremental_configuration() -> Result<()> {
@@ -22,7 +22,7 @@ async fn test_session_parameters_support_bulk_and_incremental_configuration() ->
         .await?
         .collect()
         .await?;
-    let value = rows[0].get("value").unwrap();
+    let value = rows[0].value("value").unwrap();
     assert_eq!(value, &SnowflakeValue::String("48".to_owned()));
 
     let rows = session
@@ -30,7 +30,7 @@ async fn test_session_parameters_support_bulk_and_incremental_configuration() ->
         .await?
         .collect()
         .await?;
-    let value = rows[0].get("value").unwrap();
+    let value = rows[0].value("value").unwrap();
     assert_eq!(value, &SnowflakeValue::String("Asia/Tokyo".to_owned()));
 
     Ok(())


### PR DESCRIPTION
## Summary

Separate the failure representation returned by `FromCell` from the final `CellDecodeError`.

Previously, custom decoders effectively constructed a `CellDecodeError` through `CellRef`. With this change, decoders only return a `CellDecodeIssue`, and the result layer attaches contextual information when creating the final `CellDecodeError`.

## Why

`CellDecodeIssue` is a cell-local failure reason that custom `FromCell` implementations are free to describe.

`CellDecodeError` is the final diagnostic after result-set context has been attached to that issue. This removes the need for `CellRef` to act as an error factory, keeping `CellRef` focused on borrowed cell data and helper methods.