### PR TITLE
feat: CancellationToken

### DIFF
--- a/src/cancellation.rs
+++ b/src/cancellation.rs
@@ -1,0 +1,187 @@
+//! Cooperative cancellation for in-flight queries.
+
+use std::{
+    fmt,
+    future::{Future, poll_fn},
+    pin::pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::Poll,
+};
+
+use tokio::sync::Notify;
+
+/// A cooperative signal for cancelling an in-flight query.
+///
+/// Attach a token to a query with
+/// [`QueryOptions::with_cancellation_token`](crate::QueryOptions::with_cancellation_token), then call
+/// [`cancel`](CancellationToken::cancel) from anywhere — including another thread — to abort it while it runs.
+///
+/// Cancellation does two things: it stops the client-side wait for the query response, and it sends Snowflake an
+/// out-of-band abort for the statement so the warehouse stops executing it (and stops accruing cost). Cancellation
+/// covers the execution phase — statement submit and the async result poll — which is where warehouse time is spent;
+/// it does not interrupt downloading already-computed result chunks.
+///
+/// The token is cheap to [`clone`](Clone); every clone shares one cancellation state.
+///
+/// ```no_run
+/// # use snowflake_connector_rs::{CancellationToken, QueryOptions, Session};
+/// # async fn run(session: Session) -> snowflake_connector_rs::Result<()> {
+/// let token = CancellationToken::new();
+/// let watcher = token.clone();
+/// // e.g. from a cancel button on another thread/task: `watcher.cancel();`
+/// let _ = &watcher;
+/// let result = session
+///     .query_with_options("CALL long_running()", QueryOptions::new().with_cancellation_token(token))
+///     .await;
+/// # let _ = result; Ok(())
+/// # }
+/// ```
+#[derive(Clone, Default)]
+pub struct CancellationToken {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    cancelled: AtomicBool,
+    notify: Notify,
+}
+
+impl CancellationToken {
+    /// Create a fresh, un-cancelled token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Signal cancellation. Idempotent and safe to call from any thread; only the first call has an effect.
+    pub fn cancel(&self) {
+        if !self.inner.cancelled.swap(true, Ordering::SeqCst) {
+            self.inner.notify.notify_waiters();
+        }
+    }
+
+    /// Whether [`cancel`](Self::cancel) has been called on this token (or any of its clones).
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::SeqCst)
+    }
+
+    /// Resolve as soon as the token is cancelled. Cancellation-safe.
+    pub(crate) async fn cancelled(&self) {
+        loop {
+            if self.is_cancelled() {
+                return;
+            }
+            // Register the waiter, then re-check, so a `cancel` racing with this call cannot slip between the check
+            // and the wait.
+            let mut notified = pin!(self.inner.notify.notified());
+            notified.as_mut().enable();
+            if self.is_cancelled() {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+impl fmt::Debug for CancellationToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CancellationToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish()
+    }
+}
+
+/// Drive `fut` to completion unless `token` is cancelled first.
+///
+/// Returns `Some(output)` when `fut` finished, or `None` when cancellation won the race. Completion of `fut` is
+/// preferred when both are ready in the same poll, so a query that finished on the same turn it was cancelled still
+/// yields its result.
+pub(crate) async fn run_until_cancelled<F, T>(token: &CancellationToken, fut: F) -> Option<T>
+where
+    F: Future<Output = T>,
+{
+    let mut fut = pin!(fut);
+    let mut cancelled = pin!(token.cancelled());
+    poll_fn(|cx| {
+        if let Poll::Ready(out) = fut.as_mut().poll(cx) {
+            return Poll::Ready(Some(out));
+        }
+        if cancelled.as_mut().poll(cx).is_ready() {
+            return Poll::Ready(None);
+        }
+        Poll::Pending
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::{sleep, timeout};
+
+    use super::*;
+
+    #[test]
+    fn new_token_is_not_cancelled() {
+        assert!(!CancellationToken::new().is_cancelled());
+    }
+
+    #[test]
+    fn cancel_sets_the_flag_and_is_shared_across_clones() {
+        let token = CancellationToken::new();
+        let clone = token.clone();
+        token.cancel();
+        assert!(token.is_cancelled());
+        assert!(clone.is_cancelled(), "clones share one cancellation state");
+    }
+
+    #[tokio::test]
+    async fn cancelled_resolves_after_cancel() {
+        let token = CancellationToken::new();
+        let waiter = token.clone();
+        let handle = tokio::spawn(async move { waiter.cancelled().await });
+        // The waiter must still be pending until we cancel.
+        assert!(timeout(Duration::from_millis(50), async {}).await.is_ok());
+        token.cancel();
+        timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("cancelled() must resolve promptly once cancelled")
+            .expect("waiter task should not panic");
+    }
+
+    #[tokio::test]
+    async fn cancelled_resolves_immediately_when_already_cancelled() {
+        let token = CancellationToken::new();
+        token.cancel();
+        timeout(Duration::from_secs(1), token.cancelled())
+            .await
+            .expect("an already-cancelled token resolves without waiting");
+    }
+
+    #[tokio::test]
+    async fn run_until_cancelled_returns_output_when_future_wins() {
+        let token = CancellationToken::new();
+        let out = run_until_cancelled(&token, async { 7_u32 }).await;
+        assert_eq!(out, Some(7));
+    }
+
+    #[tokio::test]
+    async fn run_until_cancelled_returns_none_when_cancelled_first() {
+        let token = CancellationToken::new();
+        let canceller = token.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(20)).await;
+            canceller.cancel();
+        });
+        let out = run_until_cancelled(&token, async {
+            // Never completes on its own.
+            std::future::pending::<()>().await;
+        })
+        .await;
+        assert_eq!(out, None);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -137,6 +137,9 @@ pub enum ErrorKind {
     Decode,
     /// Connector-internal runtime work failed, such as a cancelled or panicked task join.
     Internal,
+    /// The query was cancelled through a [`CancellationToken`](crate::CancellationToken). The connector stopped
+    /// waiting and sent Snowflake a best-effort abort for the statement.
+    Cancelled,
     /// Caller-supplied fallback error created via [`Error::other`].
     Other,
 }
@@ -166,6 +169,7 @@ impl Error {
             | Repr::CustomPlan(_)
             | Repr::RowConversion(_) => ErrorKind::Decode,
             Repr::Internal { .. } => ErrorKind::Internal,
+            Repr::Cancelled { .. } => ErrorKind::Cancelled,
             Repr::Other(_) => ErrorKind::Other,
         }
     }
@@ -202,7 +206,8 @@ impl Error {
             Repr::Network { query_id, .. }
             | Repr::Timeout { query_id, .. }
             | Repr::Protocol { query_id, .. }
-            | Repr::Internal { query_id, .. } => query_id.as_deref(),
+            | Repr::Internal { query_id, .. }
+            | Repr::Cancelled { query_id } => query_id.as_deref(),
             Repr::Server(ServerError { query_id, .. }) => query_id.as_deref(),
             Repr::SessionExpired(SessionExpiredError { query_id, .. }) => query_id.as_deref(),
             _ => None,
@@ -219,6 +224,11 @@ impl Error {
 
     pub fn is_server(&self) -> bool {
         matches!(&*self.repr, Repr::Server(_))
+    }
+
+    /// Whether the query was cancelled through a [`CancellationToken`](crate::CancellationToken).
+    pub fn is_cancelled(&self) -> bool {
+        matches!(&*self.repr, Repr::Cancelled { .. })
     }
 
     pub fn as_cell_decode_error(&self) -> Option<&CellDecodeError> {
@@ -272,6 +282,11 @@ impl Error {
 
     pub fn other(message: impl Into<String>) -> Self {
         Self::new(Repr::Other(message.into().into_boxed_str()))
+    }
+
+    /// Build a cancellation error, carrying the Snowflake query id when it was known at cancel time.
+    pub(crate) fn cancelled(query_id: Option<Arc<str>>) -> Self {
+        Self::new(Repr::Cancelled { query_id })
     }
 
     pub(crate) fn bind_encode(message: impl Into<String>) -> Self {

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -172,6 +172,12 @@ impl Display for Error {
                 ..
             } => f.write_str("future join error"),
             Repr::BindEncode { message, .. } => write!(f, "bind encode error: {message}"),
+            Repr::Cancelled {
+                query_id: Some(query_id),
+            } => {
+                write!(f, "query cancelled (query id: {query_id})")
+            }
+            Repr::Cancelled { query_id: None } => f.write_str("query cancelled"),
             Repr::Other(message) => write!(f, "snowflake connector error: {message}"),
             Repr::Schema(error) => Display::fmt(error, f),
             Repr::CellDecode(error) => Display::fmt(error, f),

--- a/src/error/repr.rs
+++ b/src/error/repr.rs
@@ -35,6 +35,9 @@ pub(crate) enum Repr {
         error: InternalError,
         query_id: Option<Arc<str>>,
     },
+    Cancelled {
+        query_id: Option<Arc<str>>,
+    },
     Other(Box<str>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@
 
 mod auth;
 pub mod bind;
+mod cancellation;
 mod config;
 pub mod decode;
 pub mod error;
@@ -80,6 +81,7 @@ pub use auth::config::KeyPairConfig;
 pub use auth::config::{AuthConfig, PasswordConfig};
 #[cfg(feature = "external-browser-sso")]
 pub use auth::external_browser::{BrowserLaunchMode, ExternalBrowserConfig};
+pub use cancellation::CancellationToken;
 pub use config::{
     ClientConfig, EndpointConfig, ProxyConfig, QueryConfig, SessionConfig, TransportConfig,
 };

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 use std::{fmt, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use crate::{
-    ClientShared, IntoStatement, Result,
+    CancellationToken, ClientShared, IntoStatement, Result,
     result_cursor::{ResultCursor, TypedResultCursor},
     result_table::{FromRow, RowPlanContext},
     statement::{StatementExecutor, builder::into_statement_parts},
@@ -21,6 +21,7 @@ pub struct Session {
 pub struct QueryOptions {
     pub(crate) query_response_timeout: Option<Duration>,
     pub(crate) collect_prefetch_concurrency: Option<NonZeroUsize>,
+    pub(crate) cancellation_token: Option<CancellationToken>,
 }
 
 impl QueryOptions {
@@ -43,6 +44,15 @@ impl QueryOptions {
     /// final say for a specific collection call.
     pub fn with_collect_prefetch_concurrency(mut self, concurrency: NonZeroUsize) -> Self {
         self.collect_prefetch_concurrency = Some(concurrency);
+        self
+    }
+
+    /// Attach a [`CancellationToken`] so this query can be aborted while it runs.
+    ///
+    /// Cancelling the token stops the client-side wait for the query response and sends Snowflake a best-effort abort
+    /// for the statement, so the warehouse stops executing it. See [`CancellationToken`] for the exact semantics.
+    pub fn with_cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation_token = Some(token);
         self
     }
 }
@@ -100,8 +110,9 @@ impl Session {
     where
         S: IntoStatement,
     {
+        let cancellation = options.cancellation_token.clone();
         let settings = self.shared.query.resolve_options(options);
-        let executor = StatementExecutor::new(self, settings);
+        let executor = StatementExecutor::new(self, settings).with_cancellation(cancellation);
         executor.execute(into_statement_parts(statement)).await
     }
 

--- a/src/statement/client.rs
+++ b/src/statement/client.rs
@@ -5,6 +5,7 @@ use std::{
 
 use http::header::{ACCEPT, AUTHORIZATION};
 use reqwest::{Client, Url};
+use serde::Serialize;
 use tokio::time::{sleep, timeout};
 use uuid::Uuid;
 
@@ -83,10 +84,10 @@ impl StatementApiClient {
         &self,
         parts: &StatementParts,
         deadline: QueryResponseDeadline,
+        request_id: Uuid,
     ) -> Result<SnowflakeResponse> {
         validate_statement_parts_for_wire(parts)?;
 
-        let request_id = Uuid::new_v4();
         let mut url = self
             .shared
             .base_url
@@ -211,6 +212,44 @@ impl StatementApiClient {
             }
         }
     }
+
+    /// Ask Snowflake to abort the statement submitted under `request_id`.
+    ///
+    /// This posts to the same `abort-request` endpoint the official Snowflake connectors use to cancel a query. It is
+    /// best-effort: the result is intentionally ignored (the caller is already unwinding a cancellation) and the call
+    /// is bounded by a short timeout so a stuck control-plane cannot hang the cancel path.
+    pub(crate) async fn abort(&self, request_id: Uuid, sql_text: &str) {
+        let Ok(mut url) = self.shared.base_url.join("queries/v1/abort-request") else {
+            return;
+        };
+        // The abort call carries its own fresh request id; the body names the original request to cancel.
+        url.query_pairs_mut()
+            .append_pair("requestId", &Uuid::new_v4().to_string());
+
+        let request = self
+            .shared
+            .http
+            .post(url)
+            .header(ACCEPT, "application/snowflake")
+            .header(
+                AUTHORIZATION,
+                format!(r#"Snowflake Token="{}""#, self.auth.session_token),
+            )
+            .json(&AbortRequestBody {
+                sql_text,
+                request_id: request_id.to_string(),
+            });
+
+        const ABORT_TIMEOUT: Duration = Duration::from_secs(5);
+        let _ = timeout(ABORT_TIMEOUT, request.send()).await;
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AbortRequestBody<'a> {
+    sql_text: &'a str,
+    request_id: String,
 }
 
 /// Client-side backoff between consecutive poll GETs for an async query.
@@ -386,7 +425,10 @@ mod tests {
         let parts = into_statement_parts(Statement::from("select 1"));
         // A generous deadline leaves the reqwest client-wide timeout as the trigger for this case.
         let deadline = QueryResponseDeadline::new(Duration::from_secs(30));
-        let err = client.submit(&parts, deadline).await.unwrap_err();
+        let err = client
+            .submit(&parts, deadline, Uuid::new_v4())
+            .await
+            .unwrap_err();
 
         assert_eq!(err.kind(), ErrorKind::Timeout);
         assert!(err.is_timeout());

--- a/src/statement/executor.rs
+++ b/src/statement/executor.rs
@@ -1,7 +1,10 @@
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
+use uuid::Uuid;
+
 use crate::{
-    QueryExecutionSettings,
+    CancellationToken, QueryExecutionSettings,
+    cancellation::run_until_cancelled,
     error::{ProtocolError, QueryScopedError, QueryScopedResult, ServerError, SessionExpiredError},
     result_cursor::{CollectPolicy, RemotePartitionSource, ResultCursor},
     runtime::QueryRuntime,
@@ -23,6 +26,7 @@ pub(crate) struct StatementExecutor {
     query_response_timeout: Duration,
     default_collect_concurrency: NonZeroUsize,
     runtime: QueryRuntime,
+    cancellation: Option<CancellationToken>,
 }
 
 struct QueryScopedResponse {
@@ -60,19 +64,57 @@ impl StatementExecutor {
             query_response_timeout: settings.query_response_timeout,
             default_collect_concurrency: settings.collect_prefetch_concurrency,
             runtime: session.shared.runtime.clone(),
+            cancellation: None,
         }
     }
 
-    pub(crate) async fn execute(self, parts: StatementParts) -> Result<ResultCursor> {
+    pub(crate) fn with_cancellation(mut self, token: Option<CancellationToken>) -> Self {
+        self.cancellation = token;
+        self
+    }
+
+    pub(crate) async fn execute(&self, parts: StatementParts) -> Result<ResultCursor> {
+        // A client-generated request id identifies this statement for a later abort. Snowflake's abort endpoint is
+        // keyed by the original request id, so we mint it here (not inside `submit`) to keep it in reach.
+        let request_id = Uuid::new_v4();
+
+        let Some(token) = self.cancellation.clone() else {
+            return self.execute_inner(&parts, request_id).await;
+        };
+
+        // Already cancelled before we started: abort any statement Snowflake may have registered and return.
+        if token.is_cancelled() {
+            self.api.abort(request_id, parts.sql()).await;
+            return Err(Error::cancelled(None));
+        }
+
+        // The abort needs the SQL text, which `parts` owns; capture it before the borrow enters the race.
+        let sql = parts.sql().to_owned();
+        match run_until_cancelled(&token, self.execute_inner(&parts, request_id)).await {
+            Some(result) => result,
+            None => {
+                // Best-effort: stop the warehouse from continuing to run (and bill) the statement.
+                self.api.abort(request_id, &sql).await;
+                Err(Error::cancelled(None))
+            }
+        }
+    }
+
+    async fn execute_inner(
+        &self,
+        parts: &StatementParts,
+        request_id: Uuid,
+    ) -> Result<ResultCursor> {
         let deadline = QueryResponseDeadline::new(self.query_response_timeout);
-        let response = QueryScopedResponse::from_submit(self.api.submit(&parts, deadline).await?)?;
+        let response =
+            QueryScopedResponse::from_submit(self.api.submit(parts, deadline, request_id).await?)?;
         self.execute_query_scoped(response, deadline)
             .await
             .map_err(Error::from)
     }
 
     async fn execute_query_scoped(
-        self,
+        &self,
         response: QueryScopedResponse,
         deadline: QueryResponseDeadline,
     ) -> QueryScopedResult<ResultCursor> {
@@ -140,7 +182,7 @@ impl StatementExecutor {
         self.build_result_set(data)
     }
 
-    fn build_result_set(self, data: RawQueryResponse) -> QueryScopedResult<ResultCursor> {
+    fn build_result_set(&self, data: RawQueryResponse) -> QueryScopedResult<ResultCursor> {
         let manifest = ResultManifest::try_from(data)?;
 
         let source = RemotePartitionSource::new(manifest.lease, self.api.http_client());
@@ -150,7 +192,7 @@ impl StatementExecutor {
             manifest.snapshot,
             manifest.inline_rowset,
             source,
-            self.runtime,
+            self.runtime.clone(),
             default_collect_policy,
         ))
     }
@@ -162,17 +204,18 @@ mod tests {
         io::{Read, Write},
         net::TcpListener as StdTcpListener,
         num::NonZeroUsize,
+        sync::Mutex,
         thread,
         time::{Duration, Instant},
     };
 
     use bytes::Bytes;
     use reqwest::{Client, Url};
-    use tokio::time::timeout;
+    use tokio::time::{sleep, timeout};
 
     use super::*;
     use crate::{
-        ClientShared, ErrorKind, QueryConfig, QueryOptions, Statement,
+        CancellationToken, ClientShared, ErrorKind, QueryConfig, QueryOptions, Statement,
         rowset::BLOCKING_PARSE_CELLS,
         runtime::QueryRuntime,
         session::SessionAuth,
@@ -183,6 +226,36 @@ mod tests {
             wire::response::{RawQueryResponse, RawQueryResponseRowType},
         },
     };
+
+    /// A scripted server that also records the raw request head+body of each connection it accepts, so a test can
+    /// assert which endpoints were called (e.g. that an abort-request was sent).
+    fn spawn_recording_server(bodies: Vec<&'static str>) -> (Url, Arc<Mutex<Vec<String>>>) {
+        let listener = StdTcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&log);
+
+        thread::spawn(move || {
+            for body in bodies {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0_u8; 8192];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                recorded
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&buf[..n]).into_owned());
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        (Url::parse(&format!("http://{addr}/")).unwrap(), log)
+    }
 
     fn default_settings(session: &Session) -> QueryExecutionSettings {
         session
@@ -211,6 +284,7 @@ mod tests {
             query_response_timeout: crate::config::DEFAULT_QUERY_RESPONSE_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime: QueryRuntime::new(),
+            cancellation: None,
         }
     }
 
@@ -220,6 +294,7 @@ mod tests {
             query_response_timeout: timeout,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime: QueryRuntime::new(),
+            cancellation: None,
         }
     }
 
@@ -515,6 +590,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelling_a_running_query_returns_cancelled_and_sends_an_abort() {
+        // Submit resolves to an async query, the first poll returns in-progress (so the client settles into its
+        // backoff), then the token is cancelled. The executor must stop waiting, POST an abort-request, and surface a
+        // Cancelled error — the abort is what stops the warehouse from continuing to run (and bill) the statement.
+        let (base_url, requests) = spawn_recording_server(vec![
+            ASYNC_SUBMIT_RESPONSE,
+            ASYNC_IN_PROGRESS_RESPONSE,
+            // The abort-request acknowledgement; its contents are ignored by the connector.
+            r#"{"success":true,"data":{}}"#,
+        ]);
+        let session = test_session(base_url);
+        let token = CancellationToken::new();
+        let executor = StatementExecutor::new(&session, default_settings(&session))
+            .with_cancellation(Some(token.clone()));
+
+        let canceller = token.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(80)).await;
+            canceller.cancel();
+        });
+
+        let err = executor
+            .execute(select_1_parts())
+            .await
+            .expect_err("a cancelled query must return an error");
+        assert_eq!(err.kind(), ErrorKind::Cancelled);
+        assert!(err.is_cancelled());
+
+        // execute() awaits the best-effort abort before returning, so the abort-request is already recorded.
+        let recorded = requests.lock().unwrap().clone();
+        assert!(
+            recorded
+                .iter()
+                .any(|req| req.starts_with("POST /queries/v1/abort-request")),
+            "expected an abort-request POST, saw: {recorded:?}"
+        );
+        assert!(
+            recorded
+                .iter()
+                .any(|req| req.contains("abort-request") && req.contains("select 1")),
+            "the abort body should name the statement being cancelled"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_async_final_response_within_deadline_succeeds() {
         let executor = executor_with_timeout(
             spawn_scripted_server(vec![
@@ -648,6 +768,7 @@ mod tests {
             query_response_timeout: crate::config::DEFAULT_QUERY_RESPONSE_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime,
+            cancellation: None,
         };
         let response = RawQueryResponse {
             query_id: Arc::from("query-id"),
@@ -691,6 +812,7 @@ mod tests {
             query_response_timeout: crate::config::DEFAULT_QUERY_RESPONSE_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime,
+            cancellation: None,
         };
         let response = RawQueryResponse {
             query_id: Arc::from("query-id"),
@@ -729,6 +851,7 @@ mod tests {
             query_response_timeout: crate::config::DEFAULT_QUERY_RESPONSE_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime,
+            cancellation: None,
         };
         let response = RawQueryResponse {
             query_id: Arc::from("query-id"),


### PR DESCRIPTION
Adds cooperative cancellation for in-flight queries.

**Why send an abort, not just stop polling?** Dropping the client-side poll leaves the statement
running on the warehouse — and credits being consumed. Cancelling via the connector issues an out-of-band
`POST /queries/v1/abort-request` for the statement (the same action the official Snowflake
connectors performs during their `_cancel_query`). Cancellation only covers the **execution phase**
(statement submit + async result poll), which is where warehouse time accrues; it doesn't interrupt
downloading computed result chunks.


```rust
let token = CancellationToken::new();
// hand `token.clone()` to a cancel button / another task, then `token.cancel()`
let result = session
    .query_with_options(sql, QueryOptions::new().with_cancellation_token(token))
    .await;
// on cancel: result is Err with err.is_cancelled() == true
```

**What's added**
- `CancellationToken` — cheap to clone, all clones share one state; `cancel()` is safe from any
  thread. Built on `tokio::sync::Notify` + `AtomicBool`, so **no new dependencies** and no need for
  `tokio`'s `macros` feature (the query future and the cancel signal are raced with a small
  `poll_fn` helper).
- `QueryOptions::with_cancellation_token(token)`.
- `ErrorKind::Cancelled` + `Error::is_cancelled()`; the error carries the query id when known.
- The client-generated `requestId` is now minted in the executor and threaded into `submit`, so the
  abort can reference the original request.