### PR TITLE
fix(api): send the connector User-Agent on every Snowflake origin request

### DIFF
--- a/src/api_context.rs
+++ b/src/api_context.rs
@@ -1,0 +1,95 @@
+use http::Method;
+use reqwest::{Url, header::USER_AGENT};
+
+use crate::{Result, error::ConfigError};
+
+pub(crate) const DEFAULT_USER_AGENT: &str =
+    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+
+/// The connector's authority to talk to one trusted Snowflake origin.
+///
+/// It represents what every Snowflake API request has in common regardless of endpoint: the origin it is addressed
+/// to and the connector it originates from.
+pub(crate) struct ApiContext {
+    http: reqwest::Client,
+    base_url: Url,
+}
+
+impl ApiContext {
+    pub(crate) fn new(http: reqwest::Client, base_url: Url) -> Self {
+        Self { http, base_url }
+    }
+
+    pub(crate) fn resolve(&self, relative: &str) -> Result<Url> {
+        self.base_url
+            .join(relative)
+            .map_err(|e| ConfigError::invalid_url(e.to_string()).into())
+    }
+
+    pub(crate) fn request(&self, method: Method, url: Url) -> reqwest::RequestBuilder {
+        self.http
+            .request(method, url)
+            .header(USER_AGENT, DEFAULT_USER_AGENT)
+    }
+
+    pub(crate) fn base_url(&self) -> &Url {
+        &self.base_url
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ErrorKind;
+
+    fn context() -> ApiContext {
+        ApiContext::new(
+            reqwest::Client::new(),
+            Url::parse("https://example.com/").expect("test base URL must parse"),
+        )
+    }
+
+    #[test]
+    fn resolve_joins_relative_endpoint_against_base_url() {
+        let url = context().resolve("session/v1/login-request").unwrap();
+        assert_eq!(url.as_str(), "https://example.com/session/v1/login-request");
+    }
+
+    #[test]
+    fn resolve_invalid_url_is_config_error() {
+        // An empty host makes the join fail; it must surface as the same config error the endpoints used before.
+        let err = context().resolve("https://").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Config);
+    }
+
+    #[test]
+    fn request_carries_connector_user_agent() {
+        let ctx = context();
+        let url = ctx.resolve("queries/v1/query-request").unwrap();
+        let request = ctx.request(Method::POST, url).build().unwrap();
+        assert_eq!(
+            request.headers().get(USER_AGENT).unwrap(),
+            DEFAULT_USER_AGENT
+        );
+    }
+
+    #[test]
+    fn request_does_not_attach_endpoint_headers() {
+        let ctx = context();
+        let url = ctx.resolve("queries/v1/query-request").unwrap();
+        let request = ctx.request(Method::POST, url).build().unwrap();
+        assert!(request.headers().get(reqwest::header::ACCEPT).is_none());
+        assert!(
+            request
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .is_none()
+        );
+        assert!(
+            request
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .is_none()
+        );
+    }
+}

--- a/src/auth/api.rs
+++ b/src/auth/api.rs
@@ -1,13 +1,11 @@
 use std::{sync::Arc, time::Duration};
 
-use reqwest::{
-    Url,
-    header::{ACCEPT, USER_AGENT},
-};
+use http::Method;
+use reqwest::{Url, header::ACCEPT};
 
 use crate::{
-    ClientShared, Result,
-    error::{ConfigError, NetworkError, classify_request_error},
+    ApiContext, Result,
+    error::{NetworkError, classify_request_error},
 };
 
 #[cfg(feature = "external-browser-sso")]
@@ -23,32 +21,28 @@ const AUTHENTICATOR_REQUEST_ACCEPT: &str = "application/json";
 
 #[derive(Clone)]
 pub(crate) struct AuthApiClient {
-    shared: Arc<ClientShared>,
+    api: Arc<ApiContext>,
     request_timeout: Duration,
 }
 
 impl AuthApiClient {
-    pub(crate) fn new(shared: Arc<ClientShared>) -> Self {
+    pub(crate) fn new(api: Arc<ApiContext>) -> Self {
         Self {
-            shared,
+            api,
             request_timeout: AUTH_REQUEST_TIMEOUT,
         }
     }
 
     #[cfg(test)]
-    fn with_request_timeout(shared: Arc<ClientShared>, request_timeout: Duration) -> Self {
+    fn with_request_timeout(api: Arc<ApiContext>, request_timeout: Duration) -> Self {
         Self {
-            shared,
+            api,
             request_timeout,
         }
     }
 
     pub(crate) async fn login(&self, request: LoginRequest<'_>) -> Result<LoginSession> {
-        let url = self
-            .shared
-            .base_url
-            .join("session/v1/login-request")
-            .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
+        let url = self.api.resolve("session/v1/login-request")?;
 
         let response = self
             .post(url, LOGIN_REQUEST_ACCEPT)
@@ -72,11 +66,7 @@ impl AuthApiClient {
         &self,
         request: AuthenticatorRequest<'_>,
     ) -> Result<ExternalBrowserChallenge> {
-        let url = self
-            .shared
-            .base_url
-            .join("session/authenticator-request")
-            .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
+        let url = self.api.resolve("session/authenticator-request")?;
 
         let body = request.into_body(ClientEnvironment::auth_defaults(self.request_timeout));
         let response = self
@@ -96,108 +86,38 @@ impl AuthApiClient {
     }
 
     fn post(&self, url: Url, accept: &'static str) -> reqwest::RequestBuilder {
-        self.shared
-            .http
-            .post(url)
+        self.api
+            .request(Method::POST, url)
             .header(ACCEPT, accept)
-            .header(USER_AGENT, default_user_agent())
             .timeout(self.request_timeout)
     }
 }
 
-fn default_user_agent() -> String {
-    format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{io, net::SocketAddr, time::Duration};
+    use std::{net::SocketAddr, time::Duration};
 
+    use http::StatusCode;
     use serde_json::json;
-    use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
-        net::{TcpListener, TcpStream},
-    };
+    use tokio::net::TcpListener;
 
     use super::*;
     use crate::{
-        ClientSharedPartial, ErrorKind,
+        ErrorKind,
+        api_context::DEFAULT_USER_AGENT,
         auth::wire::{LoginBody, LoginCredentialWire, LoginData, LoginQuery, LoginRequest},
+        test_support::http::{base_url, read_http_request, write_json_response},
     };
-
-    fn auth_client(addr: SocketAddr) -> AuthApiClient {
-        AuthApiClient::new(
-            ClientSharedPartial::new()
-                .with_base_url(base_url_for(addr))
-                .build(),
-        )
-    }
 
     #[cfg(feature = "external-browser-sso")]
     use crate::auth::wire::AuthenticatorRequest;
 
-    async fn read_http_message(stream: &mut TcpStream) -> io::Result<String> {
-        let mut buf = Vec::new();
-        let mut header_end = None;
-
-        while header_end.is_none() {
-            let mut chunk = [0_u8; 1024];
-            let n = stream.read(&mut chunk).await?;
-            if n == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "stream closed before headers completed",
-                ));
-            }
-            buf.extend_from_slice(&chunk[..n]);
-            header_end = buf.windows(4).position(|w| w == b"\r\n\r\n");
-        }
-
-        let header_end = header_end.expect("header end must exist") + 4;
-        let headers = String::from_utf8_lossy(&buf[..header_end]);
-        let content_length = headers
-            .lines()
-            .find_map(|line| {
-                let (name, value) = line.split_once(':')?;
-                name.eq_ignore_ascii_case("content-length")
-                    .then(|| value.trim().parse::<usize>().ok())
-                    .flatten()
-            })
-            .unwrap_or(0);
-
-        while buf.len() < header_end + content_length {
-            let mut chunk = [0_u8; 1024];
-            let n = stream.read(&mut chunk).await?;
-            if n == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "stream closed before body completed",
-                ));
-            }
-            buf.extend_from_slice(&chunk[..n]);
-        }
-
-        Ok(String::from_utf8_lossy(&buf).into_owned())
+    fn test_api_context(http: reqwest::Client, base_url: Url) -> Arc<ApiContext> {
+        Arc::new(ApiContext::new(http, base_url))
     }
 
-    async fn write_http_response(
-        stream: &mut TcpStream,
-        status: &str,
-        body: &str,
-    ) -> io::Result<()> {
-        stream
-            .write_all(
-                format!(
-                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-                    body.len()
-                )
-                .as_bytes(),
-            )
-            .await
-    }
-
-    fn base_url_for(addr: SocketAddr) -> Url {
-        Url::parse(&format!("http://{addr}/")).expect("test base URL must parse")
+    fn auth_client(addr: SocketAddr) -> AuthApiClient {
+        AuthApiClient::new(test_api_context(reqwest::Client::new(), base_url(addr)))
     }
 
     fn sample_login_request<'a>() -> LoginRequest<'a> {
@@ -229,7 +149,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_message(&mut socket).await.unwrap();
+            let request = read_http_request(&mut socket).await.unwrap();
             assert!(
                 request.starts_with(
                     "POST /session/v1/login-request?warehouse=warehouse&databaseName=database&schemaName=schema&roleName=role HTTP/1.1"
@@ -241,7 +161,7 @@ mod tests {
             assert!(lowered.contains("\r\naccept: application/snowflake\r\n"));
             assert!(lowered.contains(&format!(
                 "\r\nuser-agent: {}\r\n",
-                default_user_agent().to_ascii_lowercase()
+                DEFAULT_USER_AGENT.to_ascii_lowercase()
             )));
 
             let body = request
@@ -260,9 +180,9 @@ mod tests {
                 })
             );
 
-            write_http_response(
+            write_json_response(
                 &mut socket,
-                "200 OK",
+                StatusCode::OK,
                 r#"{"success":true,"data":{"token":"session-token"}}"#,
             )
             .await
@@ -283,10 +203,14 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let _ = read_http_message(&mut socket).await.unwrap();
-            write_http_response(&mut socket, "401 Unauthorized", r#"{"message":"nope"}"#)
-                .await
-                .unwrap();
+            let _ = read_http_request(&mut socket).await.unwrap();
+            write_json_response(
+                &mut socket,
+                StatusCode::UNAUTHORIZED,
+                r#"{"message":"nope"}"#,
+            )
+            .await
+            .unwrap();
         });
 
         let client = auth_client(addr);
@@ -303,8 +227,8 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let _ = read_http_message(&mut socket).await.unwrap();
-            write_http_response(&mut socket, "200 OK", "not-json")
+            let _ = read_http_request(&mut socket).await.unwrap();
+            write_json_response(&mut socket, StatusCode::OK, "not-json")
                 .await
                 .unwrap();
         });
@@ -327,9 +251,7 @@ mod tests {
         });
 
         let client = AuthApiClient::with_request_timeout(
-            ClientSharedPartial::new()
-                .with_base_url(base_url_for(addr))
-                .build(),
+            test_api_context(reqwest::Client::new(), base_url(addr)),
             Duration::from_millis(50),
         );
         let err = client.login(sample_login_request()).await.unwrap_err();
@@ -348,13 +270,17 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_message(&mut socket).await.unwrap();
+            let request = read_http_request(&mut socket).await.unwrap();
             assert!(
                 request.starts_with("POST /session/authenticator-request HTTP/1.1"),
                 "{request}"
             );
             let lowered = request.to_ascii_lowercase();
             assert!(lowered.contains("\r\naccept: application/json\r\n"));
+            assert!(lowered.contains(&format!(
+                "\r\nuser-agent: {}\r\n",
+                DEFAULT_USER_AGENT.to_ascii_lowercase()
+            )));
 
             let body = request
                 .split("\r\n\r\n")
@@ -380,9 +306,9 @@ mod tests {
                 })
             );
 
-            write_http_response(
+            write_json_response(
                 &mut socket,
-                "200 OK",
+                StatusCode::OK,
                 r#"{"success":true,"data":{"ssoUrl":"https://example.com/sso","proofKey":"proof-key"}}"#,
             )
             .await

--- a/src/auth/credential.rs
+++ b/src/auth/credential.rs
@@ -142,12 +142,19 @@ fn prepare_jwt_credential(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use url::Url;
+
     use super::*;
 
-    use crate::{ClientSharedPartial, PasswordConfig};
+    use crate::{ApiContext, PasswordConfig};
 
     fn dummy_client() -> AuthApiClient {
-        AuthApiClient::new(ClientSharedPartial::new().build())
+        AuthApiClient::new(Arc::new(ApiContext::new(
+            reqwest::Client::new(),
+            Url::parse("https://example.com/").expect("test base URL must parse"),
+        )))
     }
 
     #[tokio::test]

--- a/src/auth/login.rs
+++ b/src/auth/login.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::{
-    ClientLoginConfig, ClientShared, InitialSessionConfig, Result,
+    ApiContext, ClientLoginConfig, InitialSessionConfig, Result,
     auth::credential::{LoginCredentialProvider, PreparedLoginCredential},
 };
 
@@ -14,8 +14,8 @@ use super::{
 };
 
 /// Login to Snowflake and return a session token.
-pub(crate) async fn login(login: &ClientLoginConfig, shared: Arc<ClientShared>) -> Result<String> {
-    let client = AuthApiClient::new(shared);
+pub(crate) async fn login(login: &ClientLoginConfig, api: Arc<ApiContext>) -> Result<String> {
+    let client = AuthApiClient::new(api);
     let context = LoginContext {
         username: login.username(),
         account: login.account(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,14 +1,9 @@
 use std::{fmt, sync::Arc};
 
-use url::Url;
-
 use crate::{
-    ClientConfig, ClientLoginConfig, QueryExecutionPolicy, Result, Session, auth::login,
-    runtime::QueryRuntime, session::SessionAuth,
+    ApiContext, ClientConfig, ClientLoginConfig, QueryExecutionPolicy, Result, Session,
+    auth::login, runtime::QueryRuntime, session::SessionAuth,
 };
-
-#[cfg(test)]
-use crate::QueryConfig;
 
 #[derive(Clone)]
 pub struct Client {
@@ -22,8 +17,8 @@ struct ClientInner {
 
 /// Connector-wide execution state shared by every session a client creates.
 pub(crate) struct ClientShared {
-    pub(crate) http: reqwest::Client,
-    pub(crate) base_url: Url,
+    pub(crate) api: Arc<ApiContext>,
+    pub(crate) chunk_http: reqwest::Client,
     pub(crate) query: QueryExecutionPolicy,
     pub(crate) runtime: QueryRuntime,
 }
@@ -32,7 +27,7 @@ impl fmt::Debug for Client {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Prints only non-secret identity fields; credentials, the reqwest client, and the runtime are omitted.
         f.debug_struct("Client")
-            .field("base_url", &self.inner.shared.base_url)
+            .field("base_url", &self.inner.shared.api.base_url())
             .field("username", &self.inner.login.username())
             .field("account", &self.inner.login.account())
             .finish_non_exhaustive()
@@ -48,9 +43,10 @@ impl Client {
     pub fn new(config: ClientConfig) -> Result<Self> {
         let prepared = config.prepare()?;
 
+        let http = prepared.shared.http;
         let shared = Arc::new(ClientShared {
-            http: prepared.shared.http,
-            base_url: prepared.shared.base_url,
+            api: Arc::new(ApiContext::new(http.clone(), prepared.shared.base_url)),
+            chunk_http: http,
             query: prepared.shared.query,
             runtime: QueryRuntime::new(),
         });
@@ -70,7 +66,7 @@ impl Client {
     /// Returns `ErrorKind::Config`, `ErrorKind::Auth`, `ErrorKind::Network`, `ErrorKind::Timeout`, `ErrorKind::Protocol`, or
     /// `ErrorKind::Internal` depending on how session establishment fails.
     pub async fn create_session(&self) -> Result<Session> {
-        let session_token = login(&self.inner.login, Arc::clone(&self.inner.shared)).await?;
+        let session_token = login(&self.inner.login, Arc::clone(&self.inner.shared.api)).await?;
         Ok(Session {
             shared: Arc::clone(&self.inner.shared),
             auth: Arc::new(SessionAuth { session_token }),
@@ -79,51 +75,60 @@ impl Client {
 }
 
 #[cfg(test)]
-pub(crate) struct ClientSharedPartial {
-    http: reqwest::Client,
-    base_url: Url,
-    query: QueryExecutionPolicy,
-    runtime: QueryRuntime,
-}
+pub(crate) use test_support::ClientSharedPartial;
 
 #[cfg(test)]
-impl ClientSharedPartial {
-    /// Build a partial shared-state handle with valid test defaults for every field.
-    pub(crate) fn new() -> Self {
-        Self {
-            http: reqwest::Client::new(),
-            base_url: Url::parse("https://example.com/").expect("test base URL must be valid"),
-            query: QueryConfig::default().into(),
-            runtime: QueryRuntime::new(),
+mod test_support {
+    use url::Url;
+
+    use crate::QueryConfig;
+
+    use super::*;
+
+    pub(crate) struct ClientSharedPartial {
+        http: reqwest::Client,
+        base_url: Url,
+        query: QueryExecutionPolicy,
+        runtime: QueryRuntime,
+    }
+
+    impl ClientSharedPartial {
+        pub(crate) fn new() -> Self {
+            Self {
+                http: reqwest::Client::new(),
+                base_url: Url::parse("https://example.com/").expect("test base URL must be valid"),
+                query: QueryConfig::new().into(),
+                runtime: QueryRuntime::new(),
+            }
         }
-    }
 
-    pub(crate) fn with_http(mut self, http: reqwest::Client) -> Self {
-        self.http = http;
-        self
-    }
+        pub(crate) fn with_http(mut self, http: reqwest::Client) -> Self {
+            self.http = http;
+            self
+        }
 
-    pub(crate) fn with_base_url(mut self, base_url: Url) -> Self {
-        self.base_url = base_url;
-        self
-    }
+        pub(crate) fn with_base_url(mut self, base_url: Url) -> Self {
+            self.base_url = base_url;
+            self
+        }
 
-    pub(crate) fn with_query(mut self, query: QueryExecutionPolicy) -> Self {
-        self.query = query;
-        self
-    }
+        pub(crate) fn with_query(mut self, query: QueryExecutionPolicy) -> Self {
+            self.query = query;
+            self
+        }
 
-    pub(crate) fn with_runtime(mut self, runtime: QueryRuntime) -> Self {
-        self.runtime = runtime;
-        self
-    }
+        pub(crate) fn with_runtime(mut self, runtime: QueryRuntime) -> Self {
+            self.runtime = runtime;
+            self
+        }
 
-    pub(crate) fn build(self) -> Arc<ClientShared> {
-        Arc::new(ClientShared {
-            http: self.http,
-            base_url: self.base_url,
-            query: self.query,
-            runtime: self.runtime,
-        })
+        pub(crate) fn build(self) -> Arc<ClientShared> {
+            Arc::new(ClientShared {
+                api: Arc::new(ApiContext::new(self.http.clone(), self.base_url)),
+                chunk_http: self.http,
+                query: self.query,
+                runtime: self.runtime,
+            })
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 //! # }
 //! ```
 
+mod api_context;
 mod auth;
 pub mod bind;
 mod client;
@@ -74,6 +75,9 @@ mod rowset;
 mod runtime;
 mod session;
 mod statement;
+
+#[cfg(test)]
+mod test_support;
 
 pub use auth::config::{AuthConfig, PasswordConfig};
 pub use client::Client;
@@ -104,6 +108,7 @@ pub use snowflake_connector_rs_derive::FromRow;
 #[doc(hidden)]
 pub mod bench_support;
 
+pub(crate) use api_context::ApiContext;
 pub(crate) use client::ClientShared;
 pub(crate) use config::{
     ClientLoginConfig, InitialSessionConfig, QueryExecutionPolicy, QueryExecutionSettings,

--- a/src/result_cursor/remote/downloader.rs
+++ b/src/result_cursor/remote/downloader.rs
@@ -195,11 +195,61 @@ fn retry_delay(retries: usize) -> Duration {
 mod tests {
     use std::sync::Arc;
 
+    use http::{HeaderMap, StatusCode};
+    use tokio::net::TcpListener;
+
     use super::*;
-    use crate::ErrorKind;
+    use crate::{
+        ErrorKind,
+        result_table::Schema,
+        test_support::http::{read_http_request, write_json_response},
+    };
 
     fn qid() -> Arc<str> {
         Arc::from("query-id")
+    }
+
+    #[tokio::test]
+    async fn chunk_request_uses_only_server_headers_without_connector_identity() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await.unwrap();
+            // Respond with a non-retryable status so the download fails after exactly one request.
+            write_json_response(&mut socket, StatusCode::FORBIDDEN, "denied")
+                .await
+                .unwrap();
+            request
+        });
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-amz-server-side-encryption", "AES256".parse().unwrap());
+        let request = DownloadRequest {
+            url: format!("http://{addr}/chunk-0"),
+            headers: Arc::new(headers),
+            query_id: qid(),
+            row_count: 1,
+            compressed_size: 1,
+            uncompressed_size: 1,
+            blocking_parse_limiter: None,
+        };
+
+        let downloader = RemotePartitionDownloader::new(reqwest::Client::new());
+        let _ = downloader
+            .download_table(request, Arc::new(Schema::from_columns(vec![])))
+            .await;
+
+        let request = server.await.unwrap();
+        let lowered = request.to_ascii_lowercase();
+        // The server-provided chunk header is forwarded.
+        assert!(lowered.contains("x-amz-server-side-encryption: aes256"));
+        // Chunk requests are built independently of the Snowflake API context, so they carry only server-provided
+        // headers. Never sending the session token to a storage origin is the invariant that matters. The absence of
+        // the connector User-Agent just follows from that independence and may change if we later choose to identify
+        // these requests; a generic HTTP-library User-Agent is out of scope either way.
+        assert!(!lowered.contains("authorization:"));
+        assert!(!lowered.contains("snowflake-connector-rs/"));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -66,7 +66,7 @@ impl fmt::Debug for Session {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // The session token authenticates every request; never print it.
         f.debug_struct("Session")
-            .field("base_url", &self.shared.base_url)
+            .field("base_url", &self.shared.api.base_url())
             .field("session_token", &"<redacted>")
             .field("query", &self.shared.query)
             .finish_non_exhaustive()
@@ -204,16 +204,15 @@ impl Session {
 mod tests {
     use std::time::Duration;
 
+    use http::StatusCode;
     use reqwest::Url;
-    use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
-        net::TcpListener,
-        sync::oneshot,
-        time::timeout,
-    };
+    use tokio::{net::TcpListener, sync::oneshot, time::timeout};
 
     use super::*;
-    use crate::{ClientSharedPartial, ErrorKind, QueryCancelStatus, QueryConfig, Statement};
+    use crate::{
+        ClientSharedPartial, ErrorKind, QueryCancelStatus, QueryConfig, Statement,
+        test_support::http::{read_http_request, write_json_response},
+    };
 
     fn test_session(base_url: Url) -> Session {
         test_session_with_config(base_url, QueryConfig::default())
@@ -260,18 +259,19 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            let query_request = read_http_request(&mut query_socket).await;
+            let query_request = read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(query_request.clone()).unwrap();
 
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            let abort_request = read_http_request(&mut abort_socket).await;
-            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
-            write_http_response(
+            let abort_request = read_http_request(&mut abort_socket).await.unwrap();
+            write_json_response(&mut abort_socket, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
+            write_json_response(
                 &mut query_socket,
-                200,
+                StatusCode::OK,
                 r#"{"code":"000604","message":"SQL execution canceled","success":false,"data":{"queryId":"query-id"}}"#,
-            )
-            .await;
+            ).await.unwrap();
             (query_request, abort_request)
         });
 
@@ -314,11 +314,13 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            let query_request = read_http_request(&mut query_socket).await;
+            let query_request = read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(()).unwrap();
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            let abort_request = read_http_request(&mut abort_socket).await;
-            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            let abort_request = read_http_request(&mut abort_socket).await.unwrap();
+            write_json_response(&mut abort_socket, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
             (query_request, abort_request)
         });
 
@@ -342,13 +344,12 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let _request = read_http_request(&mut socket).await;
-            write_http_response(
+            let _request = read_http_request(&mut socket).await.unwrap();
+            write_json_response(
                 &mut socket,
-                200,
+                StatusCode::OK,
                 r#"{"success":true,"data":{"queryId":"query-id","rowset":[],"rowtype":[],"queryResultFormat":"json"}}"#,
-            )
-            .await;
+            ).await.unwrap();
             timeout(Duration::from_millis(200), listener.accept())
                 .await
                 .is_err()
@@ -394,18 +395,22 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut query_socket).await;
+            read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(()).unwrap();
 
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut abort_socket).await;
-            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            read_http_request(&mut abort_socket).await.unwrap();
+            write_json_response(&mut abort_socket, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
 
             // The first accepted abort caches its outcome, so a concurrent caller must not open a second connection.
             let no_second_abort = timeout(Duration::from_millis(200), listener.accept())
                 .await
                 .is_err();
-            write_http_response(&mut query_socket, 200, CANCELLED_QUERY_RESPONSE).await;
+            write_json_response(&mut query_socket, StatusCode::OK, CANCELLED_QUERY_RESPONSE)
+                .await
+                .unwrap();
             no_second_abort
         });
 
@@ -435,18 +440,28 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut query_socket).await;
+            read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(()).unwrap();
 
             let (mut first_abort, _) = listener.accept().await.unwrap();
-            let first_request = read_http_request(&mut first_abort).await;
-            write_http_response(&mut first_abort, 400, r#"{"error":"bad request"}"#).await;
+            let first_request = read_http_request(&mut first_abort).await.unwrap();
+            write_json_response(
+                &mut first_abort,
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"bad request"}"#,
+            )
+            .await
+            .unwrap();
 
             let (mut second_abort, _) = listener.accept().await.unwrap();
-            let second_request = read_http_request(&mut second_abort).await;
-            write_http_response(&mut second_abort, 200, r#"{"success":true}"#).await;
+            let second_request = read_http_request(&mut second_abort).await.unwrap();
+            write_json_response(&mut second_abort, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
 
-            write_http_response(&mut query_socket, 200, CANCELLED_QUERY_RESPONSE).await;
+            write_json_response(&mut query_socket, StatusCode::OK, CANCELLED_QUERY_RESPONSE)
+                .await
+                .unwrap();
             (first_request, second_request)
         });
 
@@ -495,12 +510,12 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut query_socket).await;
+            read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(()).unwrap();
 
             // Accept the one abort and never answer it; the client drops the future while still awaiting the response.
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut abort_socket).await;
+            read_http_request(&mut abort_socket).await.unwrap();
 
             let no_retry = timeout(Duration::from_millis(300), listener.accept())
                 .await
@@ -540,11 +555,13 @@ mod tests {
             // Accept the query but never answer it, so the client-side query-response deadline elapses and the
             // execution guard drops into `OutcomeUnknown`.
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut query_socket).await;
+            read_http_request(&mut query_socket).await.unwrap();
 
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            let abort_request = read_http_request(&mut abort_socket).await;
-            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            let abort_request = read_http_request(&mut abort_socket).await.unwrap();
+            write_json_response(&mut abort_socket, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
             drop(query_socket);
             abort_request
         });
@@ -583,16 +600,20 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut query_socket).await;
+            read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(()).unwrap();
 
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut abort_socket).await;
+            read_http_request(&mut abort_socket).await.unwrap();
 
             // The query completes successfully before its abort is answered: a recorded cancel intent must not turn a
             // non-cancellation terminal response into a `Cancelled` error.
-            write_http_response(&mut query_socket, 200, SUCCESS_QUERY_RESPONSE).await;
-            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            write_json_response(&mut query_socket, StatusCode::OK, SUCCESS_QUERY_RESPONSE)
+                .await
+                .unwrap();
+            write_json_response(&mut abort_socket, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
         });
 
         let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
@@ -619,21 +640,22 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut query_socket).await;
+            read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(()).unwrap();
 
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut abort_socket).await;
-            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            read_http_request(&mut abort_socket).await.unwrap();
+            write_json_response(&mut abort_socket, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
 
             // A `success:true` payload is authoritative even when it carries a cancellation code, so the cancel intent
             // must not discard it as a `Cancelled` error.
-            write_http_response(
+            write_json_response(
                 &mut query_socket,
-                200,
+                StatusCode::OK,
                 r#"{"code":"000604","success":true,"data":{"queryId":"query-id","rowset":[],"rowtype":[],"queryResultFormat":"json"}}"#,
-            )
-            .await;
+            ).await.unwrap();
         });
 
         let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
@@ -662,20 +684,21 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut query_socket).await;
+            read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(()).unwrap();
 
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut abort_socket).await;
-            write_http_response(&mut abort_socket, 200, r#"{"success":true}"#).await;
+            read_http_request(&mut abort_socket).await.unwrap();
+            write_json_response(&mut abort_socket, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
 
             // No top-level `code`; cancellation is signaled only through `sqlState`.
-            write_http_response(
+            write_json_response(
                 &mut query_socket,
-                200,
+                StatusCode::OK,
                 r#"{"sqlState":"57014","message":"SQL execution canceled","success":false,"data":{"queryId":"query-id"}}"#,
-            )
-            .await;
+            ).await.unwrap();
         });
 
         let session = test_session(Url::parse(&format!("http://{addr}/")).unwrap());
@@ -709,17 +732,18 @@ mod tests {
         let (query_ready_tx, query_ready_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut query_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut query_socket).await;
+            read_http_request(&mut query_socket).await.unwrap();
             query_ready_tx.send(()).unwrap();
 
             let (mut abort_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut abort_socket).await;
-            write_http_response(
+            read_http_request(&mut abort_socket).await.unwrap();
+            write_json_response(
                 &mut abort_socket,
-                200,
+                StatusCode::OK,
                 r#"{"success":false,"code":"390112","message":"session expired"}"#,
             )
-            .await;
+            .await
+            .unwrap();
             drop(query_socket);
         });
 
@@ -736,46 +760,5 @@ mod tests {
         execution.abort();
         let _ = execution.await;
         server.await.unwrap();
-    }
-
-    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
-        let mut bytes = Vec::new();
-        let mut chunk = [0_u8; 1024];
-        let body_start;
-        let body_length;
-
-        loop {
-            let read = socket.read(&mut chunk).await.unwrap();
-            assert!(read > 0, "connection closed before request completed");
-            bytes.extend_from_slice(&chunk[..read]);
-            if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
-                body_start = index + 4;
-                let headers = String::from_utf8_lossy(&bytes[..index]);
-                body_length = headers
-                    .lines()
-                    .find_map(|line| {
-                        line.strip_prefix("content-length:")
-                            .or_else(|| line.strip_prefix("Content-Length:"))
-                    })
-                    .and_then(|value| value.trim().parse::<usize>().ok())
-                    .unwrap_or(0);
-                break;
-            }
-        }
-
-        while bytes.len() < body_start + body_length {
-            let read = socket.read(&mut chunk).await.unwrap();
-            assert!(read > 0, "connection closed before request body completed");
-            bytes.extend_from_slice(&chunk[..read]);
-        }
-        String::from_utf8(bytes).unwrap()
-    }
-
-    async fn write_http_response(socket: &mut tokio::net::TcpStream, status: u16, body: &str) {
-        let response = format!(
-            "HTTP/1.1 {status} OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
-            body.len()
-        );
-        socket.write_all(response.as_bytes()).await.unwrap();
     }
 }

--- a/src/statement/api.rs
+++ b/src/statement/api.rs
@@ -1,9 +1,3 @@
-use std::sync::Arc;
-
-use reqwest::Client;
-
-use crate::{ClientShared, session::SessionAuth};
-
 mod abort;
 mod deadline;
 mod poll;
@@ -12,20 +6,20 @@ mod submit;
 #[cfg(test)]
 mod test_support;
 
+use std::sync::Arc;
+
+use crate::{ApiContext, session::SessionAuth};
+
 pub(crate) use deadline::QueryResponseDeadline;
 
 #[derive(Clone)]
 pub(crate) struct QueryApiClient {
-    shared: Arc<ClientShared>,
+    api: Arc<ApiContext>,
     auth: Arc<SessionAuth>,
 }
 
 impl QueryApiClient {
-    pub(crate) fn new(shared: Arc<ClientShared>, auth: Arc<SessionAuth>) -> Self {
-        Self { shared, auth }
-    }
-
-    pub(crate) fn http_client(&self) -> Client {
-        self.shared.http.clone()
+    pub(crate) fn new(api: Arc<ApiContext>, auth: Arc<SessionAuth>) -> Self {
+        Self { api, auth }
     }
 }

--- a/src/statement/api/abort.rs
+++ b/src/statement/api/abort.rs
@@ -1,7 +1,10 @@
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
-use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use http::{
+    Method,
+    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
+};
 use serde_json::from_slice;
 use tokio::time::{sleep, timeout};
 use uuid::Uuid;
@@ -9,7 +12,7 @@ use uuid::Uuid;
 use crate::{
     Error, Result,
     error::{
-        ConfigError, NetworkError, ProtocolError, ServerError, SessionExpiredError, TimeoutError,
+        NetworkError, ProtocolError, ServerError, SessionExpiredError, TimeoutError,
         classify_request_error,
     },
     statement::wire::{
@@ -38,11 +41,7 @@ impl QueryApiClient {
         clock: &C,
     ) -> Result<()> {
         let cancel_request_id = Uuid::new_v4().to_string();
-        let mut url = self
-            .shared
-            .base_url
-            .join("queries/v1/abort-request")
-            .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
+        let mut url = self.api.resolve("queries/v1/abort-request")?;
         url.query_pairs_mut()
             .append_pair("requestId", &cancel_request_id);
 
@@ -61,9 +60,8 @@ impl QueryApiClient {
             }
 
             let request = self
-                .shared
-                .http
-                .post(url.clone())
+                .api
+                .request(Method::POST, url.clone())
                 .header(ACCEPT, "application/snowflake")
                 .header(CONTENT_TYPE, "application/json")
                 .header(
@@ -189,15 +187,16 @@ impl AbortBackoff {
 mod tests {
     use std::{sync::Mutex as StdMutex, time::Duration};
 
+    use http::StatusCode;
     use reqwest::Url;
     use tokio::{net::TcpListener, time::timeout};
 
     use super::*;
     use crate::{
         ErrorKind,
-        statement::api::test_support::{
-            read_http_request, respond_once, test_query_api, write_http_response,
-        },
+        api_context::DEFAULT_USER_AGENT,
+        statement::api::test_support::{respond_once, test_query_api},
+        test_support::http::{read_http_request, write_json_response},
     };
 
     #[tokio::test]
@@ -206,8 +205,10 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            write_http_response(&mut socket, 200, r#"{"success":true}"#).await;
+            let request = read_http_request(&mut socket).await.unwrap();
+            write_json_response(&mut socket, StatusCode::OK, r#"{"success":true}"#)
+                .await
+                .unwrap();
             request
         });
 
@@ -231,6 +232,10 @@ mod tests {
         );
         assert!(request.contains("accept: application/snowflake"));
         assert!(request.contains(r#"authorization: Snowflake Token="test-token""#));
+        assert!(request.to_ascii_lowercase().contains(&format!(
+            "user-agent: {}",
+            DEFAULT_USER_AGENT.to_ascii_lowercase()
+        )));
     }
 
     #[tokio::test]
@@ -244,8 +249,10 @@ mod tests {
                 (200, r#"{"success":true}"#),
             ] {
                 let (mut socket, _) = listener.accept().await.unwrap();
-                requests.push(read_http_request(&mut socket).await);
-                write_http_response(&mut socket, status, body).await;
+                requests.push(read_http_request(&mut socket).await.unwrap());
+                write_json_response(&mut socket, StatusCode::from_u16(status).unwrap(), body)
+                    .await
+                    .unwrap();
             }
             requests
         });
@@ -283,13 +290,14 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            write_http_response(
+            let request = read_http_request(&mut socket).await.unwrap();
+            write_json_response(
                 &mut socket,
-                200,
+                StatusCode::OK,
                 r#"{"success":false,"code":"000605","message":"query is not executing"}"#,
             )
-            .await;
+            .await
+            .unwrap();
             request
         });
 
@@ -311,8 +319,10 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            write_http_response(&mut socket, 200, r#"{"success":"yes"}"#).await;
+            let request = read_http_request(&mut socket).await.unwrap();
+            write_json_response(&mut socket, StatusCode::OK, r#"{"success":"yes"}"#)
+                .await
+                .unwrap();
             request
         });
 
@@ -350,8 +360,14 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            write_http_response(&mut socket, 400, r#"{"error":"bad request"}"#).await;
+            let request = read_http_request(&mut socket).await.unwrap();
+            write_json_response(
+                &mut socket,
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"bad request"}"#,
+            )
+            .await
+            .unwrap();
             request
         });
 

--- a/src/statement/api/poll.rs
+++ b/src/statement/api/poll.rs
@@ -1,6 +1,9 @@
 use std::{sync::Arc, time::Duration};
 
-use http::header::{ACCEPT, AUTHORIZATION};
+use http::{
+    Method,
+    header::{ACCEPT, AUTHORIZATION},
+};
 use reqwest::Url;
 use tokio::time::{sleep, timeout};
 
@@ -21,7 +24,7 @@ impl QueryApiClient {
         deadline: QueryResponseDeadline,
         query_id: Arc<str>,
     ) -> QueryScopedResult<WireQueryResponse> {
-        let poll_url = match resolve_poll_url(&self.shared.base_url, poll_relative_url) {
+        let poll_url = match resolve_poll_url(self.api.base_url(), poll_relative_url) {
             Ok(url) => url,
             Err(err) => {
                 return Err(QueryScopedError::new(query_id, err));
@@ -38,9 +41,8 @@ impl QueryApiClient {
             };
 
             let request = self
-                .shared
-                .http
-                .get(poll_url.clone())
+                .api
+                .request(Method::GET, poll_url.clone())
                 .header(ACCEPT, "application/snowflake")
                 .header(
                     AUTHORIZATION,
@@ -180,12 +182,62 @@ fn validate_same_origin_absolute_url(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
+    use http::StatusCode;
     use reqwest::Url;
+    use tokio::net::TcpListener;
 
     use super::*;
-    use crate::{Error, ErrorKind};
+    use crate::{
+        Error, ErrorKind,
+        api_context::DEFAULT_USER_AGENT,
+        statement::api::{QueryResponseDeadline, test_support::test_query_api},
+        test_support::http::{read_http_request, write_json_response},
+    };
+
+    #[tokio::test]
+    async fn poll_get_carries_session_auth_and_user_agent() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await.unwrap();
+            write_json_response(
+                &mut socket,
+                StatusCode::OK,
+                r#"{"success":true,"data":{"queryId":"q","rowtype":[],"rowset":[],"queryResultFormat":"json"}}"#,
+            )
+            .await
+            .unwrap();
+            request
+        });
+
+        let client = test_query_api(Url::parse(&format!("http://{addr}/")).unwrap());
+        let deadline = QueryResponseDeadline::new(Duration::from_secs(30));
+        client
+            .poll_async_results(
+                "/queries/v1/query-request?requestId=abc",
+                deadline,
+                Arc::from("query-id"),
+            )
+            .await
+            .unwrap();
+
+        let request = server.await.unwrap();
+        let request_line = request.lines().next().unwrap();
+        assert!(
+            request_line.starts_with("GET /queries/v1/query-request?requestId=abc HTTP/1.1"),
+            "{request_line}"
+        );
+        let lowered = request.to_ascii_lowercase();
+        assert!(lowered.contains("accept: application/snowflake"));
+        assert!(lowered.contains(r#"authorization: snowflake token="test-token""#));
+        assert!(lowered.contains(&format!(
+            "user-agent: {}",
+            DEFAULT_USER_AGENT.to_ascii_lowercase()
+        )));
+    }
 
     #[test]
     fn resolve_poll_url_accepts_relative_and_same_origin_absolute_urls() {

--- a/src/statement/api/submit.rs
+++ b/src/statement/api/submit.rs
@@ -1,10 +1,13 @@
 use bytes::Bytes;
-use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use http::{
+    Method,
+    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
+};
 use tokio::time::timeout;
 
 use crate::{
     Error, Result,
-    error::{ConfigError, NetworkError, TimeoutError, classify_request_error},
+    error::{NetworkError, TimeoutError, classify_request_error},
     statement::{
         StatementParts,
         wire::{
@@ -26,11 +29,7 @@ impl QueryApiClient {
         parts: &StatementParts,
         query_request_id: &str,
     ) -> Result<PreparedSubmit> {
-        let mut url = self
-            .shared
-            .base_url
-            .join("queries/v1/query-request")
-            .map_err(|e| ConfigError::invalid_url(e.to_string()))?;
+        let mut url = self.api.resolve("queries/v1/query-request")?;
         url.query_pairs_mut()
             .append_pair("requestId", query_request_id);
 
@@ -41,9 +40,8 @@ impl QueryApiClient {
         );
 
         let request = self
-            .shared
-            .http
-            .post(url)
+            .api
+            .request(Method::POST, url)
             .header(ACCEPT, "application/snowflake")
             .header(CONTENT_TYPE, "application/json")
             .header(
@@ -90,19 +88,19 @@ impl QueryApiClient {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
+    use http::StatusCode;
     use reqwest::Url;
     use tokio::net::TcpListener;
 
     use super::*;
     use crate::{
-        ClientSharedPartial, ErrorKind, Statement,
+        ApiContext, ErrorKind, Statement,
+        api_context::DEFAULT_USER_AGENT,
         session::SessionAuth,
-        statement::{
-            api::test_support::{read_http_request, test_query_api, write_http_response},
-            builder::into_statement_parts,
-        },
+        statement::{api::test_support::test_query_api, builder::into_statement_parts},
+        test_support::http::{read_http_request, write_json_response},
     };
 
     #[tokio::test]
@@ -111,13 +109,14 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            write_http_response(
+            let request = read_http_request(&mut socket).await.unwrap();
+            write_json_response(
                 &mut socket,
-                200,
+                StatusCode::OK,
                 r#"{"success":true,"data":{"queryId":"q","rowtype":[],"rowset":[],"queryResultFormat":"json"}}"#,
             )
-            .await;
+            .await
+            .unwrap();
             request
         });
 
@@ -140,6 +139,10 @@ mod tests {
         assert!(request.contains("accept: application/snowflake"));
         assert!(request.contains("content-type: application/json"));
         assert!(request.contains(r#"authorization: Snowflake Token="test-token""#));
+        assert!(request.to_ascii_lowercase().contains(&format!(
+            "user-agent: {}",
+            DEFAULT_USER_AGENT.to_ascii_lowercase()
+        )));
         let body = request.split("\r\n\r\n").nth(1).unwrap();
         let body: serde_json::Value = serde_json::from_str(body).unwrap();
         assert_eq!(body["sqlText"], "select 1");
@@ -155,15 +158,13 @@ mod tests {
         });
 
         let client = QueryApiClient::new(
-            ClientSharedPartial::new()
-                .with_http(
-                    reqwest::Client::builder()
-                        .timeout(Duration::from_millis(50))
-                        .build()
-                        .unwrap(),
-                )
-                .with_base_url(Url::parse(&format!("http://{addr}/")).unwrap())
-                .build(),
+            Arc::new(ApiContext::new(
+                reqwest::Client::builder()
+                    .timeout(Duration::from_millis(50))
+                    .build()
+                    .unwrap(),
+                Url::parse(&format!("http://{addr}/")).unwrap(),
+            )),
             SessionAuth::for_test("test-token"),
         );
 

--- a/src/statement/api/test_support.rs
+++ b/src/statement/api/test_support.rs
@@ -1,61 +1,27 @@
-use reqwest::Url;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
-};
+use std::sync::Arc;
 
-use crate::{ClientSharedPartial, session::SessionAuth, statement::api::QueryApiClient};
+use http::StatusCode;
+use reqwest::Url;
+use tokio::net::TcpListener;
+
+use crate::{
+    ApiContext,
+    session::SessionAuth,
+    statement::api::QueryApiClient,
+    test_support::http::{read_http_request, write_json_response},
+};
 
 pub(super) fn test_query_api(base_url: Url) -> QueryApiClient {
     QueryApiClient::new(
-        ClientSharedPartial::new().with_base_url(base_url).build(),
+        Arc::new(ApiContext::new(reqwest::Client::new(), base_url)),
         SessionAuth::for_test("test-token"),
     )
 }
 
-pub(super) async fn read_http_request(socket: &mut TcpStream) -> String {
-    let mut bytes = Vec::new();
-    let mut chunk = [0_u8; 1024];
-    let body_start;
-    let body_length;
-
-    loop {
-        let read = socket.read(&mut chunk).await.unwrap();
-        assert!(read > 0, "connection closed before request completed");
-        bytes.extend_from_slice(&chunk[..read]);
-        if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
-            body_start = index + 4;
-            let headers = String::from_utf8_lossy(&bytes[..index]);
-            body_length = headers
-                .lines()
-                .find_map(|line| {
-                    line.strip_prefix("content-length:")
-                        .or_else(|| line.strip_prefix("Content-Length:"))
-                })
-                .and_then(|value| value.trim().parse::<usize>().ok())
-                .unwrap_or(0);
-            break;
-        }
-    }
-
-    while bytes.len() < body_start + body_length {
-        let read = socket.read(&mut chunk).await.unwrap();
-        assert!(read > 0, "connection closed before request body completed");
-        bytes.extend_from_slice(&chunk[..read]);
-    }
-    String::from_utf8(bytes).unwrap()
-}
-
-pub(super) async fn write_http_response(socket: &mut TcpStream, status: u16, body: &str) {
-    let response = format!(
-        "HTTP/1.1 {status} OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
-        body.len()
-    );
-    socket.write_all(response.as_bytes()).await.unwrap();
-}
-
 pub(super) async fn respond_once(listener: &TcpListener, status: u16, body: &str) {
     let (mut socket, _) = listener.accept().await.unwrap();
-    read_http_request(&mut socket).await;
-    write_http_response(&mut socket, status, body).await;
+    read_http_request(&mut socket).await.unwrap();
+    write_json_response(&mut socket, StatusCode::from_u16(status).unwrap(), body)
+        .await
+        .unwrap();
 }

--- a/src/statement/executor.rs
+++ b/src/statement/executor.rs
@@ -24,6 +24,7 @@ use super::{
 
 pub(crate) struct StatementExecutor {
     api: QueryApiClient,
+    chunk_http: reqwest::Client,
     query_response_timeout: Duration,
     query_cancel_request_timeout: Duration,
     default_collect_concurrency: NonZeroUsize,
@@ -33,7 +34,8 @@ pub(crate) struct StatementExecutor {
 impl StatementExecutor {
     pub(crate) fn new(session: &Session, settings: QueryExecutionSettings) -> Self {
         Self {
-            api: QueryApiClient::new(Arc::clone(&session.shared), Arc::clone(&session.auth)),
+            api: QueryApiClient::new(Arc::clone(&session.shared.api), Arc::clone(&session.auth)),
+            chunk_http: session.shared.chunk_http.clone(),
             query_response_timeout: settings.query_response_timeout,
             query_cancel_request_timeout: settings.query_cancel_request_timeout,
             default_collect_concurrency: settings.collect_prefetch_concurrency,
@@ -161,7 +163,7 @@ impl StatementExecutor {
     fn build_result_set(self, data: WireQueryData) -> QueryScopedResult<ResultCursor> {
         let manifest = ResultManifest::try_from(data)?;
 
-        let source = RemotePartitionSource::new(manifest.lease, self.api.http_client());
+        let source = RemotePartitionSource::new(manifest.lease, self.chunk_http);
         let default_collect_policy = CollectPolicy::new(self.default_collect_concurrency);
 
         Ok(ResultCursor::new(
@@ -190,7 +192,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        ClientSharedPartial, ErrorKind, QueryOptions, Statement,
+        ApiContext, ClientSharedPartial, ErrorKind, QueryOptions, Statement,
         config::{DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT, DEFAULT_QUERY_RESPONSE_TIMEOUT},
         rowset::BLOCKING_PARSE_CELLS,
         runtime::QueryRuntime,
@@ -211,7 +213,7 @@ mod tests {
 
     fn test_statement_api(base_url: Url) -> QueryApiClient {
         QueryApiClient::new(
-            ClientSharedPartial::new().with_base_url(base_url).build(),
+            Arc::new(ApiContext::new(reqwest::Client::new(), base_url)),
             SessionAuth::for_test("test-token"),
         )
     }
@@ -226,6 +228,7 @@ mod tests {
     fn executor() -> StatementExecutor {
         StatementExecutor {
             api: test_statement_api(Url::parse("https://example.com/").unwrap()),
+            chunk_http: reqwest::Client::new(),
             query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
             query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
@@ -236,6 +239,7 @@ mod tests {
     fn executor_with_timeout(base_url: Url, timeout: Duration) -> StatementExecutor {
         StatementExecutor {
             api: test_statement_api(base_url),
+            chunk_http: reqwest::Client::new(),
             query_response_timeout: timeout,
             query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
@@ -680,6 +684,7 @@ mod tests {
         let permit = runtime.blocking_parse_limiter().acquire_owned().await;
         let executor = StatementExecutor {
             api: test_statement_api(Url::parse("https://example.com/").unwrap()),
+            chunk_http: reqwest::Client::new(),
             query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
             query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
@@ -724,6 +729,7 @@ mod tests {
         let permit = runtime.blocking_parse_limiter().acquire_owned().await;
         let executor = StatementExecutor {
             api: test_statement_api(Url::parse("https://example.com/").unwrap()),
+            chunk_http: reqwest::Client::new(),
             query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
             query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),
@@ -763,6 +769,7 @@ mod tests {
         let permit = runtime.blocking_parse_limiter().acquire_owned().await;
         let executor = StatementExecutor {
             api: test_statement_api(Url::parse("https://example.com/").unwrap()),
+            chunk_http: reqwest::Client::new(),
             query_response_timeout: DEFAULT_QUERY_RESPONSE_TIMEOUT,
             query_cancel_request_timeout: DEFAULT_QUERY_CANCEL_REQUEST_TIMEOUT,
             default_collect_concurrency: NonZeroUsize::new(1).unwrap(),

--- a/src/test_support/http.rs
+++ b/src/test_support/http.rs
@@ -1,0 +1,74 @@
+use std::{io, net::SocketAddr};
+
+use http::StatusCode;
+use reqwest::Url;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+};
+
+pub(crate) async fn read_http_request(stream: &mut TcpStream) -> io::Result<String> {
+    let mut buf = Vec::new();
+    let mut header_end = None;
+
+    while header_end.is_none() {
+        let mut chunk = [0_u8; 1024];
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "stream closed before headers completed",
+            ));
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        header_end = buf.windows(4).position(|w| w == b"\r\n\r\n");
+    }
+
+    let header_end = header_end.expect("header end must exist") + 4;
+    let headers = String::from_utf8_lossy(&buf[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .unwrap_or(0);
+
+    while buf.len() < header_end + content_length {
+        let mut chunk = [0_u8; 1024];
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "stream closed before body completed",
+            ));
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+pub(crate) async fn write_json_response(
+    stream: &mut TcpStream,
+    status: StatusCode,
+    body: &str,
+) -> io::Result<()> {
+    let reason = status.canonical_reason().unwrap_or("");
+    stream
+        .write_all(
+            format!(
+                "HTTP/1.1 {} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                status.as_u16(),
+                body.len(),
+            )
+            .as_bytes(),
+        )
+        .await
+}
+
+pub(crate) fn base_url(addr: SocketAddr) -> Url {
+    Url::parse(&format!("http://{addr}/")).expect("test base URL must parse")
+}

--- a/src/test_support/mod.rs
+++ b/src/test_support/mod.rs
@@ -1,0 +1,3 @@
+//! Crate-wide helpers shared by unit tests.
+
+pub(crate) mod http;


### PR DESCRIPTION
Every request this connector sends to Snowflake now identifies itself with a `User-Agent: snowflake-connector-rs/<version>` header. Until now only the sign-in requests did; the query requests did not.