### PR TITLE
Add request ID to MFA password logins

### DIFF
--- a/src/auth/credential.rs
+++ b/src/auth/credential.rs
@@ -59,6 +59,15 @@ impl PreparedLoginCredential {
     }
 
     pub(crate) fn requires_request_id(&self) -> bool {
+        if matches!(
+            self,
+            Self::Password {
+                passcode: Some(_),
+                ..
+            }
+        ) {
+            return true;
+        }
         #[cfg(feature = "external-browser-sso")]
         if matches!(self, Self::ExternalBrowser { .. }) {
             return true;

--- a/src/auth/login.rs
+++ b/src/auth/login.rs
@@ -58,7 +58,7 @@ mod tests {
     use reqwest::Url;
 
     use super::*;
-    use crate::SessionConfig;
+    use crate::{SessionConfig, auth::credential::PreparedPasscode};
 
     fn query_string(query: &LoginQuery<'_>) -> Option<String> {
         reqwest::Client::new()
@@ -92,6 +92,31 @@ mod tests {
         assert_eq!(
             query_string(&request.query).as_deref(),
             Some("warehouse=warehouse")
+        );
+    }
+
+    #[test]
+    fn password_mfa_login_request_includes_request_id() {
+        let session =
+            InitialSessionConfig::from(SessionConfig::default().with_warehouse("warehouse"));
+        let credential = PreparedLoginCredential::Password {
+            password: "secret".to_string(),
+            passcode: Some(PreparedPasscode::Separate("123456".to_string())),
+        };
+        let request = build_login_request(
+            LoginContext {
+                username: "user",
+                account: "account",
+            },
+            &session,
+            &credential,
+        );
+
+        assert!(request.query.request_id.is_some());
+        assert!(
+            query_string(&request.query)
+                .as_deref()
+                .is_some_and(|query| query.starts_with("warehouse=warehouse&request_id="))
         );
     }
 

--- a/src/auth/wire/login_request.rs
+++ b/src/auth/wire/login_request.rs
@@ -75,17 +75,19 @@ impl Serialize for LoginCredentialWire<'_> {
             Self::Password { password, passcode } => {
                 let len = match passcode {
                     None => 1,
-                    Some(PasscodeWire::InPassword) => 2,
-                    Some(PasscodeWire::Separate(_)) => 3,
+                    Some(PasscodeWire::InPassword) => 3,
+                    Some(PasscodeWire::Separate(_)) => 4,
                 };
                 let mut map = serializer.serialize_map(Some(len))?;
                 map.serialize_entry("PASSWORD", password)?;
                 match passcode {
                     None => {}
                     Some(PasscodeWire::InPassword) => {
+                        map.serialize_entry("AUTHENTICATOR", "USERNAME_PASSWORD_MFA")?;
                         map.serialize_entry("EXT_AUTHN_DUO_METHOD", "passcode")?;
                     }
                     Some(PasscodeWire::Separate(code)) => {
+                        map.serialize_entry("AUTHENTICATOR", "USERNAME_PASSWORD_MFA")?;
                         map.serialize_entry("EXT_AUTHN_DUO_METHOD", "passcode")?;
                         map.serialize_entry("PASSCODE", code)?;
                     }
@@ -176,6 +178,7 @@ mod tests {
                     "ACCOUNT_NAME": "account",
                     "LOGIN_NAME": "username",
                     "PASSWORD": "secret",
+                    "AUTHENTICATOR": "USERNAME_PASSWORD_MFA",
                     "EXT_AUTHN_DUO_METHOD": "passcode",
                     "PASSCODE": "123456",
                 }
@@ -205,6 +208,7 @@ mod tests {
                     "ACCOUNT_NAME": "account",
                     "LOGIN_NAME": "username",
                     "PASSWORD": "secret123456",
+                    "AUTHENTICATOR": "USERNAME_PASSWORD_MFA",
                     "EXT_AUTHN_DUO_METHOD": "passcode",
                 }
             })

--- a/src/auth/wire/login_request.rs
+++ b/src/auth/wire/login_request.rs
@@ -75,19 +75,17 @@ impl Serialize for LoginCredentialWire<'_> {
             Self::Password { password, passcode } => {
                 let len = match passcode {
                     None => 1,
-                    Some(PasscodeWire::InPassword) => 3,
-                    Some(PasscodeWire::Separate(_)) => 4,
+                    Some(PasscodeWire::InPassword) => 2,
+                    Some(PasscodeWire::Separate(_)) => 3,
                 };
                 let mut map = serializer.serialize_map(Some(len))?;
                 map.serialize_entry("PASSWORD", password)?;
                 match passcode {
                     None => {}
                     Some(PasscodeWire::InPassword) => {
-                        map.serialize_entry("AUTHENTICATOR", "USERNAME_PASSWORD_MFA")?;
                         map.serialize_entry("EXT_AUTHN_DUO_METHOD", "passcode")?;
                     }
                     Some(PasscodeWire::Separate(code)) => {
-                        map.serialize_entry("AUTHENTICATOR", "USERNAME_PASSWORD_MFA")?;
                         map.serialize_entry("EXT_AUTHN_DUO_METHOD", "passcode")?;
                         map.serialize_entry("PASSCODE", code)?;
                     }
@@ -178,7 +176,6 @@ mod tests {
                     "ACCOUNT_NAME": "account",
                     "LOGIN_NAME": "username",
                     "PASSWORD": "secret",
-                    "AUTHENTICATOR": "USERNAME_PASSWORD_MFA",
                     "EXT_AUTHN_DUO_METHOD": "passcode",
                     "PASSCODE": "123456",
                 }
@@ -208,7 +205,6 @@ mod tests {
                     "ACCOUNT_NAME": "account",
                     "LOGIN_NAME": "username",
                     "PASSWORD": "secret123456",
-                    "AUTHENTICATOR": "USERNAME_PASSWORD_MFA",
                     "EXT_AUTHN_DUO_METHOD": "passcode",
                 }
             })


### PR DESCRIPTION
Snowflake TOTP logins require a `request_id` query parameter. Password MFA credentials currently omit it, causing valid passcodes to be rejected as `TOTP Invalid.`

This adds a request ID when a password credential carries either passcode mode, while preserving existing plain-password behavior.

Verified with unit tests and a live Snowflake TOTP account.