### PR TITLE
refactor(result): simplify boolean digit decoding

### DIFF
--- a/src/result/decode.rs
+++ b/src/result/decode.rs
@@ -274,9 +274,9 @@ impl FromCell for bool {
         ensure_column_type(cell, matches!(cell.column().ty(), ColumnType::Boolean))?;
 
         let raw = cell.required_raw()?;
-        if raw.eq_ignore_ascii_case("1") || raw.eq_ignore_ascii_case("true") {
+        if raw == "1" || raw.eq_ignore_ascii_case("true") {
             Ok(true)
-        } else if raw.eq_ignore_ascii_case("0") || raw.eq_ignore_ascii_case("false") {
+        } else if raw == "0" || raw.eq_ignore_ascii_case("false") {
             Ok(false)
         } else {
             Err(CellDecodeIssue::builder(format!("'{raw}' is not bool")).build())

--- a/src/result/dynamic.rs
+++ b/src/result/dynamic.rs
@@ -316,9 +316,9 @@ fn decode_dynamic(cell: CellRef<'_>) -> CellDecodeResult<SnowflakeValue> {
 
     match ty {
         ColumnType::Boolean => {
-            if raw.eq_ignore_ascii_case("1") || raw.eq_ignore_ascii_case("true") {
+            if raw == "1" || raw.eq_ignore_ascii_case("true") {
                 Ok(SnowflakeValue::Boolean(true))
-            } else if raw.eq_ignore_ascii_case("0") || raw.eq_ignore_ascii_case("false") {
+            } else if raw == "0" || raw.eq_ignore_ascii_case("false") {
                 Ok(SnowflakeValue::Boolean(false))
             } else {
                 Err(CellDecodeIssue::builder(format!("'{raw}' is not bool")).build())


### PR DESCRIPTION
Use direct string equality for numeric boolean rowset values while keeping case-insensitive comparison for textual true and false values.