### PR TITLE
feat: add explicit query cancellation API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,3 +169,9 @@ name = "statement_bind"
 required-features = [
     "external-browser-sso",
 ]
+
+[[example]]
+name = "query_cancel"
+required-features = [
+    "external-browser-sso",
+]

--- a/examples/query_cancel.rs
+++ b/examples/query_cancel.rs
@@ -1,0 +1,70 @@
+use std::{env, time::Duration};
+
+use snowflake_connector_rs::{
+    AuthConfig, Client, ClientConfig, ExternalBrowserConfig, QueryCancelStatus, QueryOptions,
+    Session, SessionConfig,
+};
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let session = build_session().await?;
+
+    let query = session.query_handle_with_options(
+        "CALL SYSTEM$WAIT(120)",
+        QueryOptions::new().with_query_cancel_request_timeout(Duration::from_secs(10)),
+    )?;
+
+    let canceller = query.canceller();
+    let execution = tokio::spawn(query.execute());
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let status = canceller.cancel().await?;
+    if status == QueryCancelStatus::NotSubmitted {
+        println!("cancelled before the query was submitted");
+    } else {
+        println!("cancel status: {status:?}");
+    }
+
+    let execution_result = execution.await?;
+    match execution_result {
+        Ok(_cursor) => println!("query completed before the cancel took effect"),
+        Err(error) if error.is_cancelled() => println!("query was cancelled: {error}"),
+        Err(error) => return Err(error.into()),
+    }
+
+    Ok(())
+}
+
+async fn build_session() -> std::result::Result<Session, Box<dyn std::error::Error>> {
+    let username = env::var("SNOWFLAKE_USERNAME")?;
+    let account = env::var("SNOWFLAKE_ACCOUNT")?;
+    let role = env::var("SNOWFLAKE_ROLE").ok();
+    let warehouse = env::var("SNOWFLAKE_WAREHOUSE").ok();
+    let database = env::var("SNOWFLAKE_DATABASE").ok();
+    let schema = env::var("SNOWFLAKE_SCHEMA").ok();
+
+    let mut session_config = SessionConfig::new();
+    if let Some(value) = warehouse {
+        session_config = session_config.with_warehouse(value);
+    }
+    if let Some(value) = database {
+        session_config = session_config.with_database(value);
+    }
+    if let Some(value) = schema {
+        session_config = session_config.with_schema(value);
+    }
+    if let Some(value) = role {
+        session_config = session_config.with_role(value);
+    }
+
+    let client = Client::new(
+        ClientConfig::new(
+            &username,
+            &account,
+            AuthConfig::external_browser(ExternalBrowserConfig::default()),
+        )
+        .with_session(session_config),
+    )?;
+    Ok(client.create_session().await?)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct SessionConfig {
 }
 
 pub(crate) const DEFAULT_QUERY_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
+pub(crate) const DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_COLLECT_PREFETCH_CONCURRENCY: NonZeroUsize =
     NonZeroUsize::new(8).expect("default concurrency is non-zero");
 
@@ -41,6 +42,7 @@ const DEFAULT_COLLECT_PREFETCH_CONCURRENCY: NonZeroUsize =
 #[derive(Clone, Debug)]
 pub struct QueryConfig {
     query_response_timeout: Duration,
+    query_cancel_request_timeout: Duration,
     collect_prefetch_concurrency: NonZeroUsize,
 }
 
@@ -48,6 +50,7 @@ impl Default for QueryConfig {
     fn default() -> Self {
         Self {
             query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             collect_prefetch_concurrency: DEFAULT_COLLECT_PREFETCH_CONCURRENCY,
         }
     }
@@ -229,6 +232,15 @@ impl QueryConfig {
         self
     }
 
+    /// Sets the client-side deadline for an explicit query cancellation request. Defaults to `30s`.
+    ///
+    /// The deadline covers abort request transport, response body reading, and bounded transport retries. It is
+    /// independent of [`Self::with_query_response_timeout`].
+    pub fn with_query_cancel_request_timeout(mut self, timeout: Duration) -> Self {
+        self.query_cancel_request_timeout = timeout;
+        self
+    }
+
     /// Sets the default number of partitions fetched concurrently during collection. Defaults to `8`.
     pub fn with_collect_prefetch_concurrency(mut self, concurrency: NonZeroUsize) -> Self {
         self.collect_prefetch_concurrency = concurrency;
@@ -324,6 +336,7 @@ impl From<SessionConfig> for InitialSessionConfig {
 #[derive(Debug)]
 pub(crate) struct QueryExecutionPolicy {
     query_response_timeout: Duration,
+    query_cancel_request_timeout: Duration,
     collect_prefetch_concurrency: NonZeroUsize,
 }
 
@@ -334,6 +347,9 @@ impl QueryExecutionPolicy {
             query_response_timeout: options
                 .query_response_timeout
                 .unwrap_or(self.query_response_timeout),
+            query_cancel_request_timeout: options
+                .query_cancel_request_timeout
+                .unwrap_or(self.query_cancel_request_timeout),
             collect_prefetch_concurrency: options
                 .collect_prefetch_concurrency
                 .unwrap_or(self.collect_prefetch_concurrency),
@@ -345,6 +361,7 @@ impl QueryExecutionPolicy {
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct QueryExecutionSettings {
     pub(crate) query_response_timeout: Duration,
+    pub(crate) query_cancel_request_timeout: Duration,
     pub(crate) collect_prefetch_concurrency: NonZeroUsize,
 }
 
@@ -352,6 +369,7 @@ impl From<QueryConfig> for QueryExecutionPolicy {
     fn from(config: QueryConfig) -> Self {
         Self {
             query_response_timeout: config.query_response_timeout,
+            query_cancel_request_timeout: config.query_cancel_request_timeout,
             collect_prefetch_concurrency: config.collect_prefetch_concurrency,
         }
     }
@@ -498,6 +516,10 @@ mod tests {
         let policy: QueryExecutionPolicy = QueryConfig::default().into();
         let settings = policy.resolve_options(QueryOptions::default());
         assert_eq!(settings.query_response_timeout, Duration::from_secs(300));
+        assert_eq!(
+            settings.query_cancel_request_timeout,
+            Duration::from_secs(30)
+        );
     }
 
     #[test]
@@ -536,6 +558,27 @@ mod tests {
         );
 
         assert_eq!(settings.query_response_timeout, Duration::from_secs(90));
+        assert_eq!(
+            settings.collect_prefetch_concurrency,
+            NonZeroUsize::new(4).unwrap()
+        );
+    }
+
+    #[test]
+    fn query_options_with_query_cancel_request_timeout_overrides_only_cancel_timeout() {
+        let policy: QueryExecutionPolicy = QueryConfig::default()
+            .with_query_response_timeout(Duration::from_secs(120))
+            .with_collect_prefetch_concurrency(NonZeroUsize::new(4).unwrap())
+            .into();
+        let settings = policy.resolve_options(
+            QueryOptions::default().with_query_cancel_request_timeout(Duration::from_secs(7)),
+        );
+
+        assert_eq!(settings.query_response_timeout, Duration::from_secs(120));
+        assert_eq!(
+            settings.query_cancel_request_timeout,
+            Duration::from_secs(7)
+        );
         assert_eq!(
             settings.collect_prefetch_concurrency,
             NonZeroUsize::new(4).unwrap()

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,10 +23,12 @@ pub use schema::{
 };
 
 pub(crate) use parse::RowsetParseError;
-pub(crate) use query_scoped::{QueryScopedError, QueryScopedRepr, QueryScopedResult};
+pub(crate) use query_scoped::{
+    QueryScopedError, QueryScopedRepr, QueryScopedResult, with_optional_query_id,
+};
 pub(crate) use repr::{
-    AuthError, ConfigError, InternalError, NetworkError, ProtocolError, ServerError,
-    SessionExpiredError, TimeoutError,
+    AuthError, CancelledError, ConfigError, InternalError, NetworkError, ProtocolError,
+    ServerError, SessionExpiredError, TimeoutError,
 };
 
 const VALUE_PREVIEW_MAX_CHARS: usize = 128;
@@ -44,6 +46,7 @@ const JSON_BODY_PREVIEW_MAX_BYTES: usize = 1024;
 ///
 /// - Snowflake-provided fields: [`snowflake_code`](Error::snowflake_code),
 ///   [`snowflake_message`](Error::snowflake_message), [`query_id`](Error::query_id)
+/// - Cancellation failures: [`is_cancelled`](Error::is_cancelled)
 /// - Decode failures: [`as_schema_error`](Error::as_schema_error) for schema validation failures,
 ///   [`as_cell_decode_error`](Error::as_cell_decode_error) for cell conversion failures,
 ///   [`as_custom_plan_error`](Error::as_custom_plan_error) for plan-time failures raised by a hand-written decoder,
@@ -119,6 +122,8 @@ pub enum ErrorKind {
     Network,
     /// Snowflake rejected the request and returned a server-side error message.
     Server,
+    /// A user-requested cancellation prevented submission or terminated the query.
+    Cancelled,
     /// The current session token is no longer valid.
     SessionExpired,
     /// The connector timed out while waiting for a response.
@@ -157,6 +162,7 @@ impl Error {
             Repr::Auth(_) => ErrorKind::Auth,
             Repr::Network { .. } => ErrorKind::Network,
             Repr::Server(_) => ErrorKind::Server,
+            Repr::Cancelled(_) => ErrorKind::Cancelled,
             Repr::SessionExpired(_) => ErrorKind::SessionExpired,
             Repr::Timeout { .. } => ErrorKind::Timeout,
             Repr::Protocol { .. } => ErrorKind::Protocol,
@@ -176,6 +182,7 @@ impl Error {
             Repr::Auth(AuthError::LoginRejected { message }) => message.as_deref(),
             Repr::SessionExpired(SessionExpiredError { message, .. }) => message.as_deref(),
             Repr::Server(ServerError { message, .. }) => message.as_deref(),
+            Repr::Cancelled(CancelledError { message, .. }) => message.as_deref(),
             _ => None,
         }
     }
@@ -185,6 +192,7 @@ impl Error {
         match &*self.repr {
             Repr::SessionExpired(SessionExpiredError { code, .. }) => code.as_deref(),
             Repr::Server(ServerError { code, .. }) => code.as_deref(),
+            Repr::Cancelled(CancelledError { code, .. }) => code.as_deref(),
             _ => None,
         }
     }
@@ -204,6 +212,7 @@ impl Error {
             | Repr::Protocol { query_id, .. }
             | Repr::Internal { query_id, .. } => query_id.as_deref(),
             Repr::Server(ServerError { query_id, .. }) => query_id.as_deref(),
+            Repr::Cancelled(CancelledError { query_id, .. }) => query_id.as_deref(),
             Repr::SessionExpired(SessionExpiredError { query_id, .. }) => query_id.as_deref(),
             _ => None,
         }
@@ -219,6 +228,11 @@ impl Error {
 
     pub fn is_server(&self) -> bool {
         matches!(&*self.repr, Repr::Server(_))
+    }
+
+    /// Reports whether this error is a cancellation, i.e. [`ErrorKind::Cancelled`].
+    pub fn is_cancelled(&self) -> bool {
+        matches!(&*self.repr, Repr::Cancelled(_))
     }
 
     pub fn as_cell_decode_error(&self) -> Option<&CellDecodeError> {
@@ -325,6 +339,12 @@ impl From<NetworkError> for Error {
 impl From<ServerError> for Error {
     fn from(error: ServerError) -> Self {
         Self::new(Repr::Server(error))
+    }
+}
+
+impl From<CancelledError> for Error {
+    fn from(error: CancelledError) -> Self {
+        Self::new(Repr::Cancelled(error))
     }
 }
 
@@ -500,6 +520,20 @@ impl ServerError {
     }
 }
 
+impl CancelledError {
+    pub(crate) fn new(
+        code: Option<String>,
+        message: Option<String>,
+        query_id: Option<Arc<str>>,
+    ) -> Self {
+        Self {
+            code: code.map(String::into_boxed_str),
+            message: message.map(String::into_boxed_str),
+            query_id,
+        }
+    }
+}
+
 impl SessionExpiredError {
     pub(crate) fn new(
         code: Option<String>,
@@ -525,6 +559,10 @@ impl TimeoutError {
 
     pub(crate) fn query() -> Self {
         Self::Query
+    }
+
+    pub(crate) fn query_cancel() -> Self {
+        Self::QueryCancel
     }
 
     #[cfg(feature = "external-browser-sso")]
@@ -743,6 +781,37 @@ mod tests {
         assert_eq!(server_err.snowflake_code(), Some("390100"));
         assert_eq!(server_err.snowflake_message(), None);
         assert_eq!(server_err.to_string(), "Snowflake server error 390100");
+    }
+
+    #[test]
+    fn cancelled_error_exposes_structured_details() {
+        let err: Error = CancelledError::new(
+            Some("000604".to_string()),
+            Some("SQL execution canceled".to_string()),
+            Some(Arc::from("query-id")),
+        )
+        .into();
+
+        assert_eq!(err.kind(), ErrorKind::Cancelled);
+        assert!(err.is_cancelled());
+        assert_eq!(err.snowflake_code(), Some("000604"));
+        assert_eq!(err.snowflake_message(), Some("SQL execution canceled"));
+        assert_eq!(err.query_id(), Some("query-id"));
+        assert_eq!(
+            err.to_string(),
+            "query cancelled: SQL execution canceled (query id: query-id)"
+        );
+    }
+
+    #[test]
+    fn cancelled_error_without_server_fields_has_stable_display() {
+        let err: Error = CancelledError::new(None, None, None).into();
+        assert_eq!(err.kind(), ErrorKind::Cancelled);
+        assert!(err.is_cancelled());
+        assert_eq!(err.to_string(), "query cancelled");
+        assert_eq!(err.snowflake_code(), None);
+        assert_eq!(err.snowflake_message(), None);
+        assert_eq!(err.query_id(), None);
     }
 
     #[test]

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -6,8 +6,8 @@ use std::{
 use super::{
     Error,
     repr::{
-        AuthError, ConfigError, InternalError, NetworkError, ProtocolError, Repr, ServerError,
-        TimeoutError,
+        AuthError, CancelledError, ConfigError, InternalError, NetworkError, ProtocolError, Repr,
+        ServerError, TimeoutError,
     },
 };
 
@@ -79,6 +79,18 @@ impl Display for Error {
                 }
                 Ok(())
             }
+            Repr::Cancelled(CancelledError {
+                message, query_id, ..
+            }) => {
+                f.write_str("query cancelled")?;
+                if let Some(message) = message {
+                    write!(f, ": {message}")?;
+                }
+                if let Some(query_id) = query_id {
+                    write!(f, " (query id: {query_id})")?;
+                }
+                Ok(())
+            }
             Repr::SessionExpired(_) => f.write_str("session expired"),
             Repr::Timeout {
                 error: TimeoutError::Request(_),
@@ -88,6 +100,10 @@ impl Display for Error {
                 error: TimeoutError::Query,
                 ..
             } => f.write_str("timed out waiting for query response"),
+            Repr::Timeout {
+                error: TimeoutError::QueryCancel,
+                ..
+            } => f.write_str("timed out waiting for query cancellation response"),
             #[cfg(feature = "external-browser-sso")]
             Repr::Timeout {
                 error: TimeoutError::BrowserCallback,

--- a/src/error/query_scoped.rs
+++ b/src/error/query_scoped.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use super::{
-    Error, InternalError, NetworkError, ProtocolError, RowsetParseError, ServerError,
-    SessionExpiredError, TimeoutError, repr::Repr,
+    CancelledError, Error, InternalError, NetworkError, ProtocolError, RowsetParseError,
+    ServerError, SessionExpiredError, TimeoutError, repr::Repr,
 };
 
 #[derive(Debug)]
@@ -18,6 +18,7 @@ pub(crate) enum QueryScopedRepr {
     Protocol(ProtocolError),
     Internal(InternalError),
     Server(ServerError),
+    Cancelled(CancelledError),
     SessionExpired(SessionExpiredError),
 }
 
@@ -62,6 +63,12 @@ impl From<QueryScopedError> for Error {
                 }
                 Repr::Server(error)
             }
+            QueryScopedRepr::Cancelled(mut error) => {
+                if error.query_id.is_none() {
+                    error.query_id = Some(query_id);
+                }
+                Repr::Cancelled(error)
+            }
             QueryScopedRepr::SessionExpired(mut error) => {
                 if error.query_id.is_none() {
                     error.query_id = Some(query_id);
@@ -103,6 +110,12 @@ impl From<ServerError> for QueryScopedRepr {
     }
 }
 
+impl From<CancelledError> for QueryScopedRepr {
+    fn from(error: CancelledError) -> Self {
+        Self::Cancelled(error)
+    }
+}
+
 impl From<SessionExpiredError> for QueryScopedRepr {
     fn from(error: SessionExpiredError) -> Self {
         Self::SessionExpired(error)
@@ -112,5 +125,24 @@ impl From<SessionExpiredError> for QueryScopedRepr {
 impl From<RowsetParseError> for QueryScopedRepr {
     fn from(error: RowsetParseError) -> Self {
         Self::Protocol(ProtocolError::RowsetParse(error))
+    }
+}
+
+pub(crate) fn with_optional_query_id(
+    inner: impl Into<QueryScopedRepr>,
+    query_id: Option<Arc<str>>,
+) -> Error {
+    let inner = inner.into();
+    match query_id {
+        Some(query_id) => QueryScopedError::new(query_id, inner).into(),
+        None => match inner {
+            QueryScopedRepr::Network(error) => error.into(),
+            QueryScopedRepr::Timeout(error) => error.into(),
+            QueryScopedRepr::Protocol(error) => error.into(),
+            QueryScopedRepr::Internal(error) => error.into(),
+            QueryScopedRepr::Server(error) => error.into(),
+            QueryScopedRepr::Cancelled(error) => error.into(),
+            QueryScopedRepr::SessionExpired(error) => error.into(),
+        },
     }
 }

--- a/src/error/repr.rs
+++ b/src/error/repr.rs
@@ -14,6 +14,7 @@ pub(crate) enum Repr {
         query_id: Option<Arc<str>>,
     },
     Server(ServerError),
+    Cancelled(CancelledError),
     SessionExpired(SessionExpiredError),
     Timeout {
         error: TimeoutError,
@@ -77,6 +78,13 @@ pub(crate) struct ServerError {
 }
 
 #[derive(Debug)]
+pub(crate) struct CancelledError {
+    pub(crate) code: Option<Box<str>>,
+    pub(crate) message: Option<Box<str>>,
+    pub(crate) query_id: Option<Arc<str>>,
+}
+
+#[derive(Debug)]
 pub(crate) struct SessionExpiredError {
     pub(crate) code: Option<Box<str>>,
     pub(crate) message: Option<Box<str>>,
@@ -87,6 +95,7 @@ pub(crate) struct SessionExpiredError {
 pub(crate) enum TimeoutError {
     Request(reqwest::Error),
     Query,
+    QueryCancel,
     #[cfg(feature = "external-browser-sso")]
     BrowserCallback,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub use result_table::{
 use runtime::QueryRuntime;
 pub use session::{QueryOptions, Session};
 pub use statement::builder::{IntoStatement, NamedBinds, PositionalBinds, Statement, UnboundBinds};
+pub use statement::{QueryCancelStatus, QueryCanceller, QueryHandle};
 
 #[cfg(feature = "derive")]
 pub use snowflake_connector_rs_derive::FromRow;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,10 +1,12 @@
 use std::{fmt, num::NonZeroUsize, sync::Arc, time::Duration};
 
+use uuid::Uuid;
+
 use crate::{
     ClientShared, IntoStatement, Result,
     result_cursor::{ResultCursor, TypedResultCursor},
-    result_table::{FromRow, RowPlanContext},
-    statement::{StatementExecutor, builder::into_statement_parts},
+    result_table::FromRow,
+    statement::{QueryControl, QueryHandle, StatementExecutor, builder::into_statement_parts},
 };
 
 pub struct Session {
@@ -12,14 +14,15 @@ pub struct Session {
     pub(crate) auth: Arc<SessionAuth>,
 }
 
-/// Per-query overrides for a single [`Session::query_with_options`] /
-/// [`Session::query_as_with_options`] call.
+/// Per-query overrides for a single [`Session::query_with_options`] / [`Session::query_as_with_options`] /
+/// [`Session::query_handle_with_options`] call.
 ///
 /// Unset options inherit the defaults from [`QueryConfig`](crate::QueryConfig). These options sit between the
 /// client-wide query defaults and per-collect [`CollectOptions`](crate::CollectOptions).
 #[derive(Clone, Debug, Default)]
 pub struct QueryOptions {
     pub(crate) query_response_timeout: Option<Duration>,
+    pub(crate) query_cancel_request_timeout: Option<Duration>,
     pub(crate) collect_prefetch_concurrency: Option<NonZeroUsize>,
 }
 
@@ -32,6 +35,13 @@ impl QueryOptions {
     /// this query.
     pub fn with_query_response_timeout(mut self, timeout: Duration) -> Self {
         self.query_response_timeout = Some(timeout);
+        self
+    }
+
+    /// Overrides [`QueryConfig::with_query_cancel_request_timeout`](crate::QueryConfig::with_query_cancel_request_timeout)
+    /// for this query's explicit cancellation requests.
+    pub fn with_query_cancel_request_timeout(mut self, timeout: Duration) -> Self {
+        self.query_cancel_request_timeout = Some(timeout);
         self
     }
 
@@ -100,9 +110,9 @@ impl Session {
     where
         S: IntoStatement,
     {
-        let settings = self.shared.query.resolve_options(options);
-        let executor = StatementExecutor::new(self, settings);
-        executor.execute(into_statement_parts(statement)).await
+        self.query_handle_with_options(statement, options)?
+            .execute()
+            .await
     }
 
     /// Submit a statement and return a typed `ResultCursor` for streaming partition access.
@@ -144,8 +154,632 @@ impl Session {
         T: FromRow,
         S: IntoStatement,
     {
-        let result = self.query_with_options(statement, options).await?;
-        let plan = T::build_plan(RowPlanContext::new(result.shared_schema()))?;
-        Ok(TypedResultCursor::new(result, plan))
+        self.query_handle_with_options(statement, options)?
+            .execute_as::<T>()
+            .await
+    }
+
+    /// Create a query whose execution can be cancelled explicitly.
+    ///
+    /// Use this instead of [`Session::query`] when a running query may have to be cancelled: dropping a query future
+    /// never cancels the query on Snowflake, so explicit cancellation requires retaining a
+    /// [`QueryCanceller`](crate::QueryCanceller) via [`QueryHandle::canceller`](crate::QueryHandle::canceller) before
+    /// driving [`QueryHandle::execute`]. The canceller then aborts the query from any task, independently of the
+    /// execution future. If you never need to cancel, [`Session::query`] is equivalent and simpler.
+    ///
+    /// No HTTP request is sent until [`QueryHandle::execute`] is polled.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ErrorKind::BindEncode` when bind values cannot be validated before the request is sent.
+    pub fn query_handle<S: IntoStatement>(&self, statement: S) -> Result<QueryHandle> {
+        self.query_handle_with_options(statement, QueryOptions::default())
+    }
+
+    /// Create a query whose execution can be cancelled explicitly, with per-query [`QueryOptions`].
+    ///
+    /// Unset options inherit the configured [`QueryConfig`](crate::QueryConfig) defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Session::query_handle`].
+    pub fn query_handle_with_options<S>(
+        &self,
+        statement: S,
+        options: QueryOptions,
+    ) -> Result<QueryHandle>
+    where
+        S: IntoStatement,
+    {
+        let parts = into_statement_parts(statement)?;
+        let settings = self.shared.query.resolve_options(options);
+        let query_request_id = Arc::from(Uuid::new_v4().to_string());
+        let control = QueryControl::new(query_request_id);
+        let executor = StatementExecutor::new(self, settings);
+        Ok(QueryHandle::new(parts, executor, control))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use reqwest::Url;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+        sync::oneshot,
+        time::timeout,
+    };
+
+    use super::*;
+    use crate::{
+        ClientShared, ErrorKind, QueryCancelStatus, QueryConfig, Statement, runtime::QueryRuntime,
+    };
+
+    fn test_session(base_url: Url) -> Session {
+        test_session_with_config(base_url, QueryConfig::default())
+    }
+
+    fn test_session_with_config(base_url: Url, config: QueryConfig) -> Session {
+        Session {
+            shared: ClientShared::for_test_with(
+                reqwest::Client::new(),
+                base_url,
+                config.into(),
+                QueryRuntime::new(),
+            ),
+            auth: SessionAuth::for_test("test-token"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_before_execute_sends_neither_query_nor_abort() {
+        let session = test_session(Url::parse("http://127.0.0.1:1/").unwrap());
+        let handle = session.query_handle("SELECT 1").unwrap();
+        let canceller = handle.canceller();
+
+        assert_eq!(
+            handle.request_id(),
+            canceller.request_id(),
+            "handle and canceller must share the request identity"
+        );
+        assert_eq!(
+            canceller.cancel().await.unwrap(),
+            QueryCancelStatus::NotSubmitted
+        );
+
+        let error = handle.execute().await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Cancelled);
+        assert!(error.is_cancelled());
+        assert_eq!(error.snowflake_code(), None);
+        assert_eq!(error.snowflake_message(), None);
+        assert_eq!(error.query_id(), None);
+    }
+
+    #[tokio::test]
+    async fn cancel_after_submit_returns_accepted_and_execution_is_cancelled() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            let query_request = read_http_request(&mut query_socket).await;
+            query_ready_tx.send(query_request.clone()).unwrap();
+
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            let abort_request = read_http_request(&mut abort_socket).await;
+            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            write_http_response(
+                &mut query_socket,
+                200,
+                r#"{"code":"000604","message":"SQL execution canceled","success":false,"data":{"queryId":"query-id"}}"#,
+            )
+            .await;
+            (query_request, abort_request)
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let request_id = handle.request_id().to_owned();
+        let canceller = handle.canceller();
+        let execution = tokio::spawn(handle.execute());
+
+        let _query_request = query_ready_rx.await.unwrap();
+        let outcome = canceller.cancel().await.unwrap();
+        let error = execution.await.unwrap().unwrap_err();
+        let (query_request, abort_request) = server.await.unwrap();
+
+        assert_eq!(outcome, QueryCancelStatus::Accepted);
+        assert_eq!(error.kind(), ErrorKind::Cancelled);
+        assert_eq!(error.snowflake_code(), Some("000604"));
+        assert_eq!(error.snowflake_message(), Some("SQL execution canceled"));
+        assert_eq!(error.query_id(), Some("query-id"));
+
+        let query_target = query_request.split_whitespace().nth(1).unwrap();
+        let query_url = Url::parse(&format!("http://localhost{query_target}")).unwrap();
+        assert_eq!(
+            query_url
+                .query_pairs()
+                .find_map(|(key, value)| (key == "requestId").then(|| value.into_owned()))
+                .as_deref(),
+            Some(request_id.as_str())
+        );
+        assert_eq!(
+            abort_request.split("\r\n\r\n").nth(1).unwrap(),
+            format!(r#"{{"requestId":"{request_id}"}}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn canceller_can_abort_after_execution_future_is_dropped() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            let query_request = read_http_request(&mut query_socket).await;
+            query_ready_tx.send(()).unwrap();
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            let abort_request = read_http_request(&mut abort_socket).await;
+            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            (query_request, abort_request)
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let canceller = handle.canceller();
+        let task = tokio::spawn(handle.execute());
+        query_ready_rx.await.unwrap();
+        task.abort();
+        let _ = task.await;
+
+        let outcome = canceller.cancel().await.unwrap();
+        assert_eq!(outcome, QueryCancelStatus::Accepted);
+        let (_query_request, abort_request) = server.await.unwrap();
+        assert!(abort_request.contains(r#"{"requestId":""#));
+    }
+
+    #[tokio::test]
+    async fn finished_query_cancel_is_local_and_does_not_send_abort() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let _request = read_http_request(&mut socket).await;
+            write_http_response(
+                &mut socket,
+                200,
+                r#"{"success":true,"data":{"queryId":"query-id","rowset":[],"rowtype":[],"queryResultFormat":"json"}}"#,
+            )
+            .await;
+            timeout(Duration::from_millis(200), listener.accept())
+                .await
+                .is_err()
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT 1").unwrap();
+        let canceller = handle.canceller();
+        let _cursor = handle.execute().await.unwrap();
+
+        assert_eq!(
+            canceller.cancel().await.unwrap(),
+            QueryCancelStatus::AlreadyFinished
+        );
+        assert!(server.await.unwrap());
+    }
+
+    #[test]
+    fn query_handle_validates_named_bind_keys_synchronously() {
+        let session = test_session(Url::parse("http://127.0.0.1:1/").unwrap());
+        let error = match session.query_handle(Statement::new("SELECT :id").bind_named("", 1_i64)) {
+            Ok(_) => panic!("empty bind names must fail synchronously"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), ErrorKind::BindEncode);
+    }
+
+    const CANCELLED_QUERY_RESPONSE: &str = r#"{"code":"000604","sqlState":"57014","message":"SQL execution canceled","success":false,"data":{"queryId":"query-id"}}"#;
+
+    fn abort_request_id(request: &str) -> String {
+        let target = request.split_whitespace().nth(1).unwrap();
+        Url::parse(&format!("http://localhost{target}"))
+            .unwrap()
+            .query_pairs()
+            .find_map(|(key, value)| (key == "requestId").then(|| value.into_owned()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn concurrent_cancel_sends_a_single_abort() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut query_socket).await;
+            query_ready_tx.send(()).unwrap();
+
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut abort_socket).await;
+            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+
+            // The first accepted abort caches its outcome, so a concurrent caller must not open a second connection.
+            let no_second_abort = timeout(Duration::from_millis(200), listener.accept())
+                .await
+                .is_err();
+            write_http_response(&mut query_socket, 200, CANCELLED_QUERY_RESPONSE).await;
+            no_second_abort
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let canceller_a = handle.canceller();
+        let canceller_b = handle.canceller();
+        let execution = tokio::spawn(handle.execute());
+
+        query_ready_rx.await.unwrap();
+        let (first, second) = tokio::join!(canceller_a.cancel(), canceller_b.cancel());
+        assert_eq!(first.unwrap(), QueryCancelStatus::Accepted);
+        assert_eq!(second.unwrap(), QueryCancelStatus::Accepted);
+
+        let error = execution.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Cancelled);
+        assert!(
+            server.await.unwrap(),
+            "single-flight must send exactly one abort for concurrent cancels"
+        );
+    }
+
+    #[tokio::test]
+    async fn public_cancel_retry_uses_a_fresh_request_id_after_a_failed_attempt() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut query_socket).await;
+            query_ready_tx.send(()).unwrap();
+
+            let (mut first_abort, _) = listener.accept().await.unwrap();
+            let first_request = read_http_request(&mut first_abort).await;
+            write_http_response(&mut first_abort, 400, r#"{"error":"bad request"}"#).await;
+
+            let (mut second_abort, _) = listener.accept().await.unwrap();
+            let second_request = read_http_request(&mut second_abort).await;
+            write_http_response(&mut second_abort, 200, r#"{"success":true}"#).await;
+
+            write_http_response(&mut query_socket, 200, CANCELLED_QUERY_RESPONSE).await;
+            (first_request, second_request)
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let request_id = handle.request_id().to_owned();
+        let canceller = handle.canceller();
+        let execution = tokio::spawn(handle.execute());
+
+        query_ready_rx.await.unwrap();
+        // A non-retryable abort failure must not cache success, so the next explicit call retries with a new id.
+        assert_eq!(
+            canceller.cancel().await.unwrap_err().kind(),
+            ErrorKind::Network
+        );
+        assert_eq!(
+            canceller.cancel().await.unwrap(),
+            QueryCancelStatus::Accepted
+        );
+
+        let error = execution.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Cancelled);
+
+        let (first_request, second_request) = server.await.unwrap();
+        assert_ne!(
+            abort_request_id(&first_request),
+            abort_request_id(&second_request),
+            "each explicit cancel call must use a fresh cancel-request-id"
+        );
+        let expected_body = format!(r#"{{"requestId":"{request_id}"}}"#);
+        assert_eq!(
+            first_request.split("\r\n\r\n").nth(1).unwrap(),
+            expected_body,
+            "the abort body must keep targeting the original query-request-id"
+        );
+        assert_eq!(
+            second_request.split("\r\n\r\n").nth(1).unwrap(),
+            expected_body
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_the_cancel_future_issues_no_further_abort() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut query_socket).await;
+            query_ready_tx.send(()).unwrap();
+
+            // Accept the one abort and never answer it; the client drops the future while still awaiting the response.
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut abort_socket).await;
+
+            let no_retry = timeout(Duration::from_millis(300), listener.accept())
+                .await
+                .is_err();
+            drop(abort_socket);
+            drop(query_socket);
+            no_retry
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let canceller = handle.canceller();
+        let execution = tokio::spawn(handle.execute());
+
+        query_ready_rx.await.unwrap();
+        let dropped = timeout(Duration::from_millis(150), canceller.cancel()).await;
+        assert!(
+            dropped.is_err(),
+            "cancel must still be awaiting the unanswered abort when dropped"
+        );
+
+        assert!(
+            server.await.unwrap(),
+            "a dropped cancel future must not leave a background retry running"
+        );
+        execution.abort();
+        let _ = execution.await;
+    }
+
+    const SUCCESS_QUERY_RESPONSE: &str = r#"{"success":true,"data":{"queryId":"query-id","rowset":[],"rowtype":[],"queryResultFormat":"json"}}"#;
+
+    #[tokio::test]
+    async fn cancel_after_response_timeout_still_sends_abort() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            // Accept the query but never answer it, so the client-side query-response deadline elapses and the
+            // execution guard drops into `OutcomeUnknown`.
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut query_socket).await;
+
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            let abort_request = read_http_request(&mut abort_socket).await;
+            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            drop(query_socket);
+            abort_request
+        });
+
+        let session = test_session_with_config(
+            Url::parse(&format!("http://{addr}/")).unwrap(),
+            QueryConfig::default().with_query_response_timeout(Duration::from_millis(150)),
+        );
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let request_id = handle.request_id().to_owned();
+        let canceller = handle.canceller();
+
+        let error = handle.execute().await.unwrap_err();
+        assert_eq!(
+            error.kind(),
+            ErrorKind::Timeout,
+            "the unanswered submit must time out"
+        );
+
+        // The dropped guard left the query in `OutcomeUnknown`, so the retained canceller must still send an abort.
+        assert_eq!(
+            canceller.cancel().await.unwrap(),
+            QueryCancelStatus::Accepted
+        );
+        let abort_request = server.await.unwrap();
+        assert_eq!(
+            abort_request.split("\r\n\r\n").nth(1).unwrap(),
+            format!(r#"{{"requestId":"{request_id}"}}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn normal_completion_after_cancel_intent_yields_result_and_accepted() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut query_socket).await;
+            query_ready_tx.send(()).unwrap();
+
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut abort_socket).await;
+
+            // The query completes successfully before its abort is answered: a recorded cancel intent must not turn a
+            // non-cancellation terminal response into a `Cancelled` error.
+            write_http_response(&mut query_socket, 200, SUCCESS_QUERY_RESPONSE).await;
+            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let canceller = handle.canceller();
+        let execution = tokio::spawn(handle.execute());
+
+        query_ready_rx.await.unwrap();
+        let outcome = canceller.cancel().await.unwrap();
+        let cursor = execution.await.unwrap();
+
+        assert_eq!(outcome, QueryCancelStatus::Accepted);
+        assert!(
+            cursor.is_ok(),
+            "a successful terminal response must build a cursor despite the cancel intent"
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_intent_does_not_cancel_a_successful_response_carrying_a_marker() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut query_socket).await;
+            query_ready_tx.send(()).unwrap();
+
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut abort_socket).await;
+            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+
+            // A `success:true` payload is authoritative even when it carries a cancellation code, so the cancel intent
+            // must not discard it as a `Cancelled` error.
+            write_http_response(
+                &mut query_socket,
+                200,
+                r#"{"code":"000604","success":true,"data":{"queryId":"query-id","rowset":[],"rowtype":[],"queryResultFormat":"json"}}"#,
+            )
+            .await;
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let canceller = handle.canceller();
+        let execution = tokio::spawn(handle.execute());
+
+        query_ready_rx.await.unwrap();
+        assert_eq!(
+            canceller.cancel().await.unwrap(),
+            QueryCancelStatus::Accepted
+        );
+
+        let cursor = execution.await.unwrap();
+        assert!(
+            cursor.is_ok(),
+            "a successful marked response must build a cursor, not a Cancelled error"
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancellation_recognized_from_sql_state_only_terminal_response() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut query_socket).await;
+            query_ready_tx.send(()).unwrap();
+
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut abort_socket).await;
+            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+
+            // No top-level `code`; cancellation is signaled only through `sqlState`.
+            write_http_response(
+                &mut query_socket,
+                200,
+                r#"{"sqlState":"57014","message":"SQL execution canceled","success":false,"data":{"queryId":"query-id"}}"#,
+            )
+            .await;
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let canceller = handle.canceller();
+        let execution = tokio::spawn(handle.execute());
+
+        query_ready_rx.await.unwrap();
+        assert_eq!(
+            canceller.cancel().await.unwrap(),
+            QueryCancelStatus::Accepted
+        );
+
+        let error = execution.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Cancelled);
+        assert!(error.is_cancelled());
+        assert_eq!(
+            error.snowflake_code(),
+            None,
+            "a sqlState-only response carries no Snowflake code"
+        );
+        assert_eq!(error.snowflake_message(), Some("SQL execution canceled"));
+        assert_eq!(error.query_id(), Some("query-id"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn abort_session_expired_response_is_session_expired_error() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (query_ready_tx, query_ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut query_socket).await;
+            query_ready_tx.send(()).unwrap();
+
+            let (mut abort_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut abort_socket).await;
+            write_http_response(
+                &mut abort_socket,
+                200,
+                r#"{"success":false,"code":"390112","message":"session expired"}"#,
+            )
+            .await;
+            drop(query_socket);
+        });
+
+        let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
+        let handle = session.query_handle("SELECT SYSTEM$WAIT(120)").unwrap();
+        let canceller = handle.canceller();
+        let execution = tokio::spawn(handle.execute());
+
+        query_ready_rx.await.unwrap();
+        let error = canceller.cancel().await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::SessionExpired);
+        assert_eq!(error.snowflake_code(), Some("390112"));
+
+        execution.abort();
+        let _ = execution.await;
+        server.await.unwrap();
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        let mut bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let body_start;
+        let body_length;
+
+        loop {
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "connection closed before request completed");
+            bytes.extend_from_slice(&chunk[..read]);
+            if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                body_start = index + 4;
+                let headers = String::from_utf8_lossy(&bytes[..index]);
+                body_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.strip_prefix("content-length:")
+                            .or_else(|| line.strip_prefix("Content-Length:"))
+                    })
+                    .and_then(|value| value.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                break;
+            }
+        }
+
+        while bytes.len() < body_start + body_length {
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "connection closed before request body completed");
+            bytes.extend_from_slice(&chunk[..read]);
+        }
+        String::from_utf8(bytes).unwrap()
+    }
+
+    async fn write_http_response(socket: &mut tokio::net::TcpStream, status: u16, body: &str) {
+        let response = format!(
+            "HTTP/1.1 {status} OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
     }
 }

--- a/src/statement/bind.rs
+++ b/src/statement/bind.rs
@@ -119,7 +119,7 @@ impl Bind {
 ///
 /// Pass the bare name (without the leading `:`): use `"id"` for `:id` and `"1"` for `:1`. The name is sent to Snowflake
 /// verbatim — leading colons and other characters are not stripped or normalized. Empty names are rejected when the statement
-/// is submitted.
+/// is passed to a query method.
 ///
 /// Built from `&'static str` or `String` via [`From`].
 ///

--- a/src/statement/builder.rs
+++ b/src/statement/builder.rs
@@ -6,6 +6,8 @@ use std::borrow::Cow;
 
 use indexmap::IndexMap;
 
+use crate::{Error, Result};
+
 use super::bind::{Bind, BindName, IntoBind, encode_bind};
 
 /// Typestate marker for a [`Statement`] with no binds attached yet.
@@ -125,7 +127,7 @@ impl Statement<UnboundBinds> {
     /// Adds a named bind, transitioning to [`NamedBinds`] mode.
     ///
     /// Pass the bare placeholder name (no leading `:`): `"id"` matches `:id`, `"1"` matches `:1`. The name is sent verbatim.
-    /// Empty names are rejected when the statement is submitted.
+    /// Empty names are rejected when the statement is passed to a query method.
     ///
     /// # Examples
     ///
@@ -300,18 +302,17 @@ pub trait IntoStatement: into_statement_sealed::Sealed {}
 
 mod into_statement_sealed {
     pub trait Sealed {
-        fn into_statement_parts(self) -> super::StatementParts;
+        fn into_statement_parts(self) -> crate::Result<super::StatementParts>;
     }
 }
 
-pub(crate) fn into_statement_parts<S>(statement: S) -> StatementParts
+pub(crate) fn into_statement_parts<S>(statement: S) -> Result<StatementParts>
 where
     S: IntoStatement,
 {
     <S as into_statement_sealed::Sealed>::into_statement_parts(statement)
 }
 
-#[doc(hidden)]
 #[derive(Debug)]
 pub(crate) struct StatementParts(StatementPartsRepr);
 
@@ -347,46 +348,55 @@ impl StatementParts {
 impl IntoStatement for &'static str {}
 
 impl into_statement_sealed::Sealed for &'static str {
-    fn into_statement_parts(self) -> StatementParts {
-        StatementParts(StatementPartsRepr::Unbound { sql: self.into() })
+    fn into_statement_parts(self) -> Result<StatementParts> {
+        Ok(StatementParts(StatementPartsRepr::Unbound {
+            sql: self.into(),
+        }))
     }
 }
 
 impl IntoStatement for String {}
 
 impl into_statement_sealed::Sealed for String {
-    fn into_statement_parts(self) -> StatementParts {
-        StatementParts(StatementPartsRepr::Unbound { sql: self.into() })
+    fn into_statement_parts(self) -> Result<StatementParts> {
+        Ok(StatementParts(StatementPartsRepr::Unbound {
+            sql: self.into(),
+        }))
     }
 }
 
 impl IntoStatement for Statement<UnboundBinds> {}
 
 impl into_statement_sealed::Sealed for Statement<UnboundBinds> {
-    fn into_statement_parts(self) -> StatementParts {
-        StatementParts(StatementPartsRepr::Unbound { sql: self.sql })
+    fn into_statement_parts(self) -> Result<StatementParts> {
+        Ok(StatementParts(StatementPartsRepr::Unbound {
+            sql: self.sql,
+        }))
     }
 }
 
 impl IntoStatement for Statement<PositionalBinds> {}
 
 impl into_statement_sealed::Sealed for Statement<PositionalBinds> {
-    fn into_statement_parts(self) -> StatementParts {
-        StatementParts(StatementPartsRepr::Positional {
+    fn into_statement_parts(self) -> Result<StatementParts> {
+        Ok(StatementParts(StatementPartsRepr::Positional {
             sql: self.sql,
             bindings: self.bindings.0,
-        })
+        }))
     }
 }
 
 impl IntoStatement for Statement<NamedBinds> {}
 
 impl into_statement_sealed::Sealed for Statement<NamedBinds> {
-    fn into_statement_parts(self) -> StatementParts {
-        StatementParts(StatementPartsRepr::Named {
+    fn into_statement_parts(self) -> Result<StatementParts> {
+        if self.bindings.0.keys().any(BindName::is_empty) {
+            return Err(Error::bind_encode("bind name must not be empty"));
+        }
+        Ok(StatementParts(StatementPartsRepr::Named {
             sql: self.sql,
             bindings: self.bindings.0,
-        })
+        }))
     }
 }
 
@@ -411,7 +421,7 @@ mod tests {
         let statement = Statement::from("SELECT 1");
         assert_eq!(statement.sql(), "SELECT 1");
 
-        match into_statement_parts(statement).repr() {
+        match into_statement_parts(statement).unwrap().repr() {
             StatementPartsRepr::Unbound { sql } => {
                 assert!(matches!(sql, Cow::Borrowed("SELECT 1")));
             }
@@ -423,7 +433,7 @@ mod tests {
     fn positional_statement_parts_preserve_bind_order_and_typed_values() {
         let statement = Statement::new("SELECT ?, ?").bind(1_i64).bind("hi");
 
-        match into_statement_parts(statement).repr() {
+        match into_statement_parts(statement).unwrap().repr() {
             StatementPartsRepr::Positional { sql, bindings } => {
                 assert!(matches!(sql, Cow::Borrowed("SELECT ?, ?")));
                 assert_eq!(bindings.len(), 2);
@@ -438,12 +448,24 @@ mod tests {
     }
 
     #[test]
+    fn named_statement_with_empty_bind_name_fails_conversion() {
+        let statement = Statement::new("SELECT :id").bind_named("", 1_i64);
+
+        let err = into_statement_parts(statement).unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::BindEncode);
+        assert_eq!(
+            err.to_string(),
+            "bind encode error: bind name must not be empty"
+        );
+    }
+
+    #[test]
     fn named_statement_last_wins_for_duplicate_keys() {
         let statement = Statement::new("SELECT :id")
             .bind_named("id", 1_i64)
             .bind_named("id", 2_i64);
 
-        match into_statement_parts(statement).repr() {
+        match into_statement_parts(statement).unwrap().repr() {
             StatementPartsRepr::Named { sql, bindings } => {
                 assert!(matches!(sql, Cow::Borrowed("SELECT :id")));
                 assert_eq!(bindings.len(), 1);
@@ -458,8 +480,8 @@ mod tests {
     #[test]
     fn statement_clone_allows_reuse() {
         let statement = Statement::new("SELECT ?").bind(1_i64);
-        let first = into_statement_parts(statement.clone());
-        let second = into_statement_parts(statement);
+        let first = into_statement_parts(statement.clone()).unwrap();
+        let second = into_statement_parts(statement).unwrap();
 
         for parts in [&first, &second] {
             match parts.repr() {

--- a/src/statement/cancel.rs
+++ b/src/statement/cancel.rs
@@ -1,0 +1,297 @@
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard};
+
+use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
+
+use super::handle::QueryCancelStatus;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExecutionPhase {
+    Prepared,
+    InFlight,
+    OutcomeUnknown,
+    Finished,
+    CancelledBeforeSubmit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SuccessfulCancel {
+    NotSubmitted,
+    Accepted,
+}
+
+#[derive(Debug)]
+struct ControlState {
+    execution: ExecutionPhase,
+    query_id: Option<Arc<str>>,
+    cancel_intent: bool,
+    successful_cancel: Option<SuccessfulCancel>,
+}
+
+#[derive(Debug)]
+pub(crate) struct QueryRequestIdentity {
+    query_request_id: Arc<str>,
+}
+
+impl QueryRequestIdentity {
+    pub(crate) fn new(query_request_id: Arc<str>) -> Self {
+        Self { query_request_id }
+    }
+
+    pub(crate) fn request_id(&self) -> &str {
+        &self.query_request_id
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct QueryControl {
+    identity: QueryRequestIdentity,
+    state: StdMutex<ControlState>,
+    cancel_gate: TokioMutex<()>,
+}
+
+pub(crate) enum SubmissionDecision {
+    Start(ExecutionGuard),
+    CancelledBeforeSubmit,
+    AlreadyStarted,
+}
+
+pub(crate) enum CancelDecision {
+    Return(QueryCancelStatus),
+    SendAbort,
+}
+
+impl QueryControl {
+    pub(crate) fn new(query_request_id: Arc<str>) -> Arc<Self> {
+        Arc::new(Self {
+            identity: QueryRequestIdentity::new(query_request_id),
+            state: StdMutex::new(ControlState {
+                execution: ExecutionPhase::Prepared,
+                query_id: None,
+                cancel_intent: false,
+                successful_cancel: None,
+            }),
+            cancel_gate: TokioMutex::new(()),
+        })
+    }
+
+    pub(crate) fn query_request_id(&self) -> &str {
+        self.identity.request_id()
+    }
+
+    pub(crate) async fn lock_cancel_gate(&self) -> TokioMutexGuard<'_, ()> {
+        self.cancel_gate.lock().await
+    }
+
+    pub(crate) fn begin_submission(self: &Arc<Self>) -> SubmissionDecision {
+        let mut state = self.lock_state();
+        match state.execution {
+            ExecutionPhase::Prepared => {
+                state.execution = ExecutionPhase::InFlight;
+                SubmissionDecision::Start(ExecutionGuard {
+                    control: Arc::clone(self),
+                    terminal: false,
+                })
+            }
+            ExecutionPhase::CancelledBeforeSubmit => SubmissionDecision::CancelledBeforeSubmit,
+            ExecutionPhase::InFlight
+            | ExecutionPhase::OutcomeUnknown
+            | ExecutionPhase::Finished => SubmissionDecision::AlreadyStarted,
+        }
+    }
+
+    pub(crate) fn begin_cancel_attempt(&self) -> CancelDecision {
+        let mut state = self.lock_state();
+
+        if let Some(outcome) = state.successful_cancel {
+            return CancelDecision::Return(match outcome {
+                SuccessfulCancel::NotSubmitted => QueryCancelStatus::NotSubmitted,
+                SuccessfulCancel::Accepted => QueryCancelStatus::Accepted,
+            });
+        }
+
+        match state.execution {
+            ExecutionPhase::Prepared => {
+                state.execution = ExecutionPhase::CancelledBeforeSubmit;
+                state.successful_cancel = Some(SuccessfulCancel::NotSubmitted);
+                CancelDecision::Return(QueryCancelStatus::NotSubmitted)
+            }
+            ExecutionPhase::CancelledBeforeSubmit => {
+                state.successful_cancel = Some(SuccessfulCancel::NotSubmitted);
+                CancelDecision::Return(QueryCancelStatus::NotSubmitted)
+            }
+            ExecutionPhase::Finished => CancelDecision::Return(QueryCancelStatus::AlreadyFinished),
+            ExecutionPhase::InFlight | ExecutionPhase::OutcomeUnknown => {
+                state.cancel_intent = true;
+                CancelDecision::SendAbort
+            }
+        }
+    }
+
+    pub(crate) fn record_abort_accepted(&self) {
+        let mut state = self.lock_state();
+        state.successful_cancel = Some(SuccessfulCancel::Accepted);
+    }
+
+    pub(crate) fn mark_outcome_unknown(&self) {
+        let mut state = self.lock_state();
+        if state.execution == ExecutionPhase::InFlight {
+            state.execution = ExecutionPhase::OutcomeUnknown;
+        }
+    }
+
+    pub(crate) fn mark_terminal(&self) {
+        let mut state = self.lock_state();
+        if matches!(
+            state.execution,
+            ExecutionPhase::InFlight | ExecutionPhase::OutcomeUnknown
+        ) {
+            state.execution = ExecutionPhase::Finished;
+        }
+    }
+
+    pub(crate) fn record_query_id(&self, query_id: Arc<str>) {
+        self.lock_state().query_id = Some(query_id);
+    }
+
+    pub(crate) fn query_id(&self) -> Option<Arc<str>> {
+        self.lock_state().query_id.clone()
+    }
+
+    pub(crate) fn cancel_intent(&self) -> bool {
+        self.lock_state().cancel_intent
+    }
+
+    pub(crate) fn execution_phase(&self) -> ExecutionPhase {
+        self.lock_state().execution
+    }
+
+    fn lock_state(&self) -> StdMutexGuard<'_, ControlState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+pub(crate) struct ExecutionGuard {
+    control: Arc<QueryControl>,
+    terminal: bool,
+}
+
+impl ExecutionGuard {
+    pub(crate) fn record_query_id(&self, query_id: Arc<str>) {
+        self.control.record_query_id(query_id);
+    }
+
+    pub(crate) fn mark_terminal(&mut self) {
+        self.control.mark_terminal();
+        self.terminal = true;
+    }
+}
+
+impl Drop for ExecutionGuard {
+    fn drop(&mut self) {
+        if !self.terminal {
+            self.control.mark_outcome_unknown();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn control() -> Arc<QueryControl> {
+        QueryControl::new(Arc::from("query-request-id"))
+    }
+
+    #[test]
+    fn cancel_before_submission_prevents_start_and_is_cached() {
+        let control = control();
+
+        assert!(matches!(
+            control.begin_cancel_attempt(),
+            CancelDecision::Return(QueryCancelStatus::NotSubmitted)
+        ));
+        assert_eq!(
+            control.execution_phase(),
+            ExecutionPhase::CancelledBeforeSubmit
+        );
+        assert!(matches!(
+            control.begin_submission(),
+            SubmissionDecision::CancelledBeforeSubmit
+        ));
+        assert!(matches!(
+            control.begin_cancel_attempt(),
+            CancelDecision::Return(QueryCancelStatus::NotSubmitted)
+        ));
+    }
+
+    #[test]
+    fn submission_wins_and_guard_drop_marks_outcome_unknown() {
+        let control = control();
+        let guard = match control.begin_submission() {
+            SubmissionDecision::Start(guard) => guard,
+            _ => panic!("submission should start"),
+        };
+
+        assert_eq!(control.execution_phase(), ExecutionPhase::InFlight);
+        assert!(matches!(
+            control.begin_cancel_attempt(),
+            CancelDecision::SendAbort
+        ));
+        assert!(control.cancel_intent());
+        drop(guard);
+        assert_eq!(control.execution_phase(), ExecutionPhase::OutcomeUnknown);
+        assert!(matches!(
+            control.begin_cancel_attempt(),
+            CancelDecision::SendAbort
+        ));
+    }
+
+    #[test]
+    fn terminal_execution_returns_already_finished() {
+        let control = control();
+        let mut guard = match control.begin_submission() {
+            SubmissionDecision::Start(guard) => guard,
+            _ => panic!("submission should start"),
+        };
+        guard.mark_terminal();
+
+        assert_eq!(control.execution_phase(), ExecutionPhase::Finished);
+        assert!(matches!(
+            control.begin_cancel_attempt(),
+            CancelDecision::Return(QueryCancelStatus::AlreadyFinished)
+        ));
+    }
+
+    #[test]
+    fn accepted_cancel_is_cached_but_failed_attempt_can_retry() {
+        let control = control();
+        let _guard = match control.begin_submission() {
+            SubmissionDecision::Start(guard) => guard,
+            _ => panic!("submission should start"),
+        };
+
+        assert!(matches!(
+            control.begin_cancel_attempt(),
+            CancelDecision::SendAbort
+        ));
+        assert!(matches!(
+            control.begin_cancel_attempt(),
+            CancelDecision::SendAbort
+        ));
+
+        control.record_abort_accepted();
+        assert!(matches!(
+            control.begin_cancel_attempt(),
+            CancelDecision::Return(QueryCancelStatus::Accepted)
+        ));
+    }
+
+    #[test]
+    fn query_id_is_retained_for_diagnostics() {
+        let control = control();
+        control.record_query_id(Arc::from("query-id"));
+        assert_eq!(control.query_id().as_deref(), Some("query-id"));
+    }
+}

--- a/src/statement/client.rs
+++ b/src/statement/client.rs
@@ -3,26 +3,27 @@ use std::{
     time::{Duration, Instant},
 };
 
-use http::header::{ACCEPT, AUTHORIZATION};
+use bytes::Bytes;
+use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::{Client, Url};
+use serde_json::from_slice;
 use tokio::time::{sleep, timeout};
 use uuid::Uuid;
 
 use crate::{
     ClientShared, Error, Result,
     error::{
-        ConfigError, NetworkError, ProtocolError, QueryScopedError, QueryScopedResult,
-        TimeoutError, classify_request_error,
+        ConfigError, NetworkError, ProtocolError, QueryScopedError, QueryScopedResult, ServerError,
+        SessionExpiredError, TimeoutError, classify_request_error,
     },
     session::SessionAuth,
     statement::{
         StatementParts,
-        builder::StatementPartsRepr,
         wire::{
-            request::WireQueryBody,
+            request::{WireAbortBody, WireQueryBody},
             response::{
-                QUERY_IN_PROGRESS_ASYNC_CODE, QUERY_IN_PROGRESS_CODE, SnowflakeResponse,
-                parse_response,
+                QUERY_IN_PROGRESS_ASYNC_CODE, QUERY_IN_PROGRESS_CODE, SESSION_EXPIRED,
+                SnowflakeResponse, WireAbortResponse, parse_response,
             },
         },
     },
@@ -65,9 +66,14 @@ impl QueryResponseDeadline {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct StatementApiClient {
     shared: Arc<ClientShared>,
     auth: Arc<SessionAuth>,
+}
+
+pub(crate) struct PreparedSubmit {
+    request: reqwest::RequestBuilder,
 }
 
 impl StatementApiClient {
@@ -79,38 +85,53 @@ impl StatementApiClient {
         self.shared.http.clone()
     }
 
-    pub(crate) async fn submit(
+    pub(crate) fn prepare_submit(
         &self,
         parts: &StatementParts,
-        deadline: QueryResponseDeadline,
-    ) -> Result<SnowflakeResponse> {
-        validate_statement_parts_for_wire(parts)?;
-
-        let request_id = Uuid::new_v4();
+        query_request_id: &str,
+    ) -> Result<PreparedSubmit> {
         let mut url = self
             .shared
             .base_url
             .join("queries/v1/query-request")
             .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
         url.query_pairs_mut()
-            .append_pair("requestId", &request_id.to_string());
+            .append_pair("requestId", query_request_id);
 
-        // Apply the shared query-response deadline while waiting for Snowflake's submit response. No query id is known
-        // yet, so a timeout here yields an error without one.
-        let remaining = deadline.remaining_or_timeout()?;
+        let body = Bytes::from(
+            serde_json::to_vec(&WireQueryBody::from_statement_parts(parts)).map_err(|error| {
+                Error::other(format!("failed to serialize query request: {error}"))
+            })?,
+        );
+
         let request = self
             .shared
             .http
             .post(url)
             .header(ACCEPT, "application/snowflake")
+            .header(CONTENT_TYPE, "application/json")
             .header(
                 AUTHORIZATION,
                 format!(r#"Snowflake Token="{}""#, self.auth.session_token),
             )
-            .json(&WireQueryBody::from_statement_parts(parts));
+            .body(body);
+
+        Ok(PreparedSubmit { request })
+    }
+
+    pub(crate) async fn send_prepared_submit(
+        &self,
+        prepared: PreparedSubmit,
+        deadline: QueryResponseDeadline,
+    ) -> Result<SnowflakeResponse> {
+        let remaining = deadline.remaining_or_timeout()?;
 
         let body = match timeout(remaining, async {
-            let response = request.send().await.map_err(classify_request_error)?;
+            let response = prepared
+                .request
+                .send()
+                .await
+                .map_err(classify_request_error)?;
             let status = response.status();
             let body = response.bytes().await.map_err(classify_request_error)?;
             if !status.is_success() {
@@ -128,6 +149,124 @@ impl StatementApiClient {
         };
 
         parse_response(body).map_err(Error::from)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn submit(
+        &self,
+        parts: &StatementParts,
+        query_request_id: &str,
+        deadline: QueryResponseDeadline,
+    ) -> Result<SnowflakeResponse> {
+        let prepared = self.prepare_submit(parts, query_request_id)?;
+        self.send_prepared_submit(prepared, deadline).await
+    }
+
+    pub(crate) async fn abort_query(
+        &self,
+        query_request_id: &str,
+        request_timeout: Duration,
+    ) -> Result<()> {
+        self.abort_query_with_clock(query_request_id, &RealAbortClock::new(request_timeout))
+            .await
+    }
+
+    async fn abort_query_with_clock<C: AbortClock>(
+        &self,
+        query_request_id: &str,
+        clock: &C,
+    ) -> Result<()> {
+        let cancel_request_id = Uuid::new_v4().to_string();
+        let mut url = self
+            .shared
+            .base_url
+            .join("queries/v1/abort-request")
+            .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
+        url.query_pairs_mut()
+            .append_pair("requestId", &cancel_request_id);
+
+        let body = Bytes::from(
+            serde_json::to_vec(&WireAbortBody {
+                request_id: query_request_id,
+            })
+            .map_err(|error| Error::other(format!("failed to serialize abort request: {error}")))?,
+        );
+        let mut backoff = AbortBackoff::new();
+
+        for attempt in 0..MAX_ABORT_ATTEMPTS {
+            let remaining = clock.remaining();
+            if remaining.is_zero() {
+                return Err(TimeoutError::query_cancel().into());
+            }
+
+            let request = self
+                .shared
+                .http
+                .post(url.clone())
+                .header(ACCEPT, "application/snowflake")
+                .header(CONTENT_TYPE, "application/json")
+                .header(
+                    AUTHORIZATION,
+                    format!(r#"Snowflake Token="{}""#, self.auth.session_token),
+                )
+                .body(body.clone());
+
+            let attempt_result = match timeout(remaining, async {
+                let response = request.send().await?;
+                let status = response.status();
+                let body = response.bytes().await?;
+                Ok::<_, reqwest::Error>((status, body))
+            })
+            .await
+            {
+                Ok(Ok((status, body))) => {
+                    if !status.is_success() {
+                        let error = NetworkError::http_status(status.as_u16(), &body);
+                        if is_retryable_abort_status(status.as_u16()) {
+                            Err((true, Error::from(error)))
+                        } else {
+                            Err((false, Error::from(error)))
+                        }
+                    } else {
+                        let response: WireAbortResponse = from_slice(&body).map_err(|error| {
+                            Error::from(ProtocolError::json_parse(error, &body))
+                        })?;
+                        if response.code.as_deref() == Some(SESSION_EXPIRED) {
+                            Err((
+                                false,
+                                SessionExpiredError::new(response.code, response.message, None)
+                                    .into(),
+                            ))
+                        } else if !response.success {
+                            Err((
+                                false,
+                                ServerError::new(response.code, response.message, None).into(),
+                            ))
+                        } else {
+                            Ok(())
+                        }
+                    }
+                }
+                Ok(Err(error)) => Err((true, classify_request_error(error))),
+                Err(_elapsed) => Err((true, TimeoutError::query_cancel().into())),
+            };
+
+            match attempt_result {
+                Ok(()) => return Ok(()),
+                Err((retryable, error)) if !retryable || attempt + 1 == MAX_ABORT_ATTEMPTS => {
+                    return Err(error);
+                }
+                Err((_retryable, _error)) => {
+                    let remaining = clock.remaining();
+                    if remaining.is_zero() {
+                        return Err(TimeoutError::query_cancel().into());
+                    }
+                    clock.sleep(remaining.min(backoff.next_delay())).await;
+                }
+            }
+        }
+
+        unreachable!("abort retry loop always returns within the attempt budget");
     }
 
     pub(crate) async fn poll_async_results(
@@ -293,28 +432,91 @@ fn validate_same_origin_absolute_url(
     Ok(())
 }
 
-fn validate_statement_parts_for_wire(parts: &StatementParts) -> Result<()> {
-    if let StatementPartsRepr::Named { bindings, .. } = parts.repr() {
-        for name in bindings.keys() {
-            if name.is_empty() {
-                return Err(crate::Error::bind_encode("bind name must not be empty"));
-            }
-        }
+const MAX_ABORT_ATTEMPTS: usize = 8;
+
+fn is_retryable_abort_status(status: u16) -> bool {
+    matches!(status, 408 | 429 | 500..=599)
+}
+
+pub(crate) trait AbortClock {
+    fn remaining(&self) -> Duration;
+    fn sleep(&self, duration: Duration) -> impl std::future::Future<Output = ()> + Send;
+}
+
+struct RealAbortClock {
+    deadline: Instant,
+}
+
+impl RealAbortClock {
+    fn new(timeout: Duration) -> Self {
+        let now = Instant::now();
+        let deadline = now
+            .checked_add(timeout)
+            .or_else(|| now.checked_add(FAR_FUTURE))
+            .unwrap_or(now);
+        Self { deadline }
     }
-    Ok(())
+}
+
+impl AbortClock for RealAbortClock {
+    fn remaining(&self) -> Duration {
+        self.deadline.saturating_duration_since(Instant::now())
+    }
+
+    fn sleep(&self, duration: Duration) -> impl std::future::Future<Output = ()> + Send {
+        sleep(duration)
+    }
+}
+
+struct AbortBackoff {
+    step: usize,
+}
+
+impl AbortBackoff {
+    const STEPS: [Duration; 4] = [
+        Duration::from_millis(200),
+        Duration::from_millis(500),
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+    ];
+
+    fn new() -> Self {
+        Self { step: 0 }
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        let delay = Self::STEPS[self.step];
+        self.step = (self.step + 1).min(Self::STEPS.len() - 1);
+        delay
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
-    use tokio::net::TcpListener;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
 
     use super::*;
     use crate::{
-        ErrorKind, QueryConfig, Statement, runtime::QueryRuntime,
-        statement::builder::into_statement_parts,
+        ClientShared, ErrorKind, QueryConfig, Statement, runtime::QueryRuntime,
+        session::SessionAuth, statement::builder::into_statement_parts,
     };
+
+    fn test_statement_api(base_url: Url) -> StatementApiClient {
+        StatementApiClient::new(
+            ClientShared::for_test_with(
+                reqwest::Client::new(),
+                base_url,
+                QueryConfig::default().into(),
+                QueryRuntime::new(),
+            ),
+            SessionAuth::for_test("test-token"),
+        )
+    }
 
     #[test]
     fn resolve_poll_url_accepts_relative_and_same_origin_absolute_urls() {
@@ -383,10 +585,13 @@ mod tests {
             SessionAuth::for_test("test-token"),
         );
 
-        let parts = into_statement_parts(Statement::from("select 1"));
+        let parts = into_statement_parts(Statement::from("select 1")).unwrap();
         // A generous deadline leaves the reqwest client-wide timeout as the trigger for this case.
         let deadline = QueryResponseDeadline::new(Duration::from_secs(30));
-        let err = client.submit(&parts, deadline).await.unwrap_err();
+        let err = client
+            .submit(&parts, "query-request-id", deadline)
+            .await
+            .unwrap_err();
 
         assert_eq!(err.kind(), ErrorKind::Timeout);
         assert!(err.is_timeout());
@@ -417,15 +622,338 @@ mod tests {
         );
     }
 
-    #[test]
-    fn validate_wire_rejects_empty_named_bind_keys() {
-        let parts = into_statement_parts(Statement::new("SELECT :id").bind_named("", 1_i64));
+    #[tokio::test]
+    async fn abort_request_uses_separate_cancel_id_and_minimal_body() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+            write_http_response(&mut socket, 200, r#"{"success":true}"#).await;
+            request
+        });
 
-        let err = validate_statement_parts_for_wire(&parts).unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::BindEncode);
+        let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+        client
+            .abort_query("query-request-id", Duration::from_secs(2))
+            .await
+            .unwrap();
+
+        let request = server.await.unwrap();
+        let target = request.split_whitespace().nth(1).unwrap();
+        let target_url = Url::parse(&format!("http://localhost{target}")).unwrap();
+        let cancel_request_id = target_url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "requestId").then(|| value.into_owned()))
+            .unwrap();
+        assert_ne!(cancel_request_id, "query-request-id");
         assert_eq!(
-            err.to_string(),
-            "bind encode error: bind name must not be empty"
+            request.split("\r\n\r\n").nth(1).unwrap(),
+            r#"{"requestId":"query-request-id"}"#
         );
+        assert!(request.contains("accept: application/snowflake"));
+        assert!(request.contains(r#"authorization: Snowflake Token="test-token""#));
+    }
+
+    #[tokio::test]
+    async fn abort_transport_retry_reuses_identifiers() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for (status, body) in [
+                (500, r#"{"success":false,"code":"temporary"}"#),
+                (200, r#"{"success":true}"#),
+            ] {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                requests.push(read_http_request(&mut socket).await);
+                write_http_response(&mut socket, status, body).await;
+            }
+            requests
+        });
+
+        let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+        client
+            .abort_query("query-request-id", Duration::from_secs(3))
+            .await
+            .unwrap();
+
+        let requests = server.await.unwrap();
+        assert_eq!(requests.len(), 2);
+        let first_target = requests[0].split_whitespace().nth(1).unwrap();
+        let second_target = requests[1].split_whitespace().nth(1).unwrap();
+        let first_url = Url::parse(&format!("http://localhost{first_target}")).unwrap();
+        let second_url = Url::parse(&format!("http://localhost{second_target}")).unwrap();
+        let first_id = first_url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "requestId").then(|| value.into_owned()))
+            .unwrap();
+        let second_id = second_url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "requestId").then(|| value.into_owned()))
+            .unwrap();
+        assert_eq!(first_id, second_id);
+        assert_eq!(
+            requests[0].split("\r\n\r\n").nth(1).unwrap(),
+            requests[1].split("\r\n\r\n").nth(1).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn abort_success_false_is_server_error_without_application_retry() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+            write_http_response(
+                &mut socket,
+                200,
+                r#"{"success":false,"code":"000605","message":"query is not executing"}"#,
+            )
+            .await;
+            request
+        });
+
+        let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+        let err = client
+            .abort_query("query-request-id", Duration::from_secs(2))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Server);
+        assert_eq!(err.snowflake_code(), Some("000605"));
+        assert_eq!(err.snowflake_message(), Some("query is not executing"));
+        let _ = server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn abort_malformed_response_is_protocol_error() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+            write_http_response(&mut socket, 200, r#"{"success":"yes"}"#).await;
+            request
+        });
+
+        let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+        let err = client
+            .abort_query("query-request-id", Duration::from_secs(2))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Protocol);
+        let _ = server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn abort_zero_timeout_does_not_send_a_request() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+
+        let err = client
+            .abort_query("query-request-id", Duration::ZERO)
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Timeout);
+        assert!(
+            timeout(Duration::from_millis(20), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn abort_non_retryable_http_status_is_sent_once() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+            write_http_response(&mut socket, 400, r#"{"error":"bad request"}"#).await;
+            request
+        });
+
+        let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+        let err = client
+            .abort_query("query-request-id", Duration::from_secs(2))
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Network);
+        let _ = server.await.unwrap();
+    }
+
+    struct MockAbortClock {
+        remaining: std::sync::Mutex<Duration>,
+        sleeps: std::sync::Mutex<Vec<Duration>>,
+    }
+
+    impl MockAbortClock {
+        fn new(budget: Duration) -> Self {
+            Self {
+                remaining: std::sync::Mutex::new(budget),
+                sleeps: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn recorded_sleeps(&self) -> Vec<Duration> {
+            self.sleeps.lock().unwrap().clone()
+        }
+    }
+
+    impl AbortClock for MockAbortClock {
+        fn remaining(&self) -> Duration {
+            *self.remaining.lock().unwrap()
+        }
+
+        fn sleep(&self, duration: Duration) -> impl std::future::Future<Output = ()> + Send {
+            self.sleeps.lock().unwrap().push(duration);
+            let mut remaining = self.remaining.lock().unwrap();
+            *remaining = remaining.saturating_sub(duration);
+            std::future::ready(())
+        }
+    }
+
+    async fn respond_once(listener: &TcpListener, status: u16, body: &str) {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        read_http_request(&mut socket).await;
+        write_http_response(&mut socket, status, body).await;
+    }
+
+    #[tokio::test]
+    async fn abort_retries_every_transient_status_then_succeeds() {
+        for status in [408_u16, 429, 500, 503, 599] {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let server = tokio::spawn(async move {
+                respond_once(&listener, status, r#"{"success":false}"#).await;
+                respond_once(&listener, 200, r#"{"success":true}"#).await;
+            });
+
+            let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+            let clock = MockAbortClock::new(Duration::from_secs(1_000));
+            client
+                .abort_query_with_clock("query-request-id", &clock)
+                .await
+                .unwrap_or_else(|error| panic!("status {status} must retry to success: {error}"));
+
+            server.await.unwrap();
+            assert_eq!(
+                clock.recorded_sleeps(),
+                vec![Duration::from_millis(200)],
+                "status {status} must retry exactly once before succeeding"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn abort_stops_after_the_maximum_attempt_budget() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for _ in 0..MAX_ABORT_ATTEMPTS {
+                respond_once(&listener, 503, r#"{"success":false}"#).await;
+            }
+            timeout(Duration::from_millis(200), listener.accept())
+                .await
+                .is_err()
+        });
+
+        let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+        let clock = MockAbortClock::new(Duration::from_secs(1_000));
+        let err = client
+            .abort_query_with_clock("query-request-id", &clock)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Network);
+        assert!(
+            server.await.unwrap(),
+            "the abort must not exceed {MAX_ABORT_ATTEMPTS} total sends"
+        );
+        assert_eq!(
+            clock.recorded_sleeps(),
+            vec![
+                Duration::from_millis(200),
+                Duration::from_millis(500),
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+                Duration::from_secs(2),
+                Duration::from_secs(2),
+                Duration::from_secs(2),
+            ],
+            "backoff must grow and then cap at 2s across the seven retries"
+        );
+    }
+
+    #[tokio::test]
+    async fn abort_stops_when_the_deadline_is_exhausted_between_retries() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            respond_once(&listener, 500, r#"{"success":false}"#).await;
+            timeout(Duration::from_millis(200), listener.accept())
+                .await
+                .is_err()
+        });
+
+        let client = test_statement_api(Url::parse(&format!("http://{addr}/")).unwrap());
+        // The first backoff consumes the whole remaining budget, so the next iteration must fail on the deadline
+        // instead of sending a second request.
+        let clock = MockAbortClock::new(Duration::from_millis(200));
+        let err = client
+            .abort_query_with_clock("query-request-id", &clock)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Timeout);
+        assert!(
+            server.await.unwrap(),
+            "no request may be sent once the deadline is exhausted"
+        );
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        let mut bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let body_start;
+        let body_length;
+
+        loop {
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "connection closed before request completed");
+            bytes.extend_from_slice(&chunk[..read]);
+            if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                body_start = index + 4;
+                let headers = String::from_utf8_lossy(&bytes[..index]);
+                body_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.strip_prefix("content-length:")
+                            .or_else(|| line.strip_prefix("Content-Length:"))
+                    })
+                    .and_then(|value| value.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                break;
+            }
+        }
+
+        while bytes.len() < body_start + body_length {
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "connection closed before request body completed");
+            bytes.extend_from_slice(&chunk[..read]);
+        }
+        String::from_utf8(bytes).unwrap()
+    }
+
+    async fn write_http_response(socket: &mut tokio::net::TcpStream, status: u16, body: &str) {
+        let response = format!(
+            "HTTP/1.1 {status} OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
     }
 }

--- a/src/statement/executor.rs
+++ b/src/statement/executor.rs
@@ -2,7 +2,10 @@ use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use crate::{
     QueryExecutionSettings,
-    error::{ProtocolError, QueryScopedError, QueryScopedResult, ServerError, SessionExpiredError},
+    error::{
+        CancelledError, ProtocolError, QueryScopedResult, ServerError, SessionExpiredError,
+        with_optional_query_id,
+    },
     result_cursor::{CollectPolicy, RemotePartitionSource, ResultCursor},
     runtime::QueryRuntime,
     statement::StatementParts,
@@ -10,6 +13,7 @@ use crate::{
 };
 
 use super::{
+    cancel::{QueryControl, SubmissionDecision},
     client::{QueryResponseDeadline, StatementApiClient},
     manifest::ResultManifest,
     wire::response::{
@@ -21,36 +25,9 @@ use super::{
 pub(crate) struct StatementExecutor {
     api: StatementApiClient,
     query_response_timeout: Duration,
+    query_cancel_request_timeout: Duration,
     default_collect_concurrency: NonZeroUsize,
     runtime: QueryRuntime,
-}
-
-struct QueryScopedResponse {
-    query_id: Arc<str>,
-    response: SnowflakeResponse,
-}
-
-impl QueryScopedResponse {
-    fn from_submit(response: SnowflakeResponse) -> Result<Self> {
-        match response
-            .data
-            .as_ref()
-            .map(|data| Arc::clone(&data.query_id))
-        {
-            Some(query_id) => Ok(Self { query_id, response }),
-            None if response.code.as_deref() == Some(SESSION_EXPIRED) => {
-                Err(SessionExpiredError::new(response.code, response.message, None).into())
-            }
-            None if !response.success => {
-                Err(ServerError::new(response.code, response.message, None).into())
-            }
-            None => Err(ProtocolError::missing_field("data").into()),
-        }
-    }
-
-    fn into_parts(self) -> (Arc<str>, SnowflakeResponse) {
-        (self.query_id, self.response)
-    }
 }
 
 impl StatementExecutor {
@@ -58,86 +35,127 @@ impl StatementExecutor {
         Self {
             api: StatementApiClient::new(Arc::clone(&session.shared), Arc::clone(&session.auth)),
             query_response_timeout: settings.query_response_timeout,
+            query_cancel_request_timeout: settings.query_cancel_request_timeout,
             default_collect_concurrency: settings.collect_prefetch_concurrency,
             runtime: session.shared.runtime.clone(),
         }
     }
 
-    pub(crate) async fn execute(self, parts: StatementParts) -> Result<ResultCursor> {
-        let deadline = QueryResponseDeadline::new(self.query_response_timeout);
-        let response = QueryScopedResponse::from_submit(self.api.submit(&parts, deadline).await?)?;
-        self.execute_query_scoped(response, deadline)
-            .await
-            .map_err(Error::from)
+    pub(crate) fn api_client(&self) -> StatementApiClient {
+        self.api.clone()
     }
 
-    async fn execute_query_scoped(
+    pub(crate) fn cancel_request_timeout(&self) -> Duration {
+        self.query_cancel_request_timeout
+    }
+
+    pub(crate) async fn execute(
         self,
-        response: QueryScopedResponse,
-        deadline: QueryResponseDeadline,
-    ) -> QueryScopedResult<ResultCursor> {
-        let (query_id, mut response) = response.into_parts();
+        parts: StatementParts,
+        control: Arc<QueryControl>,
+    ) -> Result<ResultCursor> {
+        let deadline = QueryResponseDeadline::new(self.query_response_timeout);
+
+        let prepared = self
+            .api
+            .prepare_submit(&parts, control.query_request_id())?;
+
+        let mut guard = match control.begin_submission() {
+            SubmissionDecision::Start(guard) => guard,
+            SubmissionDecision::CancelledBeforeSubmit => {
+                return Err(CancelledError::new(None, None, None).into());
+            }
+            SubmissionDecision::AlreadyStarted => {
+                return Err(Error::other("query execution has already started"));
+            }
+        };
+
+        let mut response = self.api.send_prepared_submit(prepared, deadline).await?;
+        if let Some(data) = response.data.as_ref() {
+            guard.record_query_id(Arc::clone(&data.query_id));
+        }
 
         let response_code = response.code.as_deref();
         if response_code == Some(QUERY_IN_PROGRESS_ASYNC_CODE)
             || response_code == Some(QUERY_IN_PROGRESS_CODE)
         {
-            let data = response
-                .data
-                .take()
-                .expect("query-scoped responses always carry a query id in data");
+            let Some(data) = response.data.take() else {
+                return Err(with_optional_query_id(
+                    ProtocolError::missing_field("data"),
+                    control.query_id(),
+                ));
+            };
             let Some(result_url) = data.get_result_url else {
-                return Err(QueryScopedError::new(
-                    query_id,
+                return Err(with_optional_query_id(
                     ProtocolError::no_polling_url(),
+                    control.query_id(),
                 ));
             };
 
             response = self
                 .api
-                .poll_async_results(&result_url, deadline, Arc::clone(&query_id))
-                .await?;
+                .poll_async_results(&result_url, deadline, Arc::clone(&data.query_id))
+                .await
+                .map_err(Error::from)?;
+            if let Some(data) = response.data.as_ref() {
+                guard.record_query_id(Arc::clone(&data.query_id));
+            }
         }
 
-        if let Some(SESSION_EXPIRED) = response.code.as_deref() {
-            return Err(QueryScopedError::new(
-                query_id,
-                SessionExpiredError::new(
-                    response.code,
-                    response.message,
-                    response.data.as_ref().map(|data| data.query_id.clone()),
+        // Mark terminality before building the local result manifest. Local schema/manifest failures do not make a
+        // completed server-side query look ambiguous.
+        guard.mark_terminal();
+        self.finish_response(response, &control)
+    }
+
+    fn finish_response(
+        self,
+        response: SnowflakeResponse,
+        control: &QueryControl,
+    ) -> Result<ResultCursor> {
+        let query_id = control.query_id();
+        if control.cancel_intent() && response.is_cancellation_marker() {
+            return Err(with_optional_query_id(
+                CancelledError::new(
+                    response.code.clone(),
+                    response.message.clone(),
+                    query_id.clone(),
                 ),
+                query_id,
+            ));
+        }
+
+        if response.code.as_deref() == Some(SESSION_EXPIRED) {
+            return Err(with_optional_query_id(
+                SessionExpiredError::new(response.code, response.message, query_id.clone()),
+                query_id,
             ));
         }
 
         if !response.success {
-            return Err(QueryScopedError::new(
+            return Err(with_optional_query_id(
+                ServerError::new(response.code, response.message, query_id.clone()),
                 query_id,
-                ServerError::new(
-                    response.code,
-                    response.message,
-                    response.data.as_ref().map(|data| data.query_id.clone()),
-                ),
             ));
         }
 
         let Some(data) = response.data else {
-            return Err(QueryScopedError::new(
-                query_id,
+            return Err(with_optional_query_id(
                 ProtocolError::missing_field("data"),
+                query_id,
             ));
         };
 
         if let Some(ref format) = data.query_result_format
             && format != "json"
         {
-            return Err(QueryScopedError::new(
-                query_id,
+            return Err(with_optional_query_id(
                 ProtocolError::unsupported_result_format(format.clone()),
+                query_id,
             ));
         }
 
-        self.build_result_set(data)
+        self.build_result_set(data).map_err(Error::from)
     }
 
     fn build_result_set(self, data: RawQueryResponse) -> QueryScopedResult<ResultCursor> {
@@ -173,11 +191,11 @@ mod tests {
     use super::*;
     use crate::{
         ClientShared, ErrorKind, QueryConfig, QueryOptions, Statement,
+        config::{DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT, DEFAULT_QUERY_RESPONSE_TIMEOUT},
         rowset::BLOCKING_PARSE_CELLS,
         runtime::QueryRuntime,
         session::SessionAuth,
         statement::{
-            StatementParts,
             builder::into_statement_parts,
             client::StatementApiClient,
             wire::response::{RawQueryResponse, RawQueryResponseRowType},
@@ -208,7 +226,8 @@ mod tests {
     fn executor() -> StatementExecutor {
         StatementExecutor {
             api: test_statement_api(Url::parse("https://example.com/").unwrap()),
-            query_response_timeout: crate::config::DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime: QueryRuntime::new(),
         }
@@ -218,6 +237,7 @@ mod tests {
         StatementExecutor {
             api: test_statement_api(base_url),
             query_response_timeout: timeout,
+            query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime: QueryRuntime::new(),
         }
@@ -329,14 +349,18 @@ mod tests {
     }
 
     fn select_1_parts() -> StatementParts {
-        into_statement_parts(Statement::from("select 1"))
+        into_statement_parts(Statement::from("select 1")).unwrap()
+    }
+
+    fn fresh_control() -> Arc<QueryControl> {
+        QueryControl::new(Arc::from("query-request-id"))
     }
 
     async fn execute_single_response_err(body: &'static str) -> crate::Error {
         let session = test_session(spawn_single_response_server(body));
 
         match StatementExecutor::new(&session, default_settings(&session))
-            .execute(select_1_parts())
+            .execute(select_1_parts(), fresh_control())
             .await
         {
             Ok(_) => panic!("expected statement execution to fail"),
@@ -431,7 +455,7 @@ mod tests {
             Duration::from_millis(100),
         );
 
-        let err = match executor.execute(select_1_parts()).await {
+        let err = match executor.execute(select_1_parts(), fresh_control()).await {
             Ok(_) => panic!("submit timeout must fail"),
             Err(err) => err,
         };
@@ -452,7 +476,7 @@ mod tests {
             Duration::from_millis(150),
         );
 
-        let err = match executor.execute(select_1_parts()).await {
+        let err = match executor.execute(select_1_parts(), fresh_control()).await {
             Ok(_) => panic!("poll timeout must fail"),
             Err(err) => err,
         };
@@ -473,7 +497,7 @@ mod tests {
             Duration::from_millis(150),
         );
 
-        let err = match executor.execute(select_1_parts()).await {
+        let err = match executor.execute(select_1_parts(), fresh_control()).await {
             Ok(_) => panic!("blocking poll must time out"),
             Err(err) => err,
         };
@@ -496,7 +520,7 @@ mod tests {
         );
 
         let start = Instant::now();
-        let err = match executor.execute(select_1_parts()).await {
+        let err = match executor.execute(select_1_parts(), fresh_control()).await {
             Ok(_) => panic!("blocking poll must time out"),
             Err(err) => err,
         };
@@ -525,7 +549,7 @@ mod tests {
         );
 
         let mut result = executor
-            .execute(select_1_parts())
+            .execute(select_1_parts(), fresh_control())
             .await
             .expect("final response within deadline must build a cursor");
         let table = result
@@ -543,7 +567,7 @@ mod tests {
         ));
 
         let err = match StatementExecutor::new(&session, default_settings(&session))
-            .execute(select_1_parts())
+            .execute(select_1_parts(), fresh_control())
             .await
         {
             Ok(_) => panic!("unsupported result format must fail"),
@@ -562,7 +586,7 @@ mod tests {
         ));
 
         let err = match StatementExecutor::new(&session, default_settings(&session))
-            .execute(select_1_parts())
+            .execute(select_1_parts(), fresh_control())
             .await
         {
             Ok(_) => panic!("session expired response must fail"),
@@ -586,7 +610,7 @@ mod tests {
         ));
 
         let err = match StatementExecutor::new(&session, default_settings(&session))
-            .execute(select_1_parts())
+            .execute(select_1_parts(), fresh_control())
             .await
         {
             Ok(_) => panic!("session expired response must fail"),
@@ -610,7 +634,7 @@ mod tests {
         ));
 
         let err = match StatementExecutor::new(&session, default_settings(&session))
-            .execute(select_1_parts())
+            .execute(select_1_parts(), fresh_control())
             .await
         {
             Ok(_) => panic!("server error response must fail"),
@@ -624,11 +648,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancellation_marker_without_cancel_intent_remains_server_error() {
+        let err = execute_single_response_err(
+            r#"{"code":"000604","message":"SQL execution canceled","success":false,"data":{"queryId":"query-id"}}"#,
+        )
+        .await;
+
+        assert_eq!(err.kind(), ErrorKind::Server);
+        assert!(!err.is_cancelled());
+        assert_eq!(err.snowflake_code(), Some("000604"));
+        assert_eq!(err.query_id(), Some("query-id"));
+    }
+
+    #[tokio::test]
     async fn execute_network_failure_has_no_query_id() {
         let session = test_session(spawn_disconnect_server());
 
         let err = match StatementExecutor::new(&session, default_settings(&session))
-            .execute(select_1_parts())
+            .execute(select_1_parts(), fresh_control())
             .await
         {
             Ok(_) => panic!("network failure must not yield a result set"),
@@ -645,7 +682,8 @@ mod tests {
         let permit = runtime.blocking_parse_limiter().acquire_owned().await;
         let executor = StatementExecutor {
             api: test_statement_api(Url::parse("https://example.com/").unwrap()),
-            query_response_timeout: crate::config::DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime,
         };
@@ -688,7 +726,8 @@ mod tests {
         let permit = runtime.blocking_parse_limiter().acquire_owned().await;
         let executor = StatementExecutor {
             api: test_statement_api(Url::parse("https://example.com/").unwrap()),
-            query_response_timeout: crate::config::DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime,
         };
@@ -726,7 +765,8 @@ mod tests {
         let permit = runtime.blocking_parse_limiter().acquire_owned().await;
         let executor = StatementExecutor {
             api: test_statement_api(Url::parse("https://example.com/").unwrap()),
-            query_response_timeout: crate::config::DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
+            query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
             runtime,
         };

--- a/src/statement/handle.rs
+++ b/src/statement/handle.rs
@@ -1,0 +1,168 @@
+use std::{fmt, sync::Arc, time::Duration};
+
+use crate::{
+    Result,
+    result_cursor::{ResultCursor, TypedResultCursor},
+    result_table::{FromRow, RowPlanContext},
+};
+
+use super::{
+    StatementExecutor, StatementParts,
+    cancel::{CancelDecision, QueryControl},
+    client::StatementApiClient,
+};
+
+/// What a successful [`QueryCanceller::cancel`] call achieved.
+///
+/// This is a report, not a control-flow discriminant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum QueryCancelStatus {
+    /// Cancellation won before the query submit request began; neither the query nor an abort request was sent.
+    NotSubmitted,
+    /// Snowflake accepted the abort request; query terminality is not implied.
+    Accepted,
+    /// The connector already processed a terminal query response; no abort request was sent.
+    AlreadyFinished,
+}
+
+/// An owned statement execution that can be explicitly cancelled through a [`QueryCanceller`].
+///
+/// Cancellation runs only through [`QueryCanceller::cancel`] on a canceller retained from [`Self::canceller`];
+/// dropping the execution future never cancels the remote query.
+pub struct QueryHandle {
+    statement: StatementParts,
+    executor: StatementExecutor,
+    control: Arc<QueryControl>,
+}
+
+/// A cloneable controller that cancels the query of the [`QueryHandle`] it was obtained from.
+///
+/// It remains usable from any task, even after the handle has been consumed by execution or the execution future
+/// has been dropped.
+#[derive(Clone)]
+pub struct QueryCanceller {
+    api: StatementApiClient,
+    control: Arc<QueryControl>,
+    request_timeout: Duration,
+}
+
+impl QueryHandle {
+    pub(crate) fn new(
+        statement: StatementParts,
+        executor: StatementExecutor,
+        control: Arc<QueryControl>,
+    ) -> Self {
+        Self {
+            statement,
+            executor,
+            control,
+        }
+    }
+
+    /// Returns the client-generated query request ID used by the submit and abort requests.
+    pub fn request_id(&self) -> &str {
+        self.control.query_request_id()
+    }
+
+    /// Returns a cloneable cancellation controller for this query.
+    pub fn canceller(&self) -> QueryCanceller {
+        QueryCanceller {
+            api: self.executor.api_client(),
+            control: Arc::clone(&self.control),
+            request_timeout: self.executor.cancel_request_timeout(),
+        }
+    }
+
+    /// Submits the statement and returns a streaming result cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Session::query`](crate::Session::query). If cancellation wins before submission,
+    /// this returns an [`ErrorKind::Cancelled`](crate::ErrorKind::Cancelled) error without sending either the query
+    /// or abort request.
+    pub async fn execute(self) -> Result<ResultCursor> {
+        let Self {
+            statement,
+            executor,
+            control,
+        } = self;
+        executor.execute(statement, control).await
+    }
+
+    /// Submits the statement and builds a typed streaming result cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::execute`]. After the statement succeeds, this also propagates plan-time
+    /// decode failures from [`FromRow::build_plan`] for `T`.
+    pub async fn execute_as<T>(self) -> Result<TypedResultCursor<T>>
+    where
+        T: FromRow,
+    {
+        let result = self.execute().await?;
+        let plan = T::build_plan(RowPlanContext::new(result.shared_schema()))?;
+        Ok(TypedResultCursor::new(result, plan))
+    }
+}
+
+impl fmt::Debug for QueryHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryHandle")
+            .field("request_id", &self.request_id())
+            .field("phase", &self.control.execution_phase())
+            .finish_non_exhaustive()
+    }
+}
+
+impl QueryCanceller {
+    /// Returns the client-generated query request ID targeted by this canceller.
+    pub fn request_id(&self) -> &str {
+        self.control.query_request_id()
+    }
+
+    /// Requests remote cancellation and waits for the abort response.
+    ///
+    /// On success, reports what the cancellation achieved as a [`QueryCancelStatus`].
+    ///
+    /// This method never returns an [`ErrorKind::Cancelled`](crate::ErrorKind::Cancelled) error; that error is what
+    /// [`QueryHandle::execute`] returns once the cancellation takes effect.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorKind::Network`](crate::ErrorKind::Network), [`ErrorKind::Timeout`](crate::ErrorKind::Timeout),
+    /// [`ErrorKind::Server`](crate::ErrorKind::Server),
+    /// [`ErrorKind::SessionExpired`](crate::ErrorKind::SessionExpired), or
+    /// [`ErrorKind::Protocol`](crate::ErrorKind::Protocol). Transient transport failures are retried within the
+    /// configured cancellation deadline, and a failed call never caches a successful status, so a later call can
+    /// retry the cancellation.
+    pub async fn cancel(&self) -> Result<QueryCancelStatus> {
+        let _gate = self.control.lock_cancel_gate().await;
+
+        match self.control.begin_cancel_attempt() {
+            CancelDecision::Return(outcome) => Ok(outcome),
+            CancelDecision::SendAbort => {
+                self.api
+                    .abort_query(self.control.query_request_id(), self.request_timeout)
+                    .await?;
+                self.control.record_abort_accepted();
+                Ok(QueryCancelStatus::Accepted)
+            }
+        }
+    }
+}
+
+impl fmt::Debug for QueryCanceller {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryCanceller")
+            .field("request_id", &self.request_id())
+            .field("phase", &self.control.execution_phase())
+            .finish_non_exhaustive()
+    }
+}
+
+const _: fn() = || {
+    fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+    assert_send_sync_static::<QueryHandle>();
+    assert_send_sync_static::<QueryCanceller>();
+};

--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -1,12 +1,16 @@
 pub(crate) mod bind;
 pub(crate) mod builder;
+mod cancel;
 mod client;
 mod executor;
+mod handle;
 mod manifest;
 pub(crate) mod wire;
 
 pub(crate) use builder::StatementParts;
+pub(crate) use cancel::QueryControl;
 pub(crate) use executor::StatementExecutor;
+pub use handle::{QueryCancelStatus, QueryCanceller, QueryHandle};
 
 #[cfg(feature = "bench-internals")]
 pub(crate) use wire::response::parse_response;

--- a/src/statement/wire/request.rs
+++ b/src/statement/wire/request.rs
@@ -65,6 +65,12 @@ impl Serialize for WireBindings<'_> {
     }
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WireAbortBody<'a> {
+    pub(crate) request_id: &'a str,
+}
+
 struct PositionalKey(usize);
 
 impl Serialize for PositionalKey {
@@ -231,7 +237,7 @@ mod tests {
     };
 
     fn wire_body(statement: impl IntoStatement) -> serde_json::Value {
-        let parts = into_statement_parts(statement);
+        let parts = into_statement_parts(statement).unwrap();
         serde_json::to_value(WireQueryBody::from_statement_parts(&parts)).unwrap()
     }
 

--- a/src/statement/wire/response.rs
+++ b/src/statement/wire/response.rs
@@ -10,6 +10,8 @@ use crate::error::ProtocolError;
 pub(crate) const SESSION_EXPIRED: &str = "390112";
 pub(crate) const QUERY_IN_PROGRESS_CODE: &str = "333333";
 pub(crate) const QUERY_IN_PROGRESS_ASYNC_CODE: &str = "333334";
+const QUERY_CANCELLED_CODE: &str = "000604";
+const QUERY_CANCELLED_SQL_STATE: &str = "57014";
 
 const HEADER_SSE_C_ALGORITHM: &str = "x-amz-server-side-encryption-customer-algorithm";
 const HEADER_SSE_C_KEY: &str = "x-amz-server-side-encryption-customer-key";
@@ -21,6 +23,15 @@ pub(crate) struct SnowflakeResponse {
     pub(crate) message: Option<String>,
     pub(crate) success: bool,
     pub(crate) code: Option<String>,
+    pub(crate) sql_state: Option<String>,
+}
+
+impl SnowflakeResponse {
+    pub(crate) fn is_cancellation_marker(&self) -> bool {
+        !self.success
+            && (self.code.as_deref() == Some(QUERY_CANCELLED_CODE)
+                || self.sql_state.as_deref() == Some(QUERY_CANCELLED_SQL_STATE))
+    }
 }
 
 // Response metadata the runtime ignores is omitted from the deserialize DTOs:
@@ -47,6 +58,8 @@ struct BorrowedSnowflakeResponse<'a> {
     message: Option<String>,
     success: bool,
     code: Option<String>,
+    #[serde(rename = "sqlState")]
+    sql_state: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -67,6 +80,14 @@ struct BorrowedRawQueryResponse<'a> {
     qrmk: Option<String>,
     chunks: Option<Vec<RawQueryResponseChunk>>,
     query_result_format: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WireAbortResponse {
+    pub(crate) success: bool,
+    pub(crate) code: Option<String>,
+    pub(crate) message: Option<String>,
 }
 
 /// Parse a response body, keeping the rowset as a zero-copy `Bytes` slice of the input.
@@ -105,6 +126,7 @@ pub(crate) fn parse_response(body: Bytes) -> Result<SnowflakeResponse, ProtocolE
         message: borrowed.message,
         success: borrowed.success,
         code: borrowed.code,
+        sql_state: borrowed.sql_state,
     })
 }
 
@@ -206,6 +228,33 @@ mod tests {
         );
         let resp = parse_response(body).unwrap();
         assert_eq!(resp.code.as_deref(), Some("390112"));
+    }
+
+    #[test]
+    fn parse_response_retains_sql_state_for_structured_error_classification() {
+        let body = Bytes::from(
+            r#"{"sqlState":"57014","message":"statement was cancelled","success":false}"#,
+        );
+        let response = parse_response(body).unwrap();
+        assert_eq!(response.sql_state.as_deref(), Some("57014"));
+    }
+
+    #[test]
+    fn cancellation_marker_recognizes_vendor_code_or_sql_state() {
+        for (code, sql_state) in [
+            (Some(QUERY_CANCELLED_CODE), None),
+            (None, Some(QUERY_CANCELLED_SQL_STATE)),
+        ] {
+            let response = SnowflakeResponse {
+                data: None,
+                message: Some("SQL execution canceled".to_string()),
+                success: false,
+                code: code.map(str::to_string),
+                sql_state: sql_state.map(str::to_string),
+            };
+
+            assert!(response.is_cancellation_marker());
+        }
     }
 
     #[test]

--- a/tests/auto_trait_compile_pass/public_async_send_futures.rs
+++ b/tests/auto_trait_compile_pass/public_async_send_futures.rs
@@ -3,9 +3,9 @@
 use std::rc::Rc;
 
 use snowflake_connector_rs::{
-    Client, CollectOptions, DynamicRow, FromRow, ResultCursor, RowPlanContext, RowRef,
+    Client, CollectOptions, DynamicRow, FromRow, QueryCanceller, QueryHandle, ResultCursor,
+    RowPlanContext, RowRef, Session,
     decode::{PlanBuildResult, RowDecodeResult},
-    Session,
 };
 
 fn client() -> Client {
@@ -17,6 +17,14 @@ fn session() -> Session {
 }
 
 fn result_cursor() -> ResultCursor {
+    unreachable!()
+}
+
+fn query_handle() -> QueryHandle {
+    unreachable!()
+}
+
+fn query_canceller() -> QueryCanceller {
     unreachable!()
 }
 
@@ -52,6 +60,11 @@ fn checks() {
     // Public untyped collect futures are Send.
     assert_send(result_cursor().collect::<Vec<DynamicRow>>());
     assert_send(result_cursor().collect_with_options::<Vec<DynamicRow>>(CollectOptions::default()));
+
+    // Active query-cancel futures are Send, and their owning handles meet the public auto-trait contract.
+    assert_send(query_handle().execute());
+    assert_send(query_handle().execute_as::<SendRow>());
+    assert_send(query_canceller().cancel());
 
     // Session query futures are Send for representative statements.
     let session = session();

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -7,5 +7,6 @@ mod test_column_metadata;
 mod test_decode;
 #[cfg(feature = "derive")]
 mod test_derive;
+mod test_query_cancel;
 mod test_query_id;
 mod test_session_parameters;

--- a/tests/cases/test_query_cancel.rs
+++ b/tests/cases/test_query_cancel.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use snowflake_connector_rs::{Error, QueryCancelStatus, Result};
+
+use super::common;
+
+// The 1s sleep makes submission overwhelmingly likely, so `Accepted` is the expected outcome, but it is not guaranteed: if a
+// network delay keeps the query POST from reaching Snowflake before the cancel, `NotSubmitted` is a legitimate result and this
+// assertion can flake.
+
+#[tokio::test]
+async fn active_query_cancel_uses_request_id_abort() -> Result<()> {
+    let session = common::default_session().await?;
+    let query = session.query_handle("CALL SYSTEM$WAIT(120)")?;
+    let canceller = query.canceller();
+    let task = tokio::spawn(query.execute());
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_eq!(canceller.cancel().await?, QueryCancelStatus::Accepted);
+
+    let result = task
+        .await
+        .map_err(|error| Error::other(error.to_string()))?;
+    let error = result.expect_err("the long-running query should be cancelled");
+    assert!(error.is_cancelled(), "unexpected query error: {error}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn active_query_cancel_during_polling_uses_request_id_abort() -> Result<()> {
+    let session = common::default_session().await?;
+    let query = session.query_handle("CALL SYSTEM$WAIT(120)")?;
+    let canceller = query.canceller();
+    let task = tokio::spawn(query.execute());
+
+    // The v1 submit request normally switches to the async response after about 45 seconds. By waiting beyond that
+    // point, cancellation targets a query whose ID has already been recorded and whose result is being polled.
+    tokio::time::sleep(Duration::from_secs(50)).await;
+    assert_eq!(canceller.cancel().await?, QueryCancelStatus::Accepted);
+
+    let result = task
+        .await
+        .map_err(|error| Error::other(error.to_string()))?;
+    let error = result.expect_err("the long-running query should be cancelled");
+    assert!(error.is_cancelled(), "unexpected query error: {error}");
+    assert!(error.query_id().is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_cancel_remains_available_after_execution_task_abort() -> Result<()> {
+    let session = common::default_session().await?;
+    let query = session.query_handle("CALL SYSTEM$WAIT(120)")?;
+    let canceller = query.canceller();
+    let task = tokio::spawn(query.execute());
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    task.abort();
+    let _ = task.await;
+
+    assert_eq!(canceller.cancel().await?, QueryCancelStatus::Accepted);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- close: #201

Adds an explicit API for actively cancelling a Snowflake query, including while the initial query request is still waiting for a response and before a Snowflake query ID is available.

## Motivation

Snowflake may continue executing a statement after its Rust query future is dropped. Merely stopping the client-side wait therefore does not stop warehouse work or its associated cost.

The cancellation capability is intentionally independent of the execution future. A retained `QueryCanceller` remains usable after a timeout, a losing `tokio::select!` branch, or execution-task abortion has dropped that future.

## Usage

```rust
let query = session.query_handle("CALL SYSTEM$WAIT(120)")?;
let canceller = query.canceller();
let execution = tokio::spawn(query.execute());

// This can run from another task, including before a query ID is known.
let status = canceller.cancel().await?;

match execution.await? {
    Err(error) if error.is_cancelled() => {
        // Snowflake reported the query as cancelled.
    }
    result => {
        // The query may have completed before the abort took effect.
        let _cursor = result?;
    }
}
```

## Acknowledgements

Thanks to @seisenberg for the work in #200, which helped inform this design.
