### PR TITLE
ci: use dedicated Cargo profile in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,25 +40,25 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace --lib --tests --examples --all-features -- -D warnings
+        run: cargo clippy --profile ci --workspace --lib --tests --examples --all-features -- -D warnings
 
       - name: Check default features
-        run: cargo check --workspace --lib --tests --examples
+        run: cargo check --profile ci --workspace --lib --tests --examples
 
       - name: Check all features
-        run: cargo check --workspace --lib --tests --examples --all-features
+        run: cargo check --profile ci --workspace --lib --tests --examples --all-features
 
       - name: Check without default features
-        run: cargo check --workspace --lib --tests --examples --no-default-features
+        run: cargo check --profile ci --workspace --lib --tests --examples --no-default-features
 
       - name: Test library
-        run: cargo test --workspace --all-features --lib
+        run: cargo test --profile ci --workspace --all-features --lib
 
       - name: Test derive macro
-        run: cargo test --workspace --all-features --test derive_trybuild
+        run: cargo test --profile ci --workspace --all-features --test derive_trybuild
 
       - name: Test integration
-        run: cargo test --workspace --test integration
+        run: cargo test --profile ci --workspace --test integration
 
       - name: Test documentation
-        run: cargo test --workspace --all-features --doc
+        run: cargo test --profile ci --workspace --all-features --doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,14 @@ keywords = [
 license = "MIT"
 readme = "README.md"
 
+[profile.ci]
+debug = 0
+incremental = false
+inherits = "test"
+
+[profile.ci.package."*"]
+debug = false
+
 [workspace]
 members = [
     "derive",


### PR DESCRIPTION
Add a ci Cargo profile that disables debug info and incremental compilation, then run clippy, check, and tests with that profile in GitHub Actions.